### PR TITLE
feat: complete Phase 16 — reverse_proxy LB, bind directive, response interception

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,6 +1037,7 @@ dependencies = [
  "dwaar-log",
  "dwaar-plugins",
  "dwaar-tls",
+ "fastrand",
  "http",
  "pingora",
  "pingora-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,9 @@ compact_str = { version = "0.8", features = ["serde"] }
 # Fast JSON serialization (SIMD-accelerated)
 sonic-rs = "0.3"
 
+# Fast random number generation (no_std-compatible, used for Random LB policy)
+fastrand = "2"
+
 # Compression
 flate2 = "1.1.9"
 brotli = "8.0.2"

--- a/crates/dwaar-cli/src/main.rs
+++ b/crates/dwaar-cli/src/main.rs
@@ -38,7 +38,8 @@ use dwaar_analytics::aggregation::service::{AggregationService, RouteValidator};
 use dwaar_analytics::beacon;
 use dwaar_config::MAX_CONFIG_SIZE;
 use dwaar_config::compile::{
-    compile_acme_domains, compile_routes, compile_tls_configs, has_tls_sites,
+    BindAddress, collect_pools, compile_acme_domains, compile_routes, compile_tls_configs,
+    extract_bind_addresses, has_tls_sites,
 };
 use dwaar_config::watcher::{ConfigWatcher, hash_content};
 use dwaar_core::proxy::DwaarProxy;
@@ -263,6 +264,10 @@ fn run_server(
     }
     info!(routes = route_table.len(), "route table compiled");
 
+    // Collect upstream pools that have health URIs before wrapping the table.
+    // This must happen before ArcSwap wrapping because collect_pools borrows the table.
+    let health_pools = collect_pools(&route_table);
+
     // Capture initial routes before wrapping — DockerWatcher needs a
     // separate snapshot of Dwaarfile routes for merge operations.
     let initial_routes = route_table.all_routes();
@@ -357,21 +362,29 @@ fn run_server(
 
     let mut proxy_service = pingora_proxy::http_proxy_service(&server.configuration, proxy);
 
-    // Multiple workers each bind the same port independently via SO_REUSEPORT.
-    // The kernel distributes incoming connections across workers, providing
-    // CPU-affinity benefits and eliminating the accept() bottleneck.
-    if worker_count > 1 {
-        let mut sock_opt = TcpSocketOptions::default();
-        sock_opt.so_reuseport = Some(true);
-        proxy_service.add_tcp_with_settings("0.0.0.0:6188", sock_opt);
-    } else {
-        proxy_service.add_tcp("0.0.0.0:6188");
+    // Bind listeners from the `bind` directive, falling back to 0.0.0.0:6188
+    // when no site specifies one. Multiple workers each bind the same TCP
+    // address independently via SO_REUSEPORT — the kernel load-balances across
+    // workers without a single accept() bottleneck.
+    let bind_addrs = extract_bind_addresses(dwaar_config);
+    for addr in &bind_addrs {
+        match addr {
+            BindAddress::Tcp(a) => {
+                if worker_count > 1 {
+                    let mut sock_opt = TcpSocketOptions::default();
+                    sock_opt.so_reuseport = Some(true);
+                    proxy_service.add_tcp_with_settings(a, sock_opt);
+                } else {
+                    proxy_service.add_tcp(a);
+                }
+                info!(listen = %a, protocol = "http", "listener registered");
+            }
+            BindAddress::Unix(path) => {
+                proxy_service.add_uds(path.to_str().expect("bind path must be valid UTF-8"), None);
+                info!(listen = ?path, protocol = "http/uds", "listener registered");
+            }
+        }
     }
-    info!(
-        listen = "0.0.0.0:6188",
-        protocol = "http",
-        "listener registered"
-    );
 
     let cert_store = Arc::new(CertStore::new("/etc/dwaar/certs", 1000));
 
@@ -439,6 +452,7 @@ fn run_server(
         agg_receiver,
         &route_table_for_agg,
         &agg_metrics,
+        health_pools,
     );
 
     info!("entering run loop, waiting for connections or signals");
@@ -462,7 +476,18 @@ fn register_background_services(
     agg_receiver: Option<aggregation::AggReceiver>,
     route_table_for_agg: &Arc<ArcSwap<dwaar_core::route::RouteTable>>,
     agg_metrics: &Arc<DashMap<String, dwaar_analytics::aggregation::DomainMetrics>>,
+    health_pools: Vec<Arc<dwaar_core::upstream::UpstreamPool>>,
 ) {
+    // Upstream health checker — only registered when there are pools with health URIs.
+    // Per Guardrail #20: all async background work must be a BackgroundService.
+    if !health_pools.is_empty() {
+        let checker = dwaar_core::upstream::HealthChecker::new(health_pools);
+        let health_bg =
+            pingora_core::services::background::background_service("health checker", checker);
+        server.add_service(health_bg);
+        info!("upstream health checker registered");
+    }
+
     // ACME + OCSP background service
     if let Some(solver) = challenge_solver {
         let issuer = Arc::new(CertIssuer::new(

--- a/crates/dwaar-config/src/compile.rs
+++ b/crates/dwaar-config/src/compile.rs
@@ -13,20 +13,23 @@
 use std::collections::HashMap;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use bytes::Bytes;
 use compact_str::CompactString;
 use dwaar_core::route::{
-    BlockKind, CompiledMap, CompiledMapEntry, CompiledMapPattern, Handler, HandlerBlock,
-    PathMatcher, RewriteRule, Route, RouteTable, is_valid_domain,
+    BlockKind, CompiledCopyResponseHeaders, CompiledIntercept, CompiledMap, CompiledMapEntry,
+    CompiledMapPattern, Handler, HandlerBlock, PathMatcher, RewriteRule, Route, RouteTable,
+    is_valid_domain,
 };
 use dwaar_core::template::{CompiledTemplate, VarRegistry, VarSlots};
+use dwaar_core::upstream::{BackendConfig, LbPolicy as CoreLbPolicy, UpstreamPool};
 use tracing::warn;
 
 use crate::model::{
-    Directive, DwaarConfig, FileServerDirective, MapDirective, MapPattern, PhpFastcgiDirective,
-    RespondDirective, ReverseProxyDirective, RootDirective, TlsDirective, UpstreamAddr,
-    UriOperation,
+    BindDirective, Directive, DwaarConfig, FileServerDirective, HeaderDirective, LbPolicy,
+    MapDirective, MapPattern, PhpFastcgiDirective, RespondDirective, ReverseProxyDirective,
+    RootDirective, TlsDirective, UpstreamAddr, UriOperation,
 };
 use dwaar_plugins::basic_auth::BasicAuthConfig;
 use dwaar_plugins::forward_auth::ForwardAuthConfig;
@@ -80,13 +83,14 @@ pub fn compile_routes(config: &DwaarConfig) -> RouteTable {
         let basic_auth = compile_basic_auth(&site.directives);
         let forward_auth = compile_forward_auth(&site.directives);
 
+        // Compile response-phase directives shared across all flat-site handler types.
+        let intercepts = compile_intercepts(&site.directives);
+        let copy_response_headers = compile_copy_response_headers(&site.directives);
+
         // Try reverse_proxy first (most common)
         if let Some(rp) = find_reverse_proxy(&site.directives) {
-            let Some(addr) = resolve_upstream(&rp.upstreams) else {
-                warn!(
-                    address = %site.address,
-                    "could not resolve any upstream address, skipping"
-                );
+            let handler_result = compile_reverse_proxy_handler(rp, &site.address);
+            let Some(proxy_handler) = handler_result else {
                 continue;
             };
             let handler = HandlerBlock {
@@ -100,7 +104,9 @@ pub fn compile_routes(config: &DwaarConfig) -> RouteTable {
                 maps: compile_maps(&site.directives, &var_registry),
                 log_append_fields: compile_log_append(&site.directives, &var_registry),
                 log_name: find_log_name(&site.directives),
-                handler: Handler::ReverseProxy { upstream: addr },
+                handler: proxy_handler,
+                intercepts: intercepts.clone(),
+                copy_response_headers: copy_response_headers.clone(),
             };
             routes.push(Route::with_handlers(
                 &site.address,
@@ -128,6 +134,8 @@ pub fn compile_routes(config: &DwaarConfig) -> RouteTable {
                     status: resp.status,
                     body: Bytes::from(resp.body.clone()),
                 },
+                intercepts: intercepts.clone(),
+                copy_response_headers: copy_response_headers.clone(),
             };
             routes.push(Route::with_handlers(
                 &site.address,
@@ -162,6 +170,8 @@ pub fn compile_routes(config: &DwaarConfig) -> RouteTable {
                     root: root_path,
                     browse: fs_directive.browse,
                 },
+                intercepts: intercepts.clone(),
+                copy_response_headers: copy_response_headers.clone(),
             };
             routes.push(Route::with_handlers(
                 &site.address,
@@ -195,6 +205,8 @@ pub fn compile_routes(config: &DwaarConfig) -> RouteTable {
                     upstream: addr,
                     root: root_path,
                 },
+                intercepts,
+                copy_response_headers,
             };
             routes.push(Route::with_handlers(
                 &site.address,
@@ -272,6 +284,114 @@ pub fn compile_acme_domains(config: &DwaarConfig) -> Vec<String> {
         })
         .map(|site| site.address.to_lowercase())
         .collect()
+}
+
+/// The fallback HTTP listen address when no `bind` directive is present.
+const DEFAULT_HTTP_BIND: &str = "0.0.0.0:6188";
+
+/// The fallback port appended when a `bind` address has no port.
+const DEFAULT_BIND_PORT: u16 = 6188;
+
+/// A compiled listener address extracted from a `bind` directive.
+///
+/// Distinguishes between TCP sockets (most common) and Unix domain sockets
+/// (`unix//tmp/dwaar.sock`). UDS is useful for same-host reverse proxy
+/// chaining without the TCP stack overhead.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BindAddress {
+    /// A TCP `ip:port` address (e.g. `"0.0.0.0:8443"`, `"127.0.0.1:80"`).
+    Tcp(String),
+    /// A Unix domain socket path (e.g. `/tmp/dwaar.sock`).
+    Unix(std::path::PathBuf),
+}
+
+/// Extract listener addresses from a parsed config.
+///
+/// Gathers `bind` directives across all site blocks. Multiple sites with `bind`
+/// produce a union of all their addresses (deduplication preserves insertion
+/// order). The function always returns at least the default TCP address so the
+/// caller never has to special-case an empty result.
+///
+/// Parsing rules for address strings:
+/// - `unix/path` or `unix//path` → [`BindAddress::Unix`]
+/// - `:port`                     → `BindAddress::Tcp("0.0.0.0:port")`
+/// - `ip` (bare IP, no port)     → `BindAddress::Tcp("ip:6188")`
+/// - `ip:port`                   → `BindAddress::Tcp("ip:port")`
+pub fn extract_bind_addresses(config: &DwaarConfig) -> Vec<BindAddress> {
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut addrs: Vec<BindAddress> = Vec::new();
+
+    for site in &config.sites {
+        if let Some(bind) = find_bind(&site.directives) {
+            for raw in &bind.addresses {
+                let addr = parse_bind_address(raw);
+                // Deduplicate by canonical string key so that two sites with
+                // the same bind don't register the same port twice.
+                let key = match &addr {
+                    BindAddress::Tcp(s) => s.clone(),
+                    BindAddress::Unix(p) => p.to_string_lossy().into_owned(),
+                };
+                if seen.insert(key) {
+                    addrs.push(addr);
+                }
+            }
+        }
+    }
+
+    // Fall back to the built-in default when no site specifies bind.
+    if addrs.is_empty() {
+        addrs.push(BindAddress::Tcp(DEFAULT_HTTP_BIND.to_owned()));
+    }
+
+    addrs
+}
+
+/// Parse a single bind address token into a [`BindAddress`].
+fn parse_bind_address(raw: &str) -> BindAddress {
+    // Unix domain socket — Caddy supports both `unix/path` and `unix//abs/path`.
+    // Stripping `unix/` gives either `path` (relative) or `/abs/path` (absolute
+    // when the original had a double-slash like `unix//tmp/sock`).
+    if let Some(after_unix) = raw.strip_prefix("unix/") {
+        return BindAddress::Unix(std::path::PathBuf::from(after_unix));
+    }
+
+    // `:port` shorthand — listen on all interfaces on the given port.
+    if let Some(port_str) = raw.strip_prefix(':') {
+        return BindAddress::Tcp(format!("0.0.0.0:{port_str}"));
+    }
+
+    // Bracketed IPv6 (with or without port) passes through unchanged:
+    // `[::1]:8080` or `[::1]` (port-less bracketed form is unusual but valid).
+    if raw.starts_with('[') {
+        // If no port bracket present, append the default port.
+        if raw.ends_with(']') {
+            return BindAddress::Tcp(format!("{raw}:{DEFAULT_BIND_PORT}"));
+        }
+        return BindAddress::Tcp(raw.to_owned());
+    }
+
+    // If there is exactly one colon it is a plain `ip:port` — pass through.
+    // More than one colon without brackets is a bare IPv6 address; append port.
+    let colon_count = raw.chars().filter(|&c| c == ':').count();
+    match colon_count.cmp(&1) {
+        std::cmp::Ordering::Equal => BindAddress::Tcp(raw.to_owned()),
+        std::cmp::Ordering::Greater => {
+            // Bare IPv6 like `::1` or `fe80::1` — wrap and append default port.
+            BindAddress::Tcp(format!("[{raw}]:{DEFAULT_BIND_PORT}"))
+        }
+        std::cmp::Ordering::Less => {
+            // Bare IPv4 address or hostname — append default port.
+            BindAddress::Tcp(format!("{raw}:{DEFAULT_BIND_PORT}"))
+        }
+    }
+}
+
+/// Find the first `bind` directive in a site's directive list.
+fn find_bind(directives: &[Directive]) -> Option<&BindDirective> {
+    directives.iter().find_map(|d| match d {
+        Directive::Bind(b) => Some(b),
+        _ => None,
+    })
 }
 
 /// Returns true if a site's directives include a TLS config that
@@ -355,8 +475,7 @@ fn compile_single_block(
 
     // Find the handler directive inside the block
     let handler = if let Some(rp) = find_reverse_proxy(inner_directives) {
-        let addr = resolve_upstream(&rp.upstreams)?;
-        Handler::ReverseProxy { upstream: addr }
+        compile_reverse_proxy_handler(rp, "handle block")?
     } else if let Some(resp) = find_respond(inner_directives) {
         Handler::StaticResponse {
             status: resp.status,
@@ -394,6 +513,8 @@ fn compile_single_block(
         log_append_fields: compile_log_append(inner_directives, registry),
         log_name: find_log_name(inner_directives),
         handler,
+        intercepts: compile_intercepts(inner_directives),
+        copy_response_headers: compile_copy_response_headers(inner_directives),
     })
 }
 
@@ -546,6 +667,99 @@ fn resolve_upstream(upstreams: &[UpstreamAddr]) -> Option<SocketAddr> {
         }
     }
     None
+}
+
+/// Resolve all upstreams in the list, logging and skipping unresolvable entries.
+fn resolve_all_upstreams(upstreams: &[UpstreamAddr]) -> Vec<SocketAddr> {
+    upstreams
+        .iter()
+        .filter_map(|u| match u {
+            UpstreamAddr::SocketAddr(addr) => Some(*addr),
+            UpstreamAddr::HostPort(hp) => {
+                if let Some(addr) = hp.to_socket_addrs().ok().and_then(|mut i| i.next()) {
+                    Some(addr)
+                } else {
+                    warn!(upstream = %hp, "DNS resolution failed for upstream, skipping");
+                    None
+                }
+            }
+        })
+        .collect()
+}
+
+/// Map a config `LbPolicy` to the runtime `CoreLbPolicy`.
+fn map_lb_policy(policy: Option<LbPolicy>) -> CoreLbPolicy {
+    match policy {
+        None | Some(LbPolicy::RoundRobin) => CoreLbPolicy::RoundRobin,
+        Some(LbPolicy::LeastConn) => CoreLbPolicy::LeastConn,
+        Some(LbPolicy::Random) => CoreLbPolicy::Random,
+        Some(LbPolicy::IpHash) => CoreLbPolicy::IpHash,
+    }
+}
+
+/// Decide whether `rp` needs a pool (multi-upstream or has block-form options).
+///
+/// Single upstream + no block-form fields → `Handler::ReverseProxy` (zero overhead).
+/// Anything else → `Handler::ReverseProxyPool`.
+fn compile_reverse_proxy_handler(rp: &ReverseProxyDirective, location: &str) -> Option<Handler> {
+    let is_block_form = rp.lb_policy.is_some()
+        || rp.health_uri.is_some()
+        || rp.health_interval.is_some()
+        || rp.fail_duration.is_some()
+        || rp.max_conns.is_some()
+        || rp.transport_tls
+        || rp.tls_server_name.is_some();
+
+    if rp.upstreams.len() <= 1 && !is_block_form {
+        // Common single-upstream case — zero overhead path.
+        let addr = resolve_upstream(&rp.upstreams)?;
+        return Some(Handler::ReverseProxy { upstream: addr });
+    }
+
+    // Multi-upstream or block-form options — build a pool.
+    let addrs = resolve_all_upstreams(&rp.upstreams);
+    if addrs.is_empty() {
+        warn!(location, "reverse_proxy: no resolvable upstreams, skipping");
+        return None;
+    }
+
+    let policy = map_lb_policy(rp.lb_policy);
+    let tls = rp.transport_tls;
+    let sni = rp.tls_server_name.clone().unwrap_or_default();
+
+    let backends = addrs
+        .into_iter()
+        .map(|addr| BackendConfig {
+            addr,
+            max_conns: rp.max_conns,
+            tls,
+            tls_server_name: sni.clone(),
+        })
+        .collect();
+
+    let pool = UpstreamPool::new(backends, policy, rp.health_uri.clone(), rp.health_interval);
+
+    Some(Handler::ReverseProxyPool {
+        pool: Arc::new(pool),
+    })
+}
+
+/// Collect all `UpstreamPool`s from a compiled route table for health checking.
+///
+/// Called once at startup to gather pools that need background health probes.
+pub fn collect_pools(table: &dwaar_core::route::RouteTable) -> Vec<Arc<UpstreamPool>> {
+    let mut pools = Vec::new();
+    for route in table.all_routes() {
+        for block in &route.handlers {
+            if let Handler::ReverseProxyPool { pool } = &block.handler {
+                // Only pools with a health URI need the background checker.
+                if pool.has_health_check() {
+                    pools.push(pool.clone());
+                }
+            }
+        }
+    }
+    pools
 }
 
 // ── Variable compilation (ISSUE-055) ─────────────────────────
@@ -745,11 +959,6 @@ fn warn_pending_runtime(address: &str, directives: &[Directive]) {
                 directive = "acme_server",
                 "directive parsed but not yet implemented by Dwaar, ignoring"
             ),
-            Directive::Intercept(_) => warn!(
-                address = %address,
-                directive = "intercept",
-                "directive parsed but not yet implemented by Dwaar, ignoring"
-            ),
             Directive::Metrics(_) => warn!(
                 address = %address,
                 directive = "metrics",
@@ -758,16 +967,6 @@ fn warn_pending_runtime(address: &str, directives: &[Directive]) {
             Directive::Tracing(_) => warn!(
                 address = %address,
                 directive = "tracing",
-                "directive parsed but not yet implemented by Dwaar, ignoring"
-            ),
-            Directive::CopyResponse(_) => warn!(
-                address = %address,
-                directive = "copy_response",
-                "directive parsed but not yet implemented by Dwaar, ignoring"
-            ),
-            Directive::CopyResponseHeaders(_) => warn!(
-                address = %address,
-                directive = "copy_response_headers",
                 "directive parsed but not yet implemented by Dwaar, ignoring"
             ),
             Directive::Fs(_) => warn!(
@@ -810,6 +1009,83 @@ fn compile_template(input: &str, registry: &VarRegistry) -> CompiledTemplate {
     }
 }
 
+// ── Intercept / CopyResponseHeaders compilation (ISSUE-067) ─────────────────
+
+/// Compile `intercept` directives into `CompiledIntercept` rules.
+///
+/// Each `intercept` may carry a nested `respond` for status/body override and
+/// `header` directives for header injection. First-match-wins semantics are
+/// enforced at runtime in `response_filter()`.
+fn compile_intercepts(directives: &[Directive]) -> Vec<CompiledIntercept> {
+    directives
+        .iter()
+        .filter_map(|d| {
+            let Directive::Intercept(i) = d else {
+                return None;
+            };
+
+            // Extract the first nested `respond` for status + body override.
+            let (replace_status, replace_body) = i
+                .directives
+                .iter()
+                .find_map(|inner| match inner {
+                    Directive::Respond(r) => {
+                        Some((Some(r.status), Some(Bytes::from(r.body.clone()))))
+                    }
+                    _ => None,
+                })
+                .unwrap_or((None, None));
+
+            // Extract nested `header Name Value` directives for response header injection.
+            let set_headers = i
+                .directives
+                .iter()
+                .filter_map(|inner| match inner {
+                    Directive::Header(HeaderDirective::Set { name, value }) => Some((
+                        CompactString::from(name.as_str()),
+                        CompactString::from(value.as_str()),
+                    )),
+                    _ => None,
+                })
+                .collect();
+
+            Some(CompiledIntercept {
+                statuses: i.statuses.clone(),
+                replace_status,
+                replace_body,
+                set_headers,
+            })
+        })
+        .collect()
+}
+
+/// Compile a `copy_response_headers` directive into a `CompiledCopyResponseHeaders`.
+///
+/// Headers prefixed with `-` are excludes; the rest are includes.
+/// Returns `None` when the directive is absent.
+fn compile_copy_response_headers(directives: &[Directive]) -> Option<CompiledCopyResponseHeaders> {
+    let crh = directives.iter().find_map(|d| match d {
+        Directive::CopyResponseHeaders(crh) => Some(crh),
+        _ => None,
+    })?;
+
+    let mut include = Vec::new();
+    let mut exclude = Vec::new();
+    for header in &crh.headers {
+        if let Some(name) = header.strip_prefix('-') {
+            exclude.push(CompactString::from(name));
+        } else {
+            include.push(CompactString::from(header.as_str()));
+        }
+    }
+
+    Some(CompiledCopyResponseHeaders {
+        statuses: vec![],
+        include,
+        exclude,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -818,6 +1094,42 @@ mod tests {
     fn rp(addr: &str) -> Directive {
         Directive::ReverseProxy(ReverseProxyDirective {
             upstreams: vec![UpstreamAddr::SocketAddr(addr.parse().expect("valid addr"))],
+            lb_policy: None,
+            health_uri: None,
+            health_interval: None,
+            fail_duration: None,
+            max_conns: None,
+            transport_tls: false,
+            tls_server_name: None,
+        })
+    }
+
+    fn rp_multi(addrs: &[&str]) -> Directive {
+        Directive::ReverseProxy(ReverseProxyDirective {
+            upstreams: addrs
+                .iter()
+                .map(|a| UpstreamAddr::SocketAddr(a.parse().expect("valid addr")))
+                .collect(),
+            lb_policy: Some(LbPolicy::RoundRobin),
+            health_uri: None,
+            health_interval: None,
+            fail_duration: None,
+            max_conns: None,
+            transport_tls: false,
+            tls_server_name: None,
+        })
+    }
+
+    fn rp_with_health(addr: &str, health_uri: &str) -> Directive {
+        Directive::ReverseProxy(ReverseProxyDirective {
+            upstreams: vec![UpstreamAddr::SocketAddr(addr.parse().expect("valid addr"))],
+            lb_policy: None,
+            health_uri: Some(health_uri.to_string()),
+            health_interval: Some(5),
+            fail_duration: None,
+            max_conns: None,
+            transport_tls: false,
+            tls_server_name: None,
         })
     }
 
@@ -895,6 +1207,13 @@ mod tests {
                 matchers: vec![],
                 directives: vec![Directive::ReverseProxy(ReverseProxyDirective {
                     upstreams: vec![UpstreamAddr::HostPort("localhost:8080".to_string())],
+                    lb_policy: None,
+                    health_uri: None,
+                    health_interval: None,
+                    fail_duration: None,
+                    max_conns: None,
+                    transport_tls: false,
+                    tls_server_name: None,
                 })],
             }],
         };
@@ -1418,5 +1737,340 @@ mod tests {
         // Should compile without panic — the unknown var produces a warning
         let table = compile_routes(&config);
         assert_eq!(table.len(), 1);
+    }
+
+    // ── bind directive extraction (ISSUE-066) ────────────────────────────────
+
+    fn bind(addrs: &[&str]) -> Directive {
+        Directive::Bind(BindDirective {
+            addresses: addrs.iter().map(std::string::ToString::to_string).collect(),
+        })
+    }
+
+    fn site_with_bind(host: &str, addrs: &[&str]) -> SiteBlock {
+        SiteBlock {
+            address: host.to_string(),
+            matchers: vec![],
+            directives: vec![bind(addrs)],
+        }
+    }
+
+    #[test]
+    fn bind_port_shorthand_expands_to_all_interfaces() {
+        let config = DwaarConfig {
+            global_options: None,
+            sites: vec![site_with_bind("example.com", &[":8443"])],
+        };
+        let addrs = extract_bind_addresses(&config);
+        assert_eq!(addrs, vec![BindAddress::Tcp("0.0.0.0:8443".to_string())]);
+    }
+
+    #[test]
+    fn bind_bare_ip_appends_default_port() {
+        let config = DwaarConfig {
+            global_options: None,
+            sites: vec![site_with_bind("example.com", &["127.0.0.1"])],
+        };
+        let addrs = extract_bind_addresses(&config);
+        assert_eq!(addrs, vec![BindAddress::Tcp("127.0.0.1:6188".to_string())]);
+    }
+
+    #[test]
+    fn bind_ip_port_passes_through() {
+        let config = DwaarConfig {
+            global_options: None,
+            sites: vec![site_with_bind("example.com", &["10.0.0.1:9090"])],
+        };
+        let addrs = extract_bind_addresses(&config);
+        assert_eq!(addrs, vec![BindAddress::Tcp("10.0.0.1:9090".to_string())]);
+    }
+
+    #[test]
+    fn bind_unix_socket_absolute_path() {
+        let config = DwaarConfig {
+            global_options: None,
+            // `unix//tmp/dwaar.sock` → strip `unix/` → `/tmp/dwaar.sock`
+            sites: vec![site_with_bind("example.com", &["unix//tmp/dwaar.sock"])],
+        };
+        let addrs = extract_bind_addresses(&config);
+        assert_eq!(
+            addrs,
+            vec![BindAddress::Unix(std::path::PathBuf::from(
+                "/tmp/dwaar.sock"
+            ))]
+        );
+    }
+
+    #[test]
+    fn bind_unix_socket_relative_path() {
+        let config = DwaarConfig {
+            global_options: None,
+            sites: vec![site_with_bind("example.com", &["unix/run/dwaar.sock"])],
+        };
+        let addrs = extract_bind_addresses(&config);
+        assert_eq!(
+            addrs,
+            vec![BindAddress::Unix(std::path::PathBuf::from(
+                "run/dwaar.sock"
+            ))]
+        );
+    }
+
+    #[test]
+    fn bind_no_directive_returns_default() {
+        let config = DwaarConfig {
+            global_options: None,
+            sites: vec![SiteBlock {
+                address: "example.com".to_string(),
+                matchers: vec![],
+                directives: vec![rp("127.0.0.1:8080")],
+            }],
+        };
+        let addrs = extract_bind_addresses(&config);
+        assert_eq!(addrs, vec![BindAddress::Tcp("0.0.0.0:6188".to_string())]);
+    }
+
+    #[test]
+    fn bind_multiple_addresses_on_one_site() {
+        let config = DwaarConfig {
+            global_options: None,
+            sites: vec![site_with_bind(
+                "example.com",
+                &["0.0.0.0:80", "0.0.0.0:8080"],
+            )],
+        };
+        let addrs = extract_bind_addresses(&config);
+        assert_eq!(addrs.len(), 2);
+        assert!(addrs.contains(&BindAddress::Tcp("0.0.0.0:80".to_string())));
+        assert!(addrs.contains(&BindAddress::Tcp("0.0.0.0:8080".to_string())));
+    }
+
+    #[test]
+    fn bind_deduplicates_across_sites() {
+        // Two different sites with the same bind address should register only once.
+        let config = DwaarConfig {
+            global_options: None,
+            sites: vec![
+                site_with_bind("a.example.com", &["0.0.0.0:80"]),
+                site_with_bind("b.example.com", &["0.0.0.0:80"]),
+            ],
+        };
+        let addrs = extract_bind_addresses(&config);
+        assert_eq!(addrs.len(), 1);
+        assert_eq!(addrs[0], BindAddress::Tcp("0.0.0.0:80".to_string()));
+    }
+
+    // ── reverse_proxy compilation (ISSUE-065) ────────────────────────────────
+
+    fn make_site(address: &str, directive: Directive) -> SiteBlock {
+        SiteBlock {
+            address: address.to_string(),
+            matchers: vec![],
+            directives: vec![directive],
+        }
+    }
+
+    #[test]
+    fn single_upstream_no_block_options_compiles_to_reverse_proxy() {
+        let config = DwaarConfig {
+            global_options: None,
+            sites: vec![make_site("example.com", rp("127.0.0.1:8080"))],
+        };
+        let table = compile_routes(&config);
+        let route = table.resolve("example.com").expect("should resolve");
+        let block = route.handlers.first().expect("has handler block");
+        assert!(
+            matches!(&block.handler, Handler::ReverseProxy { upstream }
+                    if *upstream == "127.0.0.1:8080".parse::<SocketAddr>().expect("valid test addr")),
+            "single upstream without block options must compile to ReverseProxy"
+        );
+    }
+
+    #[test]
+    fn multi_upstream_compiles_to_reverse_proxy_pool() {
+        let config = DwaarConfig {
+            global_options: None,
+            sites: vec![make_site(
+                "example.com",
+                rp_multi(&["127.0.0.1:8080", "127.0.0.1:8081"]),
+            )],
+        };
+        let table = compile_routes(&config);
+        let route = table.resolve("example.com").expect("should resolve");
+        let block = route.handlers.first().expect("has handler block");
+        assert!(
+            matches!(&block.handler, Handler::ReverseProxyPool { pool } if pool.len() == 2),
+            "multi-upstream must compile to ReverseProxyPool"
+        );
+    }
+
+    #[test]
+    fn health_uri_triggers_pool_creation() {
+        let config = DwaarConfig {
+            global_options: None,
+            sites: vec![make_site(
+                "example.com",
+                rp_with_health("127.0.0.1:8080", "/health"),
+            )],
+        };
+        let table = compile_routes(&config);
+        let route = table.resolve("example.com").expect("should resolve");
+        let block = route.handlers.first().expect("has handler block");
+        assert!(
+            matches!(&block.handler, Handler::ReverseProxyPool { .. }),
+            "health_uri must trigger pool creation even for single upstream"
+        );
+    }
+
+    #[test]
+    fn collect_pools_finds_health_pools() {
+        let config = DwaarConfig {
+            global_options: None,
+            sites: vec![
+                make_site("a.com", rp_with_health("127.0.0.1:8080", "/health")),
+                make_site("b.com", rp("127.0.0.1:9090")),
+            ],
+        };
+        let table = compile_routes(&config);
+        let pools = collect_pools(&table);
+        assert_eq!(
+            pools.len(),
+            1,
+            "only the pool with health_uri should be collected"
+        );
+    }
+
+    // ── Intercept compilation (ISSUE-067) ────────────────────────
+
+    #[test]
+    fn compile_intercept_with_respond_override() {
+        let config = DwaarConfig {
+            global_options: None,
+            sites: vec![SiteBlock {
+                address: "example.com".to_string(),
+                matchers: vec![],
+                directives: vec![
+                    rp("127.0.0.1:8080"),
+                    Directive::Intercept(InterceptDirective {
+                        statuses: vec![404],
+                        directives: vec![Directive::Respond(RespondDirective {
+                            status: 200,
+                            body: "not found page".to_string(),
+                        })],
+                    }),
+                ],
+            }],
+        };
+        let table = compile_routes(&config);
+        let route = table.resolve("example.com").expect("should resolve");
+        let block = route.handlers.first().expect("has handler block");
+        assert_eq!(block.intercepts.len(), 1);
+        let rule = &block.intercepts[0];
+        assert_eq!(rule.statuses, vec![404]);
+        assert_eq!(rule.replace_status, Some(200));
+        assert_eq!(
+            rule.replace_body.as_deref(),
+            Some(b"not found page".as_ref())
+        );
+    }
+
+    #[test]
+    fn compile_intercept_empty_statuses_is_catch_all() {
+        let config = DwaarConfig {
+            global_options: None,
+            sites: vec![SiteBlock {
+                address: "example.com".to_string(),
+                matchers: vec![],
+                directives: vec![
+                    rp("127.0.0.1:8080"),
+                    Directive::Intercept(InterceptDirective {
+                        statuses: vec![],
+                        directives: vec![Directive::Respond(RespondDirective {
+                            status: 503,
+                            body: String::new(),
+                        })],
+                    }),
+                ],
+            }],
+        };
+        let table = compile_routes(&config);
+        let route = table.resolve("example.com").expect("should resolve");
+        let block = route.handlers.first().expect("has handler block");
+        assert_eq!(block.intercepts.len(), 1);
+        // Empty statuses = catch all non-2xx at runtime
+        assert!(block.intercepts[0].statuses.is_empty());
+    }
+
+    #[test]
+    fn compile_copy_response_headers_include() {
+        let config = DwaarConfig {
+            global_options: None,
+            sites: vec![SiteBlock {
+                address: "example.com".to_string(),
+                matchers: vec![],
+                directives: vec![
+                    rp("127.0.0.1:8080"),
+                    Directive::CopyResponseHeaders(CopyResponseHeadersDirective {
+                        headers: vec!["X-Custom".to_string(), "X-Other".to_string()],
+                    }),
+                ],
+            }],
+        };
+        let table = compile_routes(&config);
+        let route = table.resolve("example.com").expect("should resolve");
+        let block = route.handlers.first().expect("has handler block");
+        let crh = block
+            .copy_response_headers
+            .as_ref()
+            .expect("has copy_response_headers");
+        assert_eq!(crh.include.len(), 2);
+        assert!(crh.exclude.is_empty());
+        assert!(crh.include.iter().any(|h| h.as_str() == "X-Custom"));
+    }
+
+    #[test]
+    fn compile_copy_response_headers_exclude() {
+        let config = DwaarConfig {
+            global_options: None,
+            sites: vec![SiteBlock {
+                address: "example.com".to_string(),
+                matchers: vec![],
+                directives: vec![
+                    rp("127.0.0.1:8080"),
+                    Directive::CopyResponseHeaders(CopyResponseHeadersDirective {
+                        headers: vec!["-Set-Cookie".to_string(), "-Server".to_string()],
+                    }),
+                ],
+            }],
+        };
+        let table = compile_routes(&config);
+        let route = table.resolve("example.com").expect("should resolve");
+        let block = route.handlers.first().expect("has handler block");
+        let crh = block
+            .copy_response_headers
+            .as_ref()
+            .expect("has copy_response_headers");
+        assert!(crh.include.is_empty());
+        assert_eq!(crh.exclude.len(), 2);
+        // Strip prefix is applied during compile — stored without the '-'
+        assert!(crh.exclude.iter().any(|h| h.as_str() == "Set-Cookie"));
+        assert!(crh.exclude.iter().any(|h| h.as_str() == "Server"));
+    }
+
+    #[test]
+    fn compile_no_copy_response_headers_gives_none() {
+        let config = DwaarConfig {
+            global_options: None,
+            sites: vec![SiteBlock {
+                address: "example.com".to_string(),
+                matchers: vec![],
+                directives: vec![rp("127.0.0.1:8080")],
+            }],
+        };
+        let table = compile_routes(&config);
+        let route = table.resolve("example.com").expect("should resolve");
+        let block = route.handlers.first().expect("has handler block");
+        assert!(block.copy_response_headers.is_none());
+        assert!(block.intercepts.is_empty());
     }
 }

--- a/crates/dwaar-config/src/format.rs
+++ b/crates/dwaar-config/src/format.rs
@@ -13,9 +13,9 @@
 use crate::model::{
     BasicAuthDirective, BindDirective, CopyResponseHeadersDirective, Directive, DwaarConfig,
     EncodeDirective, ErrorDirective, FileServerDirective, ForwardAuthDirective, FsDirective,
-    HandleErrorsDirective, HeaderDirective, InterceptDirective, LogAppendDirective, LogDirective,
-    LogFormat, LogOutput, MapDirective, MapPattern, MatcherCondition, MatcherDef, MethodDirective,
-    RateLimitDirective, RecognizedDirective, RedirDirective, RequestBodyDirective,
+    HandleErrorsDirective, HeaderDirective, InterceptDirective, LbPolicy, LogAppendDirective,
+    LogDirective, LogFormat, LogOutput, MapDirective, MapPattern, MatcherCondition, MatcherDef,
+    MethodDirective, RateLimitDirective, RecognizedDirective, RedirDirective, RequestBodyDirective,
     RequestHeaderDirective, RespondDirective, ReverseProxyDirective, RewriteDirective,
     RootDirective, TlsDirective, TryFilesDirective, UpstreamAddr, UriDirective, UriOperation,
     VarsDirective,
@@ -140,12 +140,81 @@ fn format_directive_at_depth(out: &mut String, directive: &Directive, depth: usi
 }
 
 fn format_reverse_proxy(out: &mut String, rp: &ReverseProxyDirective) {
-    out.push_str("reverse_proxy");
-    for upstream in &rp.upstreams {
-        out.push(' ');
-        match upstream {
-            UpstreamAddr::SocketAddr(addr) => out.push_str(&addr.to_string()),
-            UpstreamAddr::HostPort(hp) => out.push_str(hp),
+    let has_block_options = rp.lb_policy.is_some()
+        || rp.health_uri.is_some()
+        || rp.health_interval.is_some()
+        || rp.fail_duration.is_some()
+        || rp.max_conns.is_some()
+        || rp.transport_tls
+        || rp.tls_server_name.is_some()
+        || rp.upstreams.len() > 1;
+
+    if has_block_options {
+        // Block form — one upstream per line under `to`, then options
+        out.push_str("reverse_proxy {\n");
+        out.push('\t');
+        out.push_str("\tto");
+        for upstream in &rp.upstreams {
+            out.push(' ');
+            match upstream {
+                UpstreamAddr::SocketAddr(addr) => out.push_str(&addr.to_string()),
+                UpstreamAddr::HostPort(hp) => out.push_str(hp),
+            }
+        }
+        out.push('\n');
+
+        if let Some(policy) = rp.lb_policy {
+            out.push_str("\t\tlb_policy ");
+            out.push_str(match policy {
+                LbPolicy::RoundRobin => "round_robin",
+                LbPolicy::LeastConn => "least_conn",
+                LbPolicy::Random => "random",
+                LbPolicy::IpHash => "ip_hash",
+            });
+            out.push('\n');
+        }
+        if let Some(ref uri) = rp.health_uri {
+            out.push_str("\t\thealth_uri ");
+            out.push_str(uri);
+            out.push('\n');
+        }
+        if let Some(interval) = rp.health_interval {
+            out.push_str("\t\thealth_interval ");
+            out.push_str(&interval.to_string());
+            out.push('\n');
+        }
+        if let Some(dur) = rp.fail_duration {
+            out.push_str("\t\tfail_duration ");
+            out.push_str(&dur.to_string());
+            out.push('\n');
+        }
+        if let Some(max) = rp.max_conns {
+            out.push_str("\t\tmax_conns ");
+            out.push_str(&max.to_string());
+            out.push('\n');
+        }
+        if rp.transport_tls || rp.tls_server_name.is_some() {
+            out.push_str("\t\ttransport {\n");
+            if let Some(ref sni) = rp.tls_server_name {
+                out.push_str("\t\t\ttls_server_name ");
+                out.push_str(sni);
+                out.push('\n');
+            } else {
+                out.push_str("\t\t\ttls\n");
+            }
+            out.push_str("\t\t}\n");
+        }
+        out.push('\t');
+        out.push('}');
+    } else {
+        // Inline form — space-separated upstreams on one line
+        out.push_str("reverse_proxy");
+        for upstream in &rp.upstreams {
+            out.push(' ');
+            match upstream {
+                UpstreamAddr::SocketAddr(addr) => out.push_str(&addr.to_string()),
+                UpstreamAddr::HostPort(hp) => out.push_str(hp),
+            }
         }
     }
 }

--- a/crates/dwaar-config/src/model.rs
+++ b/crates/dwaar-config/src/model.rs
@@ -336,11 +336,41 @@ pub struct PhpFastcgiDirective {
     pub upstream: UpstreamAddr,
 }
 
+/// Load balancing strategy for multi-upstream `reverse_proxy` blocks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LbPolicy {
+    /// Distribute requests evenly in turn across backends.
+    RoundRobin,
+    /// Send each request to the backend with the fewest active connections.
+    LeastConn,
+    /// Pick a backend at random.
+    Random,
+    /// Hash the client IP to pick a backend — same client always hits same backend.
+    IpHash,
+}
+
 /// `reverse_proxy` — route requests to one or more upstream backends.
+///
+/// Supports both inline form (`reverse_proxy host:port`) and block form with
+/// load balancing, health checks, and per-upstream TLS settings.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReverseProxyDirective {
     /// One or more upstream addresses. Multiple means load-balanced.
     pub upstreams: Vec<UpstreamAddr>,
+    /// Load balancing policy. `None` defaults to `RoundRobin`.
+    pub lb_policy: Option<LbPolicy>,
+    /// HTTP path to poll on each backend for health checks (e.g. `/health`).
+    pub health_uri: Option<String>,
+    /// Seconds between health check polls.
+    pub health_interval: Option<u64>,
+    /// How long (seconds) to keep a backend marked unhealthy after a failure.
+    pub fail_duration: Option<u64>,
+    /// Maximum concurrent connections per backend (None = unlimited).
+    pub max_conns: Option<u32>,
+    /// Connect to upstream over TLS (e.g. backend is HTTPS).
+    pub transport_tls: bool,
+    /// SNI hostname to use for upstream TLS connections.
+    pub tls_server_name: Option<String>,
 }
 
 /// An upstream address — either a socket address or a host:port string
@@ -775,6 +805,13 @@ mod tests {
                     upstreams: vec![UpstreamAddr::SocketAddr(
                         "127.0.0.1:3000".parse().expect("valid"),
                     )],
+                    lb_policy: None,
+                    health_uri: None,
+                    health_interval: None,
+                    fail_duration: None,
+                    max_conns: None,
+                    transport_tls: false,
+                    tls_server_name: None,
                 }),
                 Directive::Tls(TlsDirective::Auto),
             ],

--- a/crates/dwaar-config/src/parser/directives.rs
+++ b/crates/dwaar-config/src/parser/directives.rs
@@ -12,7 +12,7 @@
 use crate::error::{ParseError, ParseErrorKind};
 use crate::model::{
     Directive, FileServerDirective, ForwardAuthDirective, HandleDirective, HandleErrorsDirective,
-    HandlePathDirective, PhpFastcgiDirective, RedirDirective, RespondDirective,
+    HandlePathDirective, LbPolicy, PhpFastcgiDirective, RedirDirective, RespondDirective,
     ReverseProxyDirective, RewriteDirective, RootDirective, RouteDirective, TryFilesDirective,
     UriDirective, UriOperation,
 };
@@ -22,25 +22,48 @@ use super::helpers::{
     expect_word_or_quoted, is_directive_name, parse_optional_pattern, parse_upstream_addr,
 };
 
-/// `reverse_proxy localhost:8080` or `reverse_proxy 10.0.0.1:3000 10.0.0.2:3000`
+/// `reverse_proxy localhost:8080` or block form:
+/// ```text
+/// reverse_proxy {
+///     to backend1:8080 backend2:8080
+///     lb_policy round_robin
+///     health_uri /health
+///     health_interval 10
+///     fail_duration 30
+///     max_conns 100
+///     transport {
+///         tls_server_name backend.internal
+///     }
+/// }
+/// ```
 pub(super) fn parse_reverse_proxy(
     t: &mut Tokenizer<'_>,
 ) -> Result<ReverseProxyDirective, ParseError> {
+    // Check whether this is inline form or block form.
+    // Inline: address words follow immediately.
+    // Block: a `{` follows immediately (possibly after whitespace).
+    if let TokenKind::OpenBrace = t.peek().kind {
+        parse_reverse_proxy_block(t)
+    } else {
+        parse_reverse_proxy_inline(t)
+    }
+}
+
+/// Parse inline form: `reverse_proxy host1:port [host2:port ...]`
+fn parse_reverse_proxy_inline(t: &mut Tokenizer<'_>) -> Result<ReverseProxyDirective, ParseError> {
     let mut upstreams = Vec::new();
 
-    // Consume upstream addresses until we hit a brace, another directive, or EOF
     loop {
         let tok = t.peek();
         match &tok.kind {
             TokenKind::Word(w) => {
-                // If this word is a known directive name, stop — it's the next directive
+                // Stop at the next directive name — it belongs to the enclosing block
                 if is_directive_name(w) {
                     break;
                 }
                 t.next_token();
                 upstreams.push(parse_upstream_addr(w));
             }
-            // Stop at braces, EOF, or quoted strings (not valid upstream addrs)
             _ => break,
         }
     }
@@ -57,7 +80,222 @@ pub(super) fn parse_reverse_proxy(
         });
     }
 
-    Ok(ReverseProxyDirective { upstreams })
+    Ok(ReverseProxyDirective {
+        upstreams,
+        lb_policy: None,
+        health_uri: None,
+        health_interval: None,
+        fail_duration: None,
+        max_conns: None,
+        transport_tls: false,
+        tls_server_name: None,
+    })
+}
+
+/// Returns true if `w` is a known subdirective keyword inside a `reverse_proxy { }` block.
+///
+/// Needed so the `to` argument parser stops at the next subdirective instead of
+/// treating keywords like `lb_policy` as upstream addresses.
+fn is_reverse_proxy_subdirective(w: &str) -> bool {
+    matches!(
+        w,
+        "to" | "lb_policy"
+            | "health_uri"
+            | "health_interval"
+            | "fail_duration"
+            | "max_conns"
+            | "transport"
+    )
+}
+
+/// Parse block form: `reverse_proxy { to ...; lb_policy ...; ... }`
+#[allow(clippy::too_many_lines)]
+fn parse_reverse_proxy_block(t: &mut Tokenizer<'_>) -> Result<ReverseProxyDirective, ParseError> {
+    // Consume the opening `{`
+    t.next_token();
+
+    let mut upstreams = Vec::new();
+    let mut lb_policy: Option<LbPolicy> = None;
+    let mut health_uri: Option<String> = None;
+    let mut health_interval: Option<u64> = None;
+    let mut fail_duration: Option<u64> = None;
+    let mut max_conns: Option<u32> = None;
+    let mut transport_tls = false;
+    let mut tls_server_name: Option<String> = None;
+
+    loop {
+        let tok = t.next_token();
+        match tok.kind {
+            TokenKind::CloseBrace | TokenKind::Eof => break,
+            TokenKind::Word(ref sub) => match sub.as_str() {
+                "to" => {
+                    // Consume upstream addresses until the next subdirective keyword or brace.
+                    // We can't use is_directive_name() here because block subdirectives like
+                    // `lb_policy` are not top-level directive names.
+                    loop {
+                        match t.peek().kind {
+                            TokenKind::Word(ref w) if !is_reverse_proxy_subdirective(w) => {
+                                let addr_tok = t.next_token();
+                                if let TokenKind::Word(w) = addr_tok.kind {
+                                    upstreams.push(parse_upstream_addr(&w));
+                                }
+                            }
+                            _ => break,
+                        }
+                    }
+                }
+                "lb_policy" => {
+                    let policy_tok = t.next_token();
+                    let (line, col) = (policy_tok.line, policy_tok.col);
+                    if let TokenKind::Word(p) = policy_tok.kind {
+                        lb_policy = Some(match p.as_str() {
+                            "round_robin" => LbPolicy::RoundRobin,
+                            "least_conn" => LbPolicy::LeastConn,
+                            "random" => LbPolicy::Random,
+                            "ip_hash" => LbPolicy::IpHash,
+                            other => {
+                                return Err(ParseError {
+                                    line,
+                                    col,
+                                    kind: ParseErrorKind::InvalidValue {
+                                        directive: "reverse_proxy".to_string(),
+                                        message: format!(
+                                            "unknown lb_policy '{other}'; \
+                                             expected round_robin, least_conn, random, ip_hash"
+                                        ),
+                                    },
+                                });
+                            }
+                        });
+                    }
+                }
+                "health_uri" => {
+                    let uri_tok = t.next_token();
+                    if let TokenKind::Word(u) | TokenKind::QuotedString(u) = uri_tok.kind {
+                        health_uri = Some(u);
+                    }
+                }
+                "health_interval" => {
+                    let val_tok = t.next_token();
+                    let (line, col) = (val_tok.line, val_tok.col);
+                    if let TokenKind::Word(v) = val_tok.kind {
+                        health_interval = Some(v.parse().map_err(|_| ParseError {
+                            line,
+                            col,
+                            kind: ParseErrorKind::InvalidValue {
+                                directive: "reverse_proxy".to_string(),
+                                message: format!(
+                                    "health_interval must be a positive integer, got '{v}'"
+                                ),
+                            },
+                        })?);
+                    }
+                }
+                "fail_duration" => {
+                    let val_tok = t.next_token();
+                    let (line, col) = (val_tok.line, val_tok.col);
+                    if let TokenKind::Word(v) = val_tok.kind {
+                        fail_duration = Some(v.parse().map_err(|_| ParseError {
+                            line,
+                            col,
+                            kind: ParseErrorKind::InvalidValue {
+                                directive: "reverse_proxy".to_string(),
+                                message: format!(
+                                    "fail_duration must be a positive integer, got '{v}'"
+                                ),
+                            },
+                        })?);
+                    }
+                }
+                "max_conns" => {
+                    let val_tok = t.next_token();
+                    let (line, col) = (val_tok.line, val_tok.col);
+                    if let TokenKind::Word(v) = val_tok.kind {
+                        max_conns = Some(v.parse().map_err(|_| ParseError {
+                            line,
+                            col,
+                            kind: ParseErrorKind::InvalidValue {
+                                directive: "reverse_proxy".to_string(),
+                                message: format!("max_conns must be a positive integer, got '{v}'"),
+                            },
+                        })?);
+                    }
+                }
+                "transport" => {
+                    // Expect an optional block `{ tls_server_name ... }`
+                    if let TokenKind::OpenBrace = t.peek().kind {
+                        t.next_token(); // consume `{`
+                        loop {
+                            let inner = t.next_token();
+                            match inner.kind {
+                                TokenKind::CloseBrace | TokenKind::Eof => break,
+                                TokenKind::Word(ref kw) if kw == "tls" => {
+                                    // `transport { tls }` — plain TLS flag
+                                    transport_tls = true;
+                                }
+                                TokenKind::Word(ref kw) if kw == "tls_server_name" => {
+                                    transport_tls = true;
+                                    let sni_tok = t.next_token();
+                                    if let TokenKind::Word(sni) | TokenKind::QuotedString(sni) =
+                                        sni_tok.kind
+                                    {
+                                        tls_server_name = Some(sni);
+                                    }
+                                }
+                                // Skip unknown transport sub-directives gracefully
+                                _ => {}
+                            }
+                        }
+                    } else {
+                        // `transport tls` on a single line — no block
+                        if let TokenKind::Word(ref kw) = t.peek().kind
+                            && kw == "tls"
+                        {
+                            t.next_token();
+                            transport_tls = true;
+                        }
+                    }
+                }
+                // Unknown sub-directive — skip tokens until the next known
+                // subdirective keyword or the closing brace. This keeps the parser
+                // forward-compatible with future `reverse_proxy` block options.
+                _ => loop {
+                    match t.peek().kind {
+                        TokenKind::CloseBrace | TokenKind::Eof => break,
+                        TokenKind::Word(ref w) if is_reverse_proxy_subdirective(w) => break,
+                        _ => {
+                            t.next_token();
+                        }
+                    }
+                },
+            },
+            _ => {}
+        }
+    }
+
+    if upstreams.is_empty() {
+        let (line, col) = t.position();
+        return Err(ParseError {
+            line,
+            col,
+            kind: ParseErrorKind::InvalidValue {
+                directive: "reverse_proxy".to_string(),
+                message: "block form requires at least one upstream via 'to' subdirective"
+                    .to_string(),
+            },
+        });
+    }
+
+    Ok(ReverseProxyDirective {
+        upstreams,
+        lb_policy,
+        health_uri,
+        health_interval,
+        fail_duration,
+        max_conns,
+        transport_tls,
+        tls_server_name,
+    })
 }
 
 /// `redir /old /new [code]`
@@ -248,15 +486,24 @@ pub(super) fn parse_respond(t: &mut Tokenizer<'_>) -> Result<RespondDirective, P
                 body: first,
             })
         }
-        // Single argument — is it a status code or body?
+        // Single argument, or `respond <status> "body"` form.
         _ => {
             if let Ok(code) = first.parse::<u16>()
                 && (100..=599).contains(&code)
             {
-                return Ok(RespondDirective {
-                    status: code,
-                    body: String::new(),
-                });
+                // Check if the next token is a quoted body string.
+                // Caddyfile allows: `respond 200 "custom body"`
+                let body = if let TokenKind::QuotedString(_) = &t.peek().kind {
+                    let body_tok = t.next_token();
+                    if let TokenKind::QuotedString(s) = body_tok.kind {
+                        s
+                    } else {
+                        String::new()
+                    }
+                } else {
+                    String::new()
+                };
+                return Ok(RespondDirective { status: code, body });
             }
             // Not a valid status — treat as body
             Ok(RespondDirective {

--- a/crates/dwaar-config/src/parser/tests.rs
+++ b/crates/dwaar-config/src/parser/tests.rs
@@ -244,6 +244,44 @@ fn passthrough_directive_with_args() {
     assert!(matches!(&config.sites[0].directives[0], Directive::Bind(_)));
 }
 
+// ── bind directive parser tests (ISSUE-066) ──────────────────────────────────
+
+#[test]
+fn bind_single_port_shorthand() {
+    let config = parse("a.com { bind :8443 }").expect("bind :port should parse");
+    let Directive::Bind(b) = &config.sites[0].directives[0] else {
+        panic!("expected Directive::Bind");
+    };
+    assert_eq!(b.addresses, vec![":8443"]);
+}
+
+#[test]
+fn bind_bare_ip() {
+    let config = parse("a.com { bind 127.0.0.1 }").expect("bind bare IP should parse");
+    let Directive::Bind(b) = &config.sites[0].directives[0] else {
+        panic!("expected Directive::Bind");
+    };
+    assert_eq!(b.addresses, vec!["127.0.0.1"]);
+}
+
+#[test]
+fn bind_multiple_addresses() {
+    let config = parse("a.com { bind 127.0.0.1 ::1 }").expect("bind multi-addr should parse");
+    let Directive::Bind(b) = &config.sites[0].directives[0] else {
+        panic!("expected Directive::Bind");
+    };
+    assert_eq!(b.addresses, vec!["127.0.0.1", "::1"]);
+}
+
+#[test]
+fn bind_missing_address_is_an_error() {
+    // `bind` with no arguments must be a parse error, not silently ignored.
+    assert!(
+        parse("a.com { bind }").is_err(),
+        "bind with no args should fail"
+    );
+}
+
 #[test]
 fn passthrough_directive_with_block() {
     // `log` with a block is now fully implemented — parses as Directive::Log
@@ -852,4 +890,306 @@ fn global_options_only_no_sites() {
     let config = parse("{\n    debug\n}\n").expect("global options without sites");
     assert!(config.global_options.is_some());
     assert!(config.sites.is_empty());
+}
+
+// ── reverse_proxy block form (ISSUE-065) ─────────────────────────────────────
+
+#[test]
+fn reverse_proxy_inline_backward_compat() {
+    // Inline form must still work after block-form support is added.
+    let config = parse("a.com {\n    reverse_proxy localhost:8080\n}\n").expect("should parse");
+    let Directive::ReverseProxy(rp) = &config.sites[0].directives[0] else {
+        panic!("expected ReverseProxy");
+    };
+    assert_eq!(rp.upstreams.len(), 1);
+    assert!(rp.lb_policy.is_none());
+    assert!(!rp.transport_tls);
+}
+
+#[test]
+fn reverse_proxy_inline_multi_upstream() {
+    let config = parse("a.com {\n    reverse_proxy 127.0.0.1:8080 127.0.0.1:8081\n}\n")
+        .expect("should parse");
+    let Directive::ReverseProxy(rp) = &config.sites[0].directives[0] else {
+        panic!("expected ReverseProxy");
+    };
+    assert_eq!(rp.upstreams.len(), 2);
+}
+
+#[test]
+fn reverse_proxy_block_basic() {
+    let config = parse(
+        "a.com {
+            reverse_proxy {
+                to 127.0.0.1:8080
+                lb_policy round_robin
+            }
+        }",
+    )
+    .expect("should parse");
+    let Directive::ReverseProxy(rp) = &config.sites[0].directives[0] else {
+        panic!("expected ReverseProxy");
+    };
+    assert_eq!(rp.upstreams.len(), 1);
+    assert_eq!(rp.lb_policy, Some(LbPolicy::RoundRobin));
+}
+
+#[test]
+fn reverse_proxy_block_all_lb_policies() {
+    for (name, expected) in [
+        ("round_robin", LbPolicy::RoundRobin),
+        ("least_conn", LbPolicy::LeastConn),
+        ("random", LbPolicy::Random),
+        ("ip_hash", LbPolicy::IpHash),
+    ] {
+        let src = format!(
+            "a.com {{\n    reverse_proxy {{\n        to 127.0.0.1:9000\n        lb_policy {name}\n    }}\n}}\n"
+        );
+        let config = parse(&src).unwrap_or_else(|_| panic!("should parse lb_policy {name}"));
+        let Directive::ReverseProxy(rp) = &config.sites[0].directives[0] else {
+            panic!("expected ReverseProxy");
+        };
+        assert_eq!(rp.lb_policy, Some(expected));
+    }
+}
+
+#[test]
+fn reverse_proxy_block_health_options() {
+    let config = parse(
+        "a.com {
+            reverse_proxy {
+                to 127.0.0.1:8080
+                health_uri /ping
+                health_interval 5
+                fail_duration 30
+            }
+        }",
+    )
+    .expect("should parse");
+    let Directive::ReverseProxy(rp) = &config.sites[0].directives[0] else {
+        panic!("expected ReverseProxy");
+    };
+    assert_eq!(rp.health_uri.as_deref(), Some("/ping"));
+    assert_eq!(rp.health_interval, Some(5));
+    assert_eq!(rp.fail_duration, Some(30));
+}
+
+#[test]
+fn reverse_proxy_block_max_conns() {
+    let config = parse(
+        "a.com {
+            reverse_proxy {
+                to 127.0.0.1:8080
+                max_conns 100
+            }
+        }",
+    )
+    .expect("should parse");
+    let Directive::ReverseProxy(rp) = &config.sites[0].directives[0] else {
+        panic!("expected ReverseProxy");
+    };
+    assert_eq!(rp.max_conns, Some(100));
+}
+
+#[test]
+fn reverse_proxy_block_transport_tls_server_name() {
+    let config = parse(
+        "a.com {
+            reverse_proxy {
+                to backend.internal:443
+                transport {
+                    tls_server_name backend.internal
+                }
+            }
+        }",
+    )
+    .expect("should parse");
+    let Directive::ReverseProxy(rp) = &config.sites[0].directives[0] else {
+        panic!("expected ReverseProxy");
+    };
+    assert!(rp.transport_tls);
+    assert_eq!(rp.tls_server_name.as_deref(), Some("backend.internal"));
+}
+
+#[test]
+fn reverse_proxy_block_transport_plain_tls() {
+    // `transport { tls }` with no server name
+    let config = parse(
+        "a.com {
+            reverse_proxy {
+                to 127.0.0.1:8443
+                transport {
+                    tls
+                }
+            }
+        }",
+    )
+    .expect("should parse");
+    let Directive::ReverseProxy(rp) = &config.sites[0].directives[0] else {
+        panic!("expected ReverseProxy");
+    };
+    assert!(rp.transport_tls);
+    assert!(rp.tls_server_name.is_none());
+}
+
+#[test]
+fn reverse_proxy_block_multi_upstream() {
+    let config = parse(
+        "a.com {
+            reverse_proxy {
+                to 127.0.0.1:8080 127.0.0.1:8081 127.0.0.1:8082
+                lb_policy least_conn
+            }
+        }",
+    )
+    .expect("should parse");
+    let Directive::ReverseProxy(rp) = &config.sites[0].directives[0] else {
+        panic!("expected ReverseProxy");
+    };
+    assert_eq!(rp.upstreams.len(), 3);
+    assert_eq!(rp.lb_policy, Some(LbPolicy::LeastConn));
+}
+
+#[test]
+fn reverse_proxy_block_empty_to_is_error() {
+    // Block form with no `to` subdirective must error.
+    let result = parse(
+        "a.com {
+            reverse_proxy {
+                lb_policy round_robin
+            }
+        }",
+    );
+    assert!(result.is_err(), "empty upstream list must be rejected");
+}
+
+#[test]
+fn reverse_proxy_block_unknown_lb_policy_is_error() {
+    let result = parse(
+        "a.com {
+            reverse_proxy {
+                to 127.0.0.1:8080
+                lb_policy magic
+            }
+        }",
+    );
+    assert!(result.is_err(), "unknown lb_policy must be rejected");
+}
+
+// ── Intercept / CopyResponseHeaders parser tests (ISSUE-067) ─────────────
+
+#[test]
+fn parse_intercept_with_status_and_respond() {
+    // Caddyfile respond syntax: respond "body" STATUS (body before status code)
+    let config = parse(
+        r#"example.com {
+            reverse_proxy 127.0.0.1:8080
+            intercept 404 {
+                respond "not found page" 200
+            }
+        }"#,
+    )
+    .expect("should parse");
+
+    assert_eq!(config.sites[0].directives.len(), 2);
+    let Directive::Intercept(i) = &config.sites[0].directives[1] else {
+        panic!("expected Intercept directive");
+    };
+    assert_eq!(i.statuses, vec![404]);
+    assert_eq!(i.directives.len(), 1);
+    let Directive::Respond(r) = &i.directives[0] else {
+        panic!("expected nested Respond directive");
+    };
+    assert_eq!(r.status, 200);
+    assert_eq!(r.body, "not found page");
+}
+
+#[test]
+fn parse_intercept_multiple_statuses() {
+    let config = parse(
+        "example.com {
+            reverse_proxy 127.0.0.1:8080
+            intercept 404 503 502 {
+                respond 200
+            }
+        }",
+    )
+    .expect("should parse");
+
+    let Directive::Intercept(i) = &config.sites[0].directives[1] else {
+        panic!("expected Intercept directive");
+    };
+    assert_eq!(i.statuses, vec![404, 503, 502]);
+}
+
+#[test]
+fn parse_intercept_inside_handle_block() {
+    let config = parse(
+        r#"example.com {
+            handle /api/* {
+                reverse_proxy 127.0.0.1:8080
+                intercept 404 {
+                    respond "api not found" 200
+                }
+            }
+        }"#,
+    )
+    .expect("should parse");
+
+    let Directive::Handle(h) = &config.sites[0].directives[0] else {
+        panic!("expected Handle directive");
+    };
+    let intercept = h
+        .directives
+        .iter()
+        .find(|d| matches!(d, Directive::Intercept(_)));
+    assert!(
+        intercept.is_some(),
+        "intercept should parse inside handle block"
+    );
+}
+
+#[test]
+fn parse_copy_response_headers_include() {
+    let config = parse(
+        "example.com {
+            reverse_proxy 127.0.0.1:8080
+            copy_response_headers {
+                X-Custom
+                X-Other
+            }
+        }",
+    )
+    .expect("should parse");
+
+    let crh = config.sites[0].directives.iter().find_map(|d| match d {
+        Directive::CopyResponseHeaders(crh) => Some(crh),
+        _ => None,
+    });
+    let crh = crh.expect("should have copy_response_headers");
+    assert!(crh.headers.contains(&"X-Custom".to_string()));
+    assert!(crh.headers.contains(&"X-Other".to_string()));
+}
+
+#[test]
+fn parse_copy_response_headers_exclude_prefix() {
+    let config = parse(
+        "example.com {
+            reverse_proxy 127.0.0.1:8080
+            copy_response_headers {
+                -Set-Cookie
+                -Server
+            }
+        }",
+    )
+    .expect("should parse");
+
+    let crh = config.sites[0].directives.iter().find_map(|d| match d {
+        Directive::CopyResponseHeaders(crh) => Some(crh),
+        _ => None,
+    });
+    let crh = crh.expect("should have copy_response_headers");
+    // Parser stores the raw string including the '-' prefix; compiler strips it
+    assert!(crh.headers.contains(&"-Set-Cookie".to_string()));
+    assert!(crh.headers.contains(&"-Server".to_string()));
 }

--- a/crates/dwaar-core/Cargo.toml
+++ b/crates/dwaar-core/Cargo.toml
@@ -34,6 +34,7 @@ thiserror = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["net", "io-util", "time"] }
+fastrand = { workspace = true }
 
 [dev-dependencies]
 tokio-test = { workspace = true }

--- a/crates/dwaar-core/src/context.rs
+++ b/crates/dwaar-core/src/context.rs
@@ -33,6 +33,7 @@
 //! ```
 
 use std::net::SocketAddr;
+use std::sync::Arc;
 use std::time::Instant;
 
 use compact_str::CompactString;
@@ -41,7 +42,9 @@ use dwaar_analytics::injector::HtmlInjector;
 use dwaar_plugins::plugin::PluginCtx;
 use uuid::Uuid;
 
+use crate::route::{CompiledCopyResponseHeaders, CompiledIntercept};
 use crate::template::VarSlots;
+use crate::upstream::UpstreamPool;
 
 /// Per-request state shared across all Pingora lifecycle hooks.
 ///
@@ -114,6 +117,23 @@ pub struct RequestContext {
 
     /// Per-request variable slots (cloned from `route.var_defaults`, populated by map evaluation).
     pub var_slots: Option<VarSlots>,
+
+    /// Intercept rules cached from route lookup (ISSUE-067).
+    /// Applied in `response_filter()` to match upstream status and override the response.
+    pub intercepts: Vec<CompiledIntercept>,
+
+    /// Body bytes to substitute for the upstream body (set when an intercept fires).
+    /// Consumed in the first `response_body_filter()` call, then cleared.
+    pub intercept_body: Option<bytes::Bytes>,
+
+    /// Copy response headers config cached from route lookup (ISSUE-067).
+    pub copy_response_headers: Option<CompiledCopyResponseHeaders>,
+
+    /// Load-balancing pool for multi-upstream routes (Guardrail #27 — no second `ArcSwap` load).
+    ///
+    /// `None` for single-upstream routes — they use `route_upstream` directly,
+    /// avoiding all pool overhead on the common case.
+    pub upstream_pool: Option<Arc<UpstreamPool>>,
 }
 
 impl RequestContext {
@@ -141,6 +161,10 @@ impl RequestContext {
             injector: None,
             decompressor: None,
             var_slots: None,
+            intercepts: Vec::new(),
+            intercept_body: None,
+            copy_response_headers: None,
+            upstream_pool: None,
         }
     }
 

--- a/crates/dwaar-core/src/lib.rs
+++ b/crates/dwaar-core/src/lib.rs
@@ -20,3 +20,4 @@ pub mod file_server;
 pub mod proxy;
 pub mod route;
 pub mod template;
+pub mod upstream;

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -39,6 +39,18 @@ use crate::context::RequestContext;
 use crate::route::RouteTable;
 use crate::template::TemplateContext;
 
+/// Headers that `copy_response_headers include` must never strip.
+///
+/// HTTP's hop-by-hop headers and framing headers (Content-Length,
+/// Transfer-Encoding, etc.) are required for correct message framing.
+/// Stripping them based on user config would break the HTTP layer.
+fn is_essential_header(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "content-type" | "content-length" | "transfer-encoding" | "connection" | "date" | "server"
+    )
+}
+
 /// Sanitize a request path for use in a redirect Location header.
 /// Prevents CRLF injection and protocol-relative open redirects.
 fn sanitize_redirect_path(path: &str) -> String {
@@ -334,6 +346,17 @@ impl ProxyHttp for DwaarProxy {
                         crate::route::Handler::ReverseProxy { upstream } => {
                             ctx.route_upstream = Some(*upstream);
                         }
+                        crate::route::Handler::ReverseProxyPool { pool } => {
+                            // Resolve the upstream now using the LB policy.
+                            // Cache the selected address in `route_upstream` so
+                            // `upstream_peer()` doesn't need to call `select()` again
+                            // for single-backend pools.
+                            let selected = pool.select(ctx.plugin_ctx.client_ip);
+                            ctx.route_upstream = selected.as_ref().map(|s| s.addr);
+                            // Always cache the pool so `upstream_peer()` can use the
+                            // correct TLS settings even in the single-backend case.
+                            ctx.upstream_pool = Some(pool.clone());
+                        }
                         crate::route::Handler::FastCgi { upstream, root } => {
                             ctx.route_upstream = Some(*upstream);
                             ctx.fastcgi_root = Some(root.clone());
@@ -346,6 +369,16 @@ impl ProxyHttp for DwaarProxy {
                     }
                     if let Some(ref fwd) = block.forward_auth {
                         ctx.forward_auth = Some(fwd.clone());
+                    }
+
+                    // Cache response-phase intercept rules (ISSUE-067).
+                    // Cloning a small Vec of compiled structs here is cheaper than
+                    // re-loading the ArcSwap in response_filter().
+                    if !block.intercepts.is_empty() {
+                        ctx.intercepts.clone_from(&block.intercepts);
+                    }
+                    if let Some(ref crh) = block.copy_response_headers {
+                        ctx.copy_response_headers = Some(crh.clone());
                     }
 
                     // Evaluate map directives to populate VarSlots (ISSUE-056)
@@ -768,13 +801,37 @@ impl ProxyHttp for DwaarProxy {
             upstream
         };
 
+        // Determine TLS settings from the pool (if this is a pool-backed route).
+        // Single-backend routes that were compiled as plain `ReverseProxy` use
+        // no TLS by default — transport TLS must be configured explicitly.
+        let (use_tls, sni) = if let Some(ref pool) = ctx.upstream_pool {
+            // Re-select from the pool to get TLS metadata for the chosen backend.
+            // The address was already selected in request_filter(), so this scan
+            // is a O(n) match on the small backends Vec — not on the hot path.
+            let tls = pool
+                .backends
+                .iter()
+                .find(|b| b.addr == upstream)
+                .is_some_and(|b| b.tls);
+            let sni = pool
+                .backends
+                .iter()
+                .find(|b| b.addr == upstream)
+                .map(|b| b.tls_server_name.clone())
+                .unwrap_or_default();
+            (tls, sni)
+        } else {
+            (false, String::new())
+        };
+
         debug!(
             upstream = %upstream,
+            tls = use_tls,
             request_id = %ctx.request_id(),
             "route resolved"
         );
 
-        let mut peer = HttpPeer::new(upstream, false, String::new());
+        let mut peer = HttpPeer::new(upstream, use_tls, sni);
         peer.options.connection_timeout = Some(std::time::Duration::from_secs(10));
         peer.options.read_timeout = Some(std::time::Duration::from_secs(30));
         peer.options.write_timeout = Some(std::time::Duration::from_secs(30));
@@ -920,6 +977,77 @@ impl ProxyHttp for DwaarProxy {
             .insert_header("X-Request-Id", ctx.request_id())
             .expect("UUID is valid header value");
 
+        // --- Intercept check (ISSUE-067) ---
+        // Run before analytics setup so we operate on the original upstream status.
+        // First matching rule wins; empty statuses catches all non-2xx responses.
+        let response_status = upstream_response.status.as_u16();
+        if !ctx.intercepts.is_empty() {
+            // Extract the matching action before touching ctx again — the borrow
+            // on ctx.intercepts must end before we can assign ctx.intercept_body.
+            let matched = ctx.intercepts.iter().find_map(|intercept| {
+                if intercept.matches_status(response_status) {
+                    Some((
+                        intercept.replace_status,
+                        intercept
+                            .set_headers
+                            .iter()
+                            .map(|(n, v)| (n.as_str().to_owned(), v.as_str().to_owned()))
+                            .collect::<Vec<_>>(),
+                        intercept.replace_body.clone(),
+                    ))
+                } else {
+                    None
+                }
+            });
+            if let Some((new_status, set_headers, replace_body)) = matched {
+                if let Some(code) = new_status {
+                    upstream_response
+                        .set_status(
+                            pingora_http::StatusCode::from_u16(code)
+                                .expect("intercept status must be a valid HTTP code"),
+                        )
+                        .expect("failed to set intercept status");
+                }
+                for (name, value) in set_headers {
+                    upstream_response
+                        .insert_header(name, value)
+                        .expect("intercept header name/value must be valid");
+                }
+                if let Some(body) = replace_body {
+                    // Signal body replacement to response_body_filter().
+                    // Remove Content-Length so the new body length is not validated.
+                    ctx.intercept_body = Some(body);
+                    upstream_response.remove_header("Content-Length");
+                }
+            }
+        }
+
+        // --- Copy response headers filter (ISSUE-067) ---
+        // Strip excluded headers and optionally keep only an allowed subset.
+        if let Some(ref crh) = ctx.copy_response_headers
+            && crh.matches_status(response_status)
+        {
+            for name in &crh.exclude {
+                upstream_response.remove_header(name.as_str());
+            }
+            if !crh.include.is_empty() {
+                // Collect names to strip; cannot mutate while iterating the map.
+                let to_remove: Vec<String> = upstream_response
+                    .headers
+                    .keys()
+                    .filter(|k| {
+                        let name = k.as_str();
+                        !crh.include.iter().any(|i| i.eq_ignore_ascii_case(name))
+                            && !is_essential_header(name)
+                    })
+                    .map(|k| k.as_str().to_owned())
+                    .collect();
+                for name in &to_remove {
+                    upstream_response.remove_header(name.as_str());
+                }
+            }
+        }
+
         // --- Analytics injection setup (ISSUE-026a + 026c) ---
         // Must run BEFORE the plugin chain so that the compression plugin
         // sees Content-Encoding already stripped (for HTML injection path).
@@ -972,6 +1100,14 @@ impl ProxyHttp for DwaarProxy {
     where
         Self::CTX: Send + Sync,
     {
+        // --- Intercept body override (ISSUE-067) ---
+        // When an intercept rule has a replacement body, substitute it here
+        // and skip all other body processing (analytics injection, compression).
+        if let Some(replacement) = ctx.intercept_body.take() {
+            *body = Some(replacement);
+            return Ok(None);
+        }
+
         // Decompress first (if compressed response) — core analytics
         if let Some(ref mut decompressor) = ctx.decompressor {
             decompressor.decompress(body, end_of_stream);

--- a/crates/dwaar-core/src/route.rs
+++ b/crates/dwaar-core/src/route.rs
@@ -51,11 +51,13 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use ahash::RandomState;
 use compact_str::CompactString;
 
 use crate::template::{CompiledTemplate, TemplateContext, VarSlots};
+use crate::upstream::UpstreamPool;
 use regex::Regex;
 
 /// Validate that a string is a legal hostname or wildcard pattern.
@@ -81,13 +83,20 @@ pub fn is_valid_domain(s: &str) -> bool {
 /// What produces the response — the terminal action for a matched request.
 ///
 /// Each handler block resolves to exactly one `Handler`. The proxy dispatches
-/// based on this: `ReverseProxy` continues to `upstream_peer()`, while future
-/// variants like `StaticResponse` and `FileServer` short-circuit in
-/// `request_filter()`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// based on this: `ReverseProxy`/`ReverseProxyPool` continue to `upstream_peer()`,
+/// while `StaticResponse` and `FileServer` short-circuit in `request_filter()`.
+#[derive(Debug, Clone)]
 pub enum Handler {
-    /// Forward the request to an upstream backend.
+    /// Forward the request to a single upstream backend (zero-overhead common case).
+    ///
+    /// Used when the config has exactly one upstream and no block-form options.
+    /// Keeps `upstream_peer()` allocation-free: no `Arc` load, no pool scan.
     ReverseProxy { upstream: SocketAddr },
+    /// Forward the request through a load-balancing pool of backends.
+    ///
+    /// Created when the config has multiple upstreams or block-form options
+    /// (`lb_policy`, `health_uri`, `max_conns`, transport tls).
+    ReverseProxyPool { pool: Arc<UpstreamPool> },
     /// Return a fixed response — no upstream contacted. Used by `respond` directive.
     StaticResponse { status: u16, body: bytes::Bytes },
     /// Serve static files from disk. Used by `file_server` directive.
@@ -101,6 +110,55 @@ pub enum Handler {
         root: std::path::PathBuf,
     },
 }
+
+impl PartialEq for Handler {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Handler::ReverseProxy { upstream: a }, Handler::ReverseProxy { upstream: b }) => {
+                a == b
+            }
+            // Pool equality is by pointer identity — two pools are equal only if
+            // they point to the same allocation. This is intentional: pool contents
+            // are mutable (health state), so value equality would be misleading.
+            (Handler::ReverseProxyPool { pool: a }, Handler::ReverseProxyPool { pool: b }) => {
+                Arc::ptr_eq(a, b)
+            }
+            (
+                Handler::StaticResponse {
+                    status: s1,
+                    body: b1,
+                },
+                Handler::StaticResponse {
+                    status: s2,
+                    body: b2,
+                },
+            ) => s1 == s2 && b1 == b2,
+            (
+                Handler::FileServer {
+                    root: r1,
+                    browse: b1,
+                },
+                Handler::FileServer {
+                    root: r2,
+                    browse: b2,
+                },
+            ) => r1 == r2 && b1 == b2,
+            (
+                Handler::FastCgi {
+                    upstream: u1,
+                    root: r1,
+                },
+                Handler::FastCgi {
+                    upstream: u2,
+                    root: r2,
+                },
+            ) => u1 == u2 && r1 == r2,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for Handler {}
 
 /// How a handler block was declared, controlling execution semantics.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -162,6 +220,61 @@ impl PathMatcher {
                 }
             }
         }
+    }
+}
+
+// ── Intercept / CopyResponseHeaders (ISSUE-067) ─────────────────────────────
+
+/// Compiled `intercept` rule — matches upstream status codes and overrides the response.
+///
+/// Applied in `response_filter()` before the response reaches the client.
+/// First matching rule wins; remaining rules are skipped.
+#[derive(Debug, Clone)]
+pub struct CompiledIntercept {
+    /// Status codes to match. Empty = match all non-2xx responses.
+    pub statuses: Vec<u16>,
+    /// Replacement status code (from nested `respond` directive).
+    pub replace_status: Option<u16>,
+    /// Replacement body bytes (from nested `respond` directive).
+    pub replace_body: Option<bytes::Bytes>,
+    /// Response headers to set when this intercept fires.
+    pub set_headers: Vec<(CompactString, CompactString)>,
+}
+
+impl CompiledIntercept {
+    /// Whether this rule matches the given upstream status code.
+    ///
+    /// Empty `statuses` acts as a catch-all for non-2xx responses — matching
+    /// Caddy's semantics where a bare `intercept` block targets error responses.
+    #[inline]
+    pub fn matches_status(&self, status: u16) -> bool {
+        if self.statuses.is_empty() {
+            !(200..300).contains(&status)
+        } else {
+            self.statuses.contains(&status)
+        }
+    }
+}
+
+/// Compiled `copy_response_headers` rule — controls which upstream headers reach the client.
+///
+/// Applied in `response_filter()`. `include` and `exclude` are mutually exclusive in
+/// practice — the Caddyfile style uses one or the other per block.
+#[derive(Debug, Clone)]
+pub struct CompiledCopyResponseHeaders {
+    /// Status codes to apply this rule to. Empty = apply to all responses.
+    pub statuses: Vec<u16>,
+    /// Header names to keep (strip everything else). Empty = keep all headers.
+    pub include: Vec<CompactString>,
+    /// Header names to strip from the upstream response.
+    pub exclude: Vec<CompactString>,
+}
+
+impl CompiledCopyResponseHeaders {
+    /// Whether this rule applies to the given status code.
+    #[inline]
+    pub fn matches_status(&self, status: u16) -> bool {
+        self.statuses.is_empty() || self.statuses.contains(&status)
     }
 }
 
@@ -252,6 +365,11 @@ pub struct HandlerBlock {
     /// Named logger from `log_name` directive.
     pub log_name: Option<String>,
     pub handler: Handler,
+    /// Intercept rules — match upstream status codes and replace the response.
+    /// Applied in `response_filter()` before the response reaches the client.
+    pub intercepts: Vec<CompiledIntercept>,
+    /// Selective header copy config — controls which upstream headers reach the client.
+    pub copy_response_headers: Option<CompiledCopyResponseHeaders>,
 }
 
 // ── Compiled Map (ISSUE-056) ──────────────────────────────────────
@@ -388,6 +506,8 @@ impl Route {
                 log_append_fields: vec![],
                 log_name: None,
                 handler: Handler::ReverseProxy { upstream },
+                intercepts: vec![],
+                copy_response_headers: None,
             }],
             var_defaults: VarSlots::default(),
         }
@@ -407,6 +527,9 @@ impl Route {
             Handler::ReverseProxy { upstream } | Handler::FastCgi { upstream, .. } => {
                 Some(*upstream)
             }
+            // For pool handlers, cache the first backend address so the common
+            // path (no pool selection needed) stays zero-cost.
+            Handler::ReverseProxyPool { pool } => pool.first_addr(),
             Handler::StaticResponse { .. } | Handler::FileServer { .. } => None,
         });
         let first = handlers.first();
@@ -896,5 +1019,111 @@ mod tests {
             replace: CompactString::from("/v2"),
         };
         assert!(r.apply("/api/v3/users", None).is_none());
+    }
+
+    // ── CompiledIntercept (ISSUE-067) ────────────────────────
+
+    #[test]
+    fn intercept_matches_explicit_status() {
+        let rule = CompiledIntercept {
+            statuses: vec![404, 503],
+            replace_status: None,
+            replace_body: None,
+            set_headers: vec![],
+        };
+        assert!(rule.matches_status(404));
+        assert!(rule.matches_status(503));
+        assert!(!rule.matches_status(200));
+        assert!(!rule.matches_status(500));
+    }
+
+    #[test]
+    fn intercept_empty_statuses_catches_non_2xx() {
+        let rule = CompiledIntercept {
+            statuses: vec![],
+            replace_status: None,
+            replace_body: None,
+            set_headers: vec![],
+        };
+        // Non-2xx: should match
+        assert!(rule.matches_status(404));
+        assert!(rule.matches_status(500));
+        assert!(rule.matches_status(301));
+        // 2xx: should NOT match (empty statuses means "catch errors, not success")
+        assert!(!rule.matches_status(200));
+        assert!(!rule.matches_status(201));
+        assert!(!rule.matches_status(299));
+    }
+
+    #[test]
+    fn intercept_carries_replace_status_and_body() {
+        let rule = CompiledIntercept {
+            statuses: vec![404],
+            replace_status: Some(200),
+            replace_body: Some(bytes::Bytes::from("custom body")),
+            set_headers: vec![],
+        };
+        assert_eq!(rule.replace_status, Some(200));
+        assert_eq!(rule.replace_body.as_deref(), Some(b"custom body".as_ref()));
+    }
+
+    #[test]
+    fn intercept_set_headers_are_collected() {
+        let rule = CompiledIntercept {
+            statuses: vec![404],
+            replace_status: None,
+            replace_body: None,
+            set_headers: vec![
+                (
+                    CompactString::from("X-Custom"),
+                    CompactString::from("value"),
+                ),
+                (
+                    CompactString::from("Cache-Control"),
+                    CompactString::from("no-store"),
+                ),
+            ],
+        };
+        assert_eq!(rule.set_headers.len(), 2);
+        assert_eq!(rule.set_headers[0].0.as_str(), "X-Custom");
+    }
+
+    // ── CompiledCopyResponseHeaders (ISSUE-067) ──────────────
+
+    #[test]
+    fn copy_response_headers_empty_statuses_matches_all() {
+        let crh = CompiledCopyResponseHeaders {
+            statuses: vec![],
+            include: vec![],
+            exclude: vec![],
+        };
+        assert!(crh.matches_status(200));
+        assert!(crh.matches_status(404));
+        assert!(crh.matches_status(500));
+    }
+
+    #[test]
+    fn copy_response_headers_explicit_statuses() {
+        let crh = CompiledCopyResponseHeaders {
+            statuses: vec![200, 201],
+            include: vec![],
+            exclude: vec![],
+        };
+        assert!(crh.matches_status(200));
+        assert!(crh.matches_status(201));
+        assert!(!crh.matches_status(404));
+    }
+
+    #[test]
+    fn copy_response_headers_include_and_exclude_populated() {
+        let crh = CompiledCopyResponseHeaders {
+            statuses: vec![],
+            include: vec![CompactString::from("X-Custom")],
+            exclude: vec![CompactString::from("Set-Cookie")],
+        };
+        assert_eq!(crh.include.len(), 1);
+        assert_eq!(crh.exclude.len(), 1);
+        assert_eq!(crh.include[0].as_str(), "X-Custom");
+        assert_eq!(crh.exclude[0].as_str(), "Set-Cookie");
     }
 }

--- a/crates/dwaar-core/src/upstream.rs
+++ b/crates/dwaar-core/src/upstream.rs
@@ -1,0 +1,777 @@
+// Copyright (C) 2026 Permanu
+// SPDX-License-Identifier: BSL-1.1
+//
+// This file is part of Dwaar — https://dwaar.dev
+// Licensed under the Business Source License 1.1
+
+//! Runtime upstream pool — load balancing, connection limiting, health tracking.
+//!
+//! `UpstreamPool` holds a fixed slice of backends compiled from config. All
+//! selection logic is lock-free: atomics for counters and health flags so that
+//! every request can pick an upstream without touching a mutex.
+//!
+//! ## Design rationale (Four Pillars)
+//!
+//! | Pillar | Decision |
+//! |---|---|
+//! | Performance | `AtomicU64`/`AtomicBool`/`AtomicU32` — no mutex on hot path |
+//! | Reliability | All-unhealthy returns `None`; caller generates 502 |
+//! | Security | `max_conns` enforced atomically before accepting new work |
+//! | Competitive Parity | Round-robin, least-conn, random, ip-hash match nginx/Caddy |
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use pingora_core::OrErr;
+use pingora_core::services::background::BackgroundService;
+use tracing::{debug, warn};
+
+/// Which algorithm the pool uses to pick a backend on each request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LbPolicy {
+    RoundRobin,
+    LeastConn,
+    Random,
+    IpHash,
+}
+
+/// A pool of upstream backends with load balancing and health tracking.
+///
+/// Created once at config compile time and placed behind an `Arc` so the proxy
+/// and health-checker share the same atomic state.
+#[derive(Debug)]
+pub struct UpstreamPool {
+    pub(crate) backends: Vec<Backend>,
+    policy: LbPolicy,
+    /// Monotonically increasing counter — wrapped on overflow (2^64 >> backend count).
+    counter: AtomicU64,
+    /// HTTP path polled by the health checker. `None` disables health checking.
+    pub(crate) health_uri: Option<String>,
+    /// Seconds between health polls.
+    pub(crate) health_interval: Duration,
+}
+
+/// One backend server inside the pool.
+#[derive(Debug)]
+pub(crate) struct Backend {
+    pub(crate) addr: SocketAddr,
+    /// `true` when the backend is considered reachable.
+    pub(crate) healthy: AtomicBool,
+    /// Number of connections currently in-flight to this backend.
+    pub(crate) active_conns: AtomicU32,
+    /// Connection cap. `None` = unlimited.
+    pub(crate) max_conns: Option<u32>,
+    /// Connect over TLS to this specific backend.
+    pub(crate) tls: bool,
+    /// SNI hostname for TLS. Empty string = use `addr.ip()` as SNI.
+    pub(crate) tls_server_name: String,
+}
+
+/// The result of a successful backend selection.
+#[derive(Debug, Clone)]
+pub struct SelectedUpstream {
+    pub addr: SocketAddr,
+    pub tls: bool,
+    pub sni: String,
+}
+
+impl UpstreamPool {
+    /// Build a pool from already-resolved backend descriptors.
+    ///
+    /// `health_uri` enables periodic HTTP health polling; `None` disables it.
+    /// `health_interval` defaults to 10 s when `None` is passed.
+    pub fn new(
+        backends: Vec<BackendConfig>,
+        policy: LbPolicy,
+        health_uri: Option<String>,
+        health_interval: Option<u64>,
+    ) -> Self {
+        let compiled = backends
+            .into_iter()
+            .map(|b| Backend {
+                addr: b.addr,
+                healthy: AtomicBool::new(true),
+                active_conns: AtomicU32::new(0),
+                max_conns: b.max_conns,
+                tls: b.tls,
+                tls_server_name: b.tls_server_name,
+            })
+            .collect();
+
+        Self {
+            backends: compiled,
+            policy,
+            counter: AtomicU64::new(0),
+            health_uri,
+            health_interval: Duration::from_secs(health_interval.unwrap_or(10)),
+        }
+    }
+
+    /// Returns `true` if this pool has a health check URI configured.
+    ///
+    /// Used by `dwaar-config` to decide which pools need a background health prober.
+    pub fn has_health_check(&self) -> bool {
+        self.health_uri.is_some()
+    }
+
+    /// Pick an upstream backend for the current request.
+    ///
+    /// Returns `None` only when every backend is either unhealthy or at its
+    /// connection limit — the caller should respond with 502.
+    ///
+    /// # Single-backend fast path
+    ///
+    /// When the pool has exactly one backend we skip the atomic counter increment
+    /// and the Vec scan entirely. This is the common case for most Dwaarfiles.
+    pub fn select(&self, client_ip: Option<std::net::IpAddr>) -> Option<SelectedUpstream> {
+        if self.backends.is_empty() {
+            return None;
+        }
+        if self.backends.len() == 1 {
+            return self.select_single();
+        }
+
+        match self.policy {
+            LbPolicy::RoundRobin => self.select_round_robin(),
+            LbPolicy::LeastConn => self.select_least_conn(),
+            LbPolicy::Random => self.select_random(),
+            LbPolicy::IpHash => self.select_ip_hash(client_ip),
+        }
+    }
+
+    /// Fast path: single-backend pool — no selection overhead at all.
+    fn select_single(&self) -> Option<SelectedUpstream> {
+        let b = &self.backends[0];
+        if !b.healthy.load(Ordering::Relaxed) {
+            return None;
+        }
+        if let Some(max) = b.max_conns
+            && b.active_conns.load(Ordering::Relaxed) >= max
+        {
+            return None;
+        }
+        Some(SelectedUpstream {
+            addr: b.addr,
+            tls: b.tls,
+            sni: b.tls_server_name.clone(),
+        })
+    }
+
+    /// Round-robin: atomically advance the global counter and mod by healthy count.
+    ///
+    /// We iterate from the selected index, wrapping around, until we find a
+    /// backend that is both healthy and under its connection cap. This handles
+    /// the case where the initially-selected backend is temporarily unavailable
+    /// without changing the distribution for the common all-healthy case.
+    fn select_round_robin(&self) -> Option<SelectedUpstream> {
+        let n = self.backends.len();
+        let start = self.counter.fetch_add(1, Ordering::Relaxed) as usize % n;
+        self.find_available_from(start)
+    }
+
+    /// Least-conn: iterate and pick the backend with the lowest active-conn count.
+    ///
+    /// We scan once (O(n)) — acceptable because backend counts are typically small
+    /// (< 32) and the scan is cache-hot. Relaxed loads are fine: a slightly stale
+    /// count won't cause correctness issues, only minor suboptimality.
+    fn select_least_conn(&self) -> Option<SelectedUpstream> {
+        let best = self
+            .backends
+            .iter()
+            .filter(|b| {
+                b.healthy.load(Ordering::Relaxed)
+                    && b.max_conns
+                        .is_none_or(|max| b.active_conns.load(Ordering::Relaxed) < max)
+            })
+            .min_by_key(|b| b.active_conns.load(Ordering::Relaxed))?;
+
+        Some(SelectedUpstream {
+            addr: best.addr,
+            tls: best.tls,
+            sni: best.tls_server_name.clone(),
+        })
+    }
+
+    /// Random: choose a uniformly random healthy backend.
+    fn select_random(&self) -> Option<SelectedUpstream> {
+        let available: Vec<_> = self
+            .backends
+            .iter()
+            .filter(|b| {
+                b.healthy.load(Ordering::Relaxed)
+                    && b.max_conns
+                        .is_none_or(|max| b.active_conns.load(Ordering::Relaxed) < max)
+            })
+            .collect();
+
+        if available.is_empty() {
+            return None;
+        }
+
+        let b = available[fastrand::usize(..available.len())];
+        Some(SelectedUpstream {
+            addr: b.addr,
+            tls: b.tls,
+            sni: b.tls_server_name.clone(),
+        })
+    }
+
+    /// IP-hash: hash the client IP and pick a backend deterministically.
+    ///
+    /// Falls back to round-robin when no client IP is available.
+    fn select_ip_hash(&self, client_ip: Option<std::net::IpAddr>) -> Option<SelectedUpstream> {
+        let Some(ip) = client_ip else {
+            return self.select_round_robin();
+        };
+
+        // FNV-1a over the raw IP bytes — cheap and distribution is good enough for LB
+        let hash = fnv_hash_ip(ip);
+        let n = self.backends.len();
+        let start = hash % n;
+        self.find_available_from(start)
+    }
+
+    /// Starting from `start`, scan the pool in order until an available backend is found.
+    fn find_available_from(&self, start: usize) -> Option<SelectedUpstream> {
+        let n = self.backends.len();
+        for offset in 0..n {
+            let b = &self.backends[(start + offset) % n];
+            if !b.healthy.load(Ordering::Relaxed) {
+                continue;
+            }
+            if let Some(max) = b.max_conns
+                && b.active_conns.load(Ordering::Relaxed) >= max
+            {
+                continue;
+            }
+            return Some(SelectedUpstream {
+                addr: b.addr,
+                tls: b.tls,
+                sni: b.tls_server_name.clone(),
+            });
+        }
+        None
+    }
+
+    /// Mark a backend as healthy (called by `HealthChecker` after a successful probe).
+    pub fn mark_healthy(&self, addr: SocketAddr) {
+        for b in &self.backends {
+            if b.addr == addr {
+                let was_unhealthy = !b.healthy.swap(true, Ordering::Relaxed);
+                if was_unhealthy {
+                    debug!(%addr, "backend marked healthy");
+                }
+                return;
+            }
+        }
+    }
+
+    /// Mark a backend as unhealthy (called by `HealthChecker` after a failed probe,
+    /// or by `upstream_peer()` when a connection is refused).
+    pub fn mark_unhealthy(&self, addr: SocketAddr) {
+        for b in &self.backends {
+            if b.addr == addr {
+                let was_healthy = b.healthy.swap(false, Ordering::Relaxed);
+                if was_healthy {
+                    warn!(%addr, "backend marked unhealthy");
+                }
+                return;
+            }
+        }
+    }
+
+    /// Increment the active-connection counter for a backend.
+    ///
+    /// Returns `false` if the backend is at `max_conns` and the increment was
+    /// rejected — the caller should try another backend or return 502.
+    pub fn acquire_connection(&self, addr: SocketAddr) -> bool {
+        for b in &self.backends {
+            if b.addr == addr {
+                if let Some(max) = b.max_conns {
+                    // Compare-and-swap loop to atomically check + increment
+                    let mut current = b.active_conns.load(Ordering::Relaxed);
+                    loop {
+                        if current >= max {
+                            return false;
+                        }
+                        match b.active_conns.compare_exchange_weak(
+                            current,
+                            current + 1,
+                            Ordering::AcqRel,
+                            Ordering::Relaxed,
+                        ) {
+                            Ok(_) => return true,
+                            Err(actual) => current = actual,
+                        }
+                    }
+                } else {
+                    b.active_conns.fetch_add(1, Ordering::Relaxed);
+                    return true;
+                }
+            }
+        }
+        // Unknown addr — don't block it
+        true
+    }
+
+    /// Decrement the active-connection counter when a request completes.
+    pub fn release_connection(&self, addr: SocketAddr) {
+        for b in &self.backends {
+            if b.addr == addr {
+                // Saturating sub prevents underflow if release is called without acquire
+                b.active_conns
+                    .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+                        Some(v.saturating_sub(1))
+                    })
+                    .ok();
+                return;
+            }
+        }
+    }
+
+    /// The address of the first backend — used for the `default_upstream` inline
+    /// cache on `Route`, so the common single-upstream path stays zero-overhead.
+    pub fn first_addr(&self) -> Option<SocketAddr> {
+        self.backends.first().map(|b| b.addr)
+    }
+
+    /// Number of configured backends.
+    pub fn len(&self) -> usize {
+        self.backends.len()
+    }
+
+    /// Returns `true` if the pool has no backends.
+    pub fn is_empty(&self) -> bool {
+        self.backends.is_empty()
+    }
+}
+
+/// Configuration for one backend, passed to `UpstreamPool::new`.
+#[derive(Debug)]
+pub struct BackendConfig {
+    pub addr: SocketAddr,
+    pub max_conns: Option<u32>,
+    pub tls: bool,
+    pub tls_server_name: String,
+}
+
+// ── FNV-1a IP hash ────────────────────────────────────────────────────────────
+
+/// FNV-1a hash of an IP address, returning a `usize` for indexing.
+///
+/// FNV-1a is chosen because it's branchless, avalanche-free at low latency,
+/// and has no dependencies. Distribution across backends is uniform in practice.
+fn fnv_hash_ip(ip: std::net::IpAddr) -> usize {
+    const FNV_OFFSET: u64 = 14_695_981_039_346_656_037;
+    const FNV_PRIME: u64 = 1_099_511_628_211;
+
+    let mut hash = FNV_OFFSET;
+    let bytes: &[u8] = match &ip {
+        std::net::IpAddr::V4(v4) => &v4.octets()[..],
+        std::net::IpAddr::V6(v6) => &v6.octets()[..],
+    };
+    // Can't use `bytes` borrow after the match arm — collect into fixed array
+    let hash = match ip {
+        std::net::IpAddr::V4(v4) => {
+            let bytes = v4.octets();
+            for &b in &bytes {
+                hash ^= u64::from(b);
+                hash = hash.wrapping_mul(FNV_PRIME);
+            }
+            hash
+        }
+        std::net::IpAddr::V6(v6) => {
+            let bytes = v6.octets();
+            for &b in &bytes {
+                hash ^= u64::from(b);
+                hash = hash.wrapping_mul(FNV_PRIME);
+            }
+            hash
+        }
+    };
+    let _ = bytes; // used in the match arms above
+    hash as usize
+}
+
+// ── HealthChecker ─────────────────────────────────────────────────────────────
+
+/// Background service that periodically probes backends and updates their health.
+///
+/// Uses Pingora's `BackgroundService` so it runs inside Pingora's own tokio
+/// runtime — no `tokio::spawn` needed before `run_forever()`.
+///
+/// Per Guardrail #20: all async background work must be a `BackgroundService`,
+/// never a raw `tokio::spawn`.
+pub struct HealthChecker {
+    /// Pools are moved in via `Mutex<Option<…>>` so `start()` can take ownership
+    /// from `&self` — Pingora calls `start()` exactly once.
+    pools: std::sync::Mutex<Option<Vec<Arc<UpstreamPool>>>>,
+}
+
+impl std::fmt::Debug for HealthChecker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HealthChecker").finish_non_exhaustive()
+    }
+}
+
+impl HealthChecker {
+    /// Create a new checker with the given pools.
+    pub fn new(pools: Vec<Arc<UpstreamPool>>) -> Self {
+        Self {
+            pools: std::sync::Mutex::new(Some(pools)),
+        }
+    }
+}
+
+#[async_trait]
+impl BackgroundService for HealthChecker {
+    async fn start(&self, mut shutdown: pingora_core::server::ShutdownWatch) {
+        // Take ownership of pools from the Mutex — this runs exactly once.
+        let pools = self
+            .pools
+            .lock()
+            .expect("HealthChecker lock not poisoned")
+            .take()
+            .unwrap_or_default();
+
+        // Filter to pools that have a health URI configured.
+        let active: Vec<Arc<UpstreamPool>> = pools
+            .into_iter()
+            .filter(|p| p.health_uri.is_some())
+            .collect();
+
+        if active.is_empty() {
+            debug!("health checker: no pools with health_uri configured, exiting");
+            return;
+        }
+
+        // Derive a common poll interval — use the smallest interval across all pools.
+        let interval = active
+            .iter()
+            .map(|p| p.health_interval)
+            .min()
+            .unwrap_or(Duration::from_secs(10));
+
+        loop {
+            // Probe all backends across all pools.
+            for pool in &active {
+                let Some(ref uri) = pool.health_uri else {
+                    continue;
+                };
+                for backend in &pool.backends {
+                    let addr = backend.addr;
+                    let probe_uri = uri.clone();
+                    match probe_backend(addr, &probe_uri).await {
+                        Ok(status) if (200..300).contains(&status) => {
+                            pool.mark_healthy(addr);
+                        }
+                        Ok(status) => {
+                            warn!(%addr, status, "health probe returned non-2xx, marking unhealthy");
+                            pool.mark_unhealthy(addr);
+                        }
+                        Err(e) => {
+                            warn!(%addr, error = %e, "health probe failed, marking unhealthy");
+                            pool.mark_unhealthy(addr);
+                        }
+                    }
+                }
+            }
+
+            // Wait for `interval` or shutdown signal.
+            tokio::select! {
+                () = tokio::time::sleep(interval) => {}
+                _ = shutdown.changed() => {
+                    debug!("health checker: shutdown signal received");
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// Send an HTTP GET to `addr/<uri>` and return the response status code.
+///
+/// Uses a plain tokio TCP connection and hand-crafted minimal HTTP/1.1 request
+/// so we avoid pulling in `reqwest` (forbidden by Guardrail dependency policy).
+/// This is health-check code, not hot-path — a small allocation here is fine.
+async fn probe_backend(
+    addr: SocketAddr,
+    uri: &str,
+) -> Result<u16, Box<dyn std::error::Error + Send + Sync>> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpStream;
+
+    // 5-second connect + read budget is generous for a health probe.
+    let mut stream = tokio::time::timeout(Duration::from_secs(5), TcpStream::connect(addr))
+        .await
+        .map_err(|_| "connect timed out")?
+        .or_err(
+            pingora_error::ErrorType::ConnectTimedout,
+            "health probe connect",
+        )?;
+
+    let host = addr.to_string();
+    let request = format!("GET {uri} HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n");
+
+    tokio::time::timeout(Duration::from_secs(5), stream.write_all(request.as_bytes()))
+        .await
+        .map_err(|_| "write timed out")?
+        .or_err(pingora_error::ErrorType::WriteError, "health probe write")?;
+
+    // Read just enough to parse the status line — `HTTP/1.1 200 OK\r\n` is ~17 bytes.
+    let mut buf = [0u8; 64];
+    let n = tokio::time::timeout(Duration::from_secs(5), stream.read(&mut buf))
+        .await
+        .map_err(|_| "read timed out")?
+        .or_err(pingora_error::ErrorType::ReadError, "health probe read")?;
+
+    // Parse "HTTP/1.x NNN ..." — we only need the status code.
+    let response = std::str::from_utf8(&buf[..n])?;
+    let status = response
+        .split_whitespace()
+        .nth(1)
+        .ok_or("missing status code")?
+        .parse::<u16>()?;
+
+    Ok(status)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    fn make_addr(port: u16) -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port)
+    }
+
+    fn make_pool(ports: &[u16], policy: LbPolicy) -> UpstreamPool {
+        let backends = ports
+            .iter()
+            .map(|&p| BackendConfig {
+                addr: make_addr(p),
+                max_conns: None,
+                tls: false,
+                tls_server_name: String::new(),
+            })
+            .collect();
+        UpstreamPool::new(backends, policy, None, None)
+    }
+
+    fn make_pool_with_max(port: u16, max_conns: u32) -> UpstreamPool {
+        UpstreamPool::new(
+            vec![BackendConfig {
+                addr: make_addr(port),
+                max_conns: Some(max_conns),
+                tls: false,
+                tls_server_name: String::new(),
+            }],
+            LbPolicy::RoundRobin,
+            None,
+            None,
+        )
+    }
+
+    // ── single-backend fast path ──────────────────────────────────────────────
+
+    #[test]
+    fn single_backend_fast_path_returns_backend() {
+        let pool = make_pool(&[8080], LbPolicy::RoundRobin);
+        let sel = pool.select(None).expect("should select");
+        assert_eq!(sel.addr, make_addr(8080));
+    }
+
+    #[test]
+    fn single_backend_unhealthy_returns_none() {
+        let pool = make_pool(&[8080], LbPolicy::RoundRobin);
+        pool.mark_unhealthy(make_addr(8080));
+        assert!(pool.select(None).is_none());
+    }
+
+    #[test]
+    fn all_backends_unhealthy_returns_none() {
+        let pool = make_pool(&[8080, 8081, 8082], LbPolicy::RoundRobin);
+        pool.mark_unhealthy(make_addr(8080));
+        pool.mark_unhealthy(make_addr(8081));
+        pool.mark_unhealthy(make_addr(8082));
+        assert!(pool.select(None).is_none());
+    }
+
+    // ── round-robin ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn round_robin_distributes_evenly() {
+        let pool = make_pool(&[8080, 8081, 8082], LbPolicy::RoundRobin);
+        let mut counts = [0usize; 3];
+        let ports = [8080u16, 8081, 8082];
+
+        for _ in 0..30 {
+            let sel = pool.select(None).expect("should select");
+            if let Some(idx) = ports.iter().position(|&p| make_addr(p) == sel.addr) {
+                counts[idx] += 1;
+            }
+        }
+
+        // Each backend should get exactly 10 requests (30 / 3)
+        assert_eq!(counts, [10, 10, 10], "round-robin must distribute evenly");
+    }
+
+    #[test]
+    fn round_robin_skips_unhealthy_backend() {
+        let pool = make_pool(&[8080, 8081, 8082], LbPolicy::RoundRobin);
+        pool.mark_unhealthy(make_addr(8081));
+
+        for _ in 0..20 {
+            let sel = pool.select(None).expect("should select");
+            assert_ne!(
+                sel.addr,
+                make_addr(8081),
+                "unhealthy backend must not be selected"
+            );
+        }
+    }
+
+    // ── least-conn ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn least_conn_picks_backend_with_fewest_connections() {
+        let pool = make_pool(&[8080, 8081, 8082], LbPolicy::LeastConn);
+
+        // Artificially load backend 8080 with 5 conns and 8081 with 3 conns
+        pool.backends[0].active_conns.store(5, Ordering::Relaxed);
+        pool.backends[1].active_conns.store(3, Ordering::Relaxed);
+        // backend 8082 has 0 connections
+
+        let sel = pool.select(None).expect("should select");
+        assert_eq!(
+            sel.addr,
+            make_addr(8082),
+            "least-conn should pick 8082 (0 conns)"
+        );
+    }
+
+    #[test]
+    fn least_conn_skips_unhealthy() {
+        let pool = make_pool(&[8080, 8081], LbPolicy::LeastConn);
+        pool.backends[0].active_conns.store(0, Ordering::Relaxed); // 8080 has 0 conns
+        pool.mark_unhealthy(make_addr(8080));
+
+        let sel = pool.select(None).expect("should select");
+        assert_eq!(sel.addr, make_addr(8081));
+    }
+
+    // ── random ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn random_selects_valid_backend() {
+        let pool = make_pool(&[8080, 8081, 8082], LbPolicy::Random);
+        let ports = [8080u16, 8081, 8082];
+
+        for _ in 0..50 {
+            let sel = pool.select(None).expect("should always select one");
+            assert!(
+                ports.contains(&sel.addr.port()),
+                "random must select a configured backend"
+            );
+        }
+    }
+
+    #[test]
+    fn random_skips_unhealthy() {
+        let pool = make_pool(&[8080, 8081], LbPolicy::Random);
+        pool.mark_unhealthy(make_addr(8080));
+
+        for _ in 0..30 {
+            let sel = pool.select(None).expect("should select");
+            assert_eq!(sel.addr, make_addr(8081));
+        }
+    }
+
+    // ── ip-hash ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn ip_hash_is_deterministic_for_same_ip() {
+        let pool = make_pool(&[8080, 8081, 8082], LbPolicy::IpHash);
+        let ip = Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)));
+
+        let first = pool.select(ip).expect("should select").addr;
+        for _ in 0..20 {
+            let sel = pool.select(ip).expect("should select").addr;
+            assert_eq!(sel, first, "ip_hash must be deterministic for same IP");
+        }
+    }
+
+    #[test]
+    fn ip_hash_falls_back_to_rr_without_ip() {
+        let pool = make_pool(&[8080, 8081], LbPolicy::IpHash);
+        // Should not panic — falls back to round-robin
+        assert!(pool.select(None).is_some());
+    }
+
+    // ── connection limit enforcement ──────────────────────────────────────────
+
+    #[test]
+    fn connection_limit_blocks_selection() {
+        let pool = make_pool_with_max(8080, 2);
+        pool.backends[0].active_conns.store(2, Ordering::Relaxed);
+        assert!(
+            pool.select(None).is_none(),
+            "pool at max_conns should return None"
+        );
+    }
+
+    #[test]
+    fn acquire_release_roundtrip() {
+        let pool = make_pool_with_max(8080, 2);
+        assert!(pool.acquire_connection(make_addr(8080)));
+        assert!(pool.acquire_connection(make_addr(8080)));
+        // At cap now
+        assert!(!pool.acquire_connection(make_addr(8080)));
+        // Release one and try again
+        pool.release_connection(make_addr(8080));
+        assert!(pool.acquire_connection(make_addr(8080)));
+    }
+
+    #[test]
+    fn release_does_not_underflow() {
+        let pool = make_pool(&[8080], LbPolicy::RoundRobin);
+        // Release without acquire — must not panic or wrap around
+        pool.release_connection(make_addr(8080));
+        assert_eq!(pool.backends[0].active_conns.load(Ordering::Relaxed), 0);
+    }
+
+    // ── health mark ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn mark_healthy_unhealthy_toggle() {
+        let pool = make_pool(&[8080], LbPolicy::RoundRobin);
+        assert!(pool.select(None).is_some());
+
+        pool.mark_unhealthy(make_addr(8080));
+        assert!(pool.select(None).is_none());
+
+        pool.mark_healthy(make_addr(8080));
+        assert!(pool.select(None).is_some());
+    }
+
+    // ── metadata ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn first_addr_returns_first_backend() {
+        let pool = make_pool(&[8080, 8081], LbPolicy::RoundRobin);
+        assert_eq!(pool.first_addr(), Some(make_addr(8080)));
+    }
+
+    #[test]
+    fn empty_pool_returns_none() {
+        let pool = UpstreamPool::new(vec![], LbPolicy::RoundRobin, None, None);
+        assert!(pool.select(None).is_none());
+        assert!(pool.first_addr().is_none());
+        assert!(pool.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Phase 16 completion — the final 3 issues that round out Caddy directive parity.

- **ISSUE-065: Block-form `reverse_proxy`** — multi-upstream load balancing (round_robin, least_conn, random, ip_hash), active health checks via `HealthChecker` BackgroundService, per-backend connection limits, upstream TLS config. Single-upstream fast path preserved (zero atomic ops).
- **ISSUE-066: `bind` directive** — replaces hardcoded `0.0.0.0:6188` with config-driven listeners. Supports TCP (`:port`, `ip:port`) and Unix sockets (`unix//path`). Deduplicates addresses.
- **ISSUE-067: `intercept` / `copy_response_headers`** — response-phase interception matching upstream status codes. Overrides status, headers, and body. `copy_response_headers` with include/exclude filtering. Wired into `response_filter()` before analytics injection.

**14 files changed, +2613 −69 lines, 1 new file (`upstream.rs`)**

## Test plan

- [x] 647 workspace tests passing (up from ~584)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --all --check` — clean
- [x] `cargo build --workspace --release` — clean
- [ ] Manual: multi-backend config with `lb_policy round_robin` distributes across upstreams
- [ ] Manual: `bind :8443` starts listener on 8443 instead of 6188
- [ ] Manual: `intercept 502 { respond 200 "maintenance" }` serves custom error page