### PR TITLE
feat: IP allowlist/blocklist plugin with CIDR trie (ISSUE-071)

### DIFF
--- a/crates/dwaar-cli/src/main.rs
+++ b/crates/dwaar-cli/src/main.rs
@@ -333,6 +333,7 @@ fn run_server(
             Box::new(dwaar_plugins::under_attack::UnderAttackPlugin::new(
                 under_attack_secret,
             )),
+            Box::new(dwaar_plugins::ip_filter::IpFilterPlugin::new()),
             Box::new(dwaar_plugins::rate_limit::RateLimitPlugin::new()),
             Box::new(dwaar_plugins::compress::CompressionPlugin::new()),
             Box::new(dwaar_plugins::security_headers::SecurityHeadersPlugin::new()),

--- a/crates/dwaar-cli/tests/proxy_integration.rs
+++ b/crates/dwaar-cli/tests/proxy_integration.rs
@@ -872,3 +872,71 @@ fn response_body_over_limit_returns_error() {
     std::fs::remove_file(&config_file).ok();
     thread::sleep(Duration::from_secs(1));
 }
+
+/// ISSUE-071: IP filter denies requests from blocked IPs (returns 403).
+/// Uses a Dwaarfile that denies 127.0.0.1 (the test client's IP).
+#[test]
+fn ip_filter_denies_blocked_ip() {
+    let _lock = PORT_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let _upstream =
+        TcpListener::bind("127.0.0.1:8080").expect("bind to 127.0.0.1:8080 for mock upstream");
+
+    let config_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    std::fs::create_dir_all(&config_path).ok();
+    let config_file = config_path.join("ip_filter_deny_test.dwaarfile");
+    std::fs::write(
+        &config_file,
+        "127.0.0.1 {\n    reverse_proxy 127.0.0.1:8080\n    ip_filter {\n        deny 127.0.0.1\n        default allow\n    }\n}\n",
+    )
+    .expect("write test Dwaarfile");
+
+    let child = start_dwaar_with_config(Some(&config_file));
+
+    // Test client connects from 127.0.0.1 — should be denied
+    let resp = send_through_proxy("/blocked");
+    assert_eq!(resp.status, 403, "denied IP should get 403 Forbidden");
+
+    stop_dwaar(child);
+    std::fs::remove_file(&config_file).ok();
+    thread::sleep(Duration::from_secs(1));
+}
+
+/// ISSUE-071: IP filter allows requests from permitted IPs.
+/// Uses a Dwaarfile with `default deny` but allows 127.0.0.0/8.
+#[test]
+fn ip_filter_allows_permitted_ip() {
+    let _lock = PORT_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let upstream =
+        TcpListener::bind("127.0.0.1:8080").expect("bind to 127.0.0.1:8080 for mock upstream");
+
+    let config_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    std::fs::create_dir_all(&config_path).ok();
+    let config_file = config_path.join("ip_filter_allow_test.dwaarfile");
+    std::fs::write(
+        &config_file,
+        "127.0.0.1 {\n    reverse_proxy 127.0.0.1:8080\n    ip_filter {\n        allow 127.0.0.0/8\n        default deny\n    }\n}\n",
+    )
+    .expect("write test Dwaarfile");
+
+    let child = start_dwaar_with_config(Some(&config_file));
+
+    let handle = thread::spawn({
+        let upstream_fd = upstream.try_clone().expect("clone listener");
+        move || serve_one_request(&upstream_fd, 200, "allowed")
+    });
+
+    let resp = send_through_proxy("/allowed");
+    handle.join().expect("upstream thread");
+    assert_eq!(
+        resp.status, 200,
+        "allowed IP should be forwarded to upstream"
+    );
+
+    stop_dwaar(child);
+    std::fs::remove_file(&config_file).ok();
+    thread::sleep(Duration::from_secs(1));
+}

--- a/crates/dwaar-config/src/compile.rs
+++ b/crates/dwaar-config/src/compile.rs
@@ -79,6 +79,7 @@ pub fn compile_routes(config: &DwaarConfig) -> RouteTable {
 
         // Flat site (no handle blocks) — extract single handler + site-level middleware
         let rate_limit_rps = find_rate_limit(&site.directives);
+        let ip_filter = compile_ip_filter(&site.directives);
         let request_body_max_size = find_request_body_max_size(&site.directives);
         let response_body_max_size = find_response_body_limit(&site.directives);
         let rewrites = collect_rewrites(&site.directives, &var_registry);
@@ -109,6 +110,7 @@ pub fn compile_routes(config: &DwaarConfig) -> RouteTable {
                 handler: proxy_handler,
                 intercepts: intercepts.clone(),
                 copy_response_headers: copy_response_headers.clone(),
+                ip_filter: ip_filter.clone(),
                 request_body_max_size,
                 response_body_max_size,
             };
@@ -140,6 +142,7 @@ pub fn compile_routes(config: &DwaarConfig) -> RouteTable {
                 },
                 intercepts: intercepts.clone(),
                 copy_response_headers: copy_response_headers.clone(),
+                ip_filter: ip_filter.clone(),
                 request_body_max_size,
                 response_body_max_size,
             };
@@ -178,6 +181,7 @@ pub fn compile_routes(config: &DwaarConfig) -> RouteTable {
                 },
                 intercepts: intercepts.clone(),
                 copy_response_headers: copy_response_headers.clone(),
+                ip_filter: ip_filter.clone(),
                 request_body_max_size,
                 response_body_max_size,
             };
@@ -215,6 +219,7 @@ pub fn compile_routes(config: &DwaarConfig) -> RouteTable {
                 },
                 intercepts,
                 copy_response_headers,
+                ip_filter,
                 request_body_max_size,
                 response_body_max_size,
             };
@@ -479,6 +484,7 @@ fn compile_single_block(
     registry: &VarRegistry,
 ) -> Option<HandlerBlock> {
     let rate_limit_rps = find_rate_limit(inner_directives);
+    let ip_filter = compile_ip_filter(inner_directives);
     let request_body_max_size = find_request_body_max_size(inner_directives);
     let response_body_max_size = find_response_body_limit(inner_directives);
     let rewrites = collect_rewrites(inner_directives, registry);
@@ -527,6 +533,7 @@ fn compile_single_block(
         handler,
         intercepts: compile_intercepts(inner_directives),
         copy_response_headers: compile_copy_response_headers(inner_directives),
+        ip_filter,
         request_body_max_size,
         response_body_max_size,
     })
@@ -662,6 +669,43 @@ fn find_rate_limit(directives: &[Directive]) -> Option<u32> {
         Directive::RateLimit(rl) => Some(rl.requests_per_second),
         _ => None,
     })
+}
+
+fn compile_ip_filter(
+    directives: &[Directive],
+) -> Option<std::sync::Arc<dwaar_plugins::ip_filter::IpFilterConfig>> {
+    use dwaar_plugins::ip_filter::{CidrTrie, DefaultPolicy, IpAction, IpFilterConfig, parse_cidr};
+    let ipf = directives.iter().find_map(|d| match d {
+        Directive::IpFilter(f) => Some(f),
+        _ => None,
+    })?;
+
+    let mut trie = CidrTrie::new();
+    for cidr_str in &ipf.allow {
+        if let Some((addr, prefix_len)) = parse_cidr(cidr_str) {
+            trie.insert(addr, prefix_len, IpAction::Allow);
+        } else {
+            warn!(cidr = %cidr_str, "invalid CIDR in ip_filter allow, skipping");
+        }
+    }
+    for cidr_str in &ipf.deny {
+        if let Some((addr, prefix_len)) = parse_cidr(cidr_str) {
+            trie.insert(addr, prefix_len, IpAction::Deny);
+        } else {
+            warn!(cidr = %cidr_str, "invalid CIDR in ip_filter deny, skipping");
+        }
+    }
+
+    let default_policy = if ipf.default_allow {
+        DefaultPolicy::Allow
+    } else {
+        DefaultPolicy::Deny
+    };
+
+    Some(std::sync::Arc::new(IpFilterConfig {
+        trie,
+        default_policy,
+    }))
 }
 
 fn find_request_body_max_size(directives: &[Directive]) -> Option<u64> {

--- a/crates/dwaar-config/src/error.rs
+++ b/crates/dwaar-config/src/error.rs
@@ -127,6 +127,7 @@ pub fn suggest_directive(input: &str) -> Option<&'static str> {
         "templates",
         "request_body",
         "response_body_limit",
+        "ip_filter",
         "request_header",
         "method",
         "try_files",

--- a/crates/dwaar-config/src/format.rs
+++ b/crates/dwaar-config/src/format.rs
@@ -13,12 +13,12 @@
 use crate::model::{
     BasicAuthDirective, BindDirective, CopyResponseHeadersDirective, Directive, DwaarConfig,
     EncodeDirective, ErrorDirective, FileServerDirective, ForwardAuthDirective, FsDirective,
-    HandleErrorsDirective, HeaderDirective, InterceptDirective, LbPolicy, LogAppendDirective,
-    LogDirective, LogFormat, LogOutput, MapDirective, MapPattern, MatcherCondition, MatcherDef,
-    MethodDirective, RateLimitDirective, RecognizedDirective, RedirDirective, RequestBodyDirective,
-    RequestHeaderDirective, RespondDirective, ResponseBodyLimitDirective, ReverseProxyDirective,
-    RewriteDirective, RootDirective, TlsDirective, TryFilesDirective, UpstreamAddr, UriDirective,
-    UriOperation, VarsDirective,
+    HandleErrorsDirective, HeaderDirective, InterceptDirective, IpFilterDirective, LbPolicy,
+    LogAppendDirective, LogDirective, LogFormat, LogOutput, MapDirective, MapPattern,
+    MatcherCondition, MatcherDef, MethodDirective, RateLimitDirective, RecognizedDirective,
+    RedirDirective, RequestBodyDirective, RequestHeaderDirective, RespondDirective,
+    ResponseBodyLimitDirective, ReverseProxyDirective, RewriteDirective, RootDirective,
+    TlsDirective, TryFilesDirective, UpstreamAddr, UriDirective, UriOperation, VarsDirective,
 };
 
 /// Format a parsed config into canonical Dwaarfile text.
@@ -93,6 +93,7 @@ fn format_directive_at_depth(out: &mut String, directive: &Directive, depth: usi
         Directive::Abort => out.push_str("abort"),
         Directive::Method(m) => format_method(out, m),
         Directive::RequestBody(rb) => format_request_body(out, rb, depth),
+        Directive::IpFilter(ipf) => format_ip_filter(out, ipf, depth),
         Directive::ResponseBodyLimit(rbl) => format_response_body_limit(out, rbl),
         Directive::TryFiles(tf) => format_try_files(out, tf),
         Directive::HandleErrors(he) => format_handle_errors(out, he, depth),
@@ -624,6 +625,32 @@ fn format_request_body(out: &mut String, rb: &RequestBodyDirective, depth: usize
         out.push_str(&format_size(max_size));
         out.push('\n');
     }
+    out.push_str(&outer);
+    out.push('}');
+}
+
+fn format_ip_filter(out: &mut String, ipf: &IpFilterDirective, depth: usize) {
+    let inner = "    ".repeat(depth + 1);
+    let outer = "    ".repeat(depth);
+    out.push_str("ip_filter {\n");
+    if !ipf.allow.is_empty() {
+        out.push_str(&inner);
+        out.push_str("allow ");
+        out.push_str(&ipf.allow.join(" "));
+        out.push('\n');
+    }
+    if !ipf.deny.is_empty() {
+        out.push_str(&inner);
+        out.push_str("deny ");
+        out.push_str(&ipf.deny.join(" "));
+        out.push('\n');
+    }
+    out.push_str(&inner);
+    out.push_str(if ipf.default_allow {
+        "default allow\n"
+    } else {
+        "default deny\n"
+    });
     out.push_str(&outer);
     out.push('}');
 }

--- a/crates/dwaar-config/src/model.rs
+++ b/crates/dwaar-config/src/model.rs
@@ -193,6 +193,9 @@ pub enum Directive {
     /// `rate_limit 100/s`
     RateLimit(RateLimitDirective),
 
+    /// `ip_filter { allow 10.0.0.0/8; deny 203.0.113.0/24; default allow }`
+    IpFilter(IpFilterDirective),
+
     /// `respond "body" 404` / `respond 204` / `respond "ok"`
     Respond(RespondDirective),
 
@@ -432,6 +435,17 @@ pub struct EncodeDirective {
 pub struct RateLimitDirective {
     /// Maximum requests per second per IP for this route.
     pub requests_per_second: u32,
+}
+
+/// `ip_filter` — IP allowlist/blocklist per route.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IpFilterDirective {
+    /// CIDR ranges to allow (e.g., `["10.0.0.0/8", "192.168.1.0/24"]`).
+    pub allow: Vec<String>,
+    /// CIDR ranges to deny (e.g., `["203.0.113.0/24"]`).
+    pub deny: Vec<String>,
+    /// Default policy when no rule matches. `true` = allow, `false` = deny.
+    pub default_allow: bool,
 }
 
 // ── New directive types (Phase 3 + 4) ─────────────────────────────────────────

--- a/crates/dwaar-config/src/parser/helpers.rs
+++ b/crates/dwaar-config/src/parser/helpers.rs
@@ -164,6 +164,7 @@ pub(super) fn is_directive_name(w: &str) -> bool {
             | "templates"
             | "request_body"
             | "response_body_limit"
+            | "ip_filter"
             | "request_header"
             | "method"
             | "try_files"

--- a/crates/dwaar-config/src/parser/mod.rs
+++ b/crates/dwaar-config/src/parser/mod.rs
@@ -399,6 +399,9 @@ fn parse_directive(t: &mut Tokenizer<'_>) -> Result<Directive, ParseError> {
         "encode" => Ok(Directive::Encode(transforms::parse_encode(t)?)),
         "basicauth" | "basic_auth" => Ok(Directive::BasicAuth(transforms::parse_basicauth(t)?)),
         "rate_limit" => Ok(Directive::RateLimit(transforms::parse_rate_limit(t)?)),
+        "ip_filter" => Ok(Directive::IpFilter(transforms::parse_ip_filter(
+            t, &name_tok,
+        )?)),
         "method" => Ok(Directive::Method(transforms::parse_method(t, &name_tok)?)),
         "request_body" => Ok(Directive::RequestBody(transforms::parse_request_body(
             t, &name_tok,

--- a/crates/dwaar-config/src/parser/transforms.rs
+++ b/crates/dwaar-config/src/parser/transforms.rs
@@ -12,7 +12,7 @@
 use crate::error::{ParseError, ParseErrorKind};
 use crate::model::{
     BasicAuthCredential, BasicAuthDirective, BindDirective, EncodeDirective, ErrorDirective,
-    HeaderDirective, MethodDirective, RateLimitDirective, RequestBodyDirective,
+    HeaderDirective, IpFilterDirective, MethodDirective, RateLimitDirective, RequestBodyDirective,
     RequestHeaderDirective, ResponseBodyLimitDirective, TlsDirective, VarsDirective,
 };
 use crate::token::{Token, TokenKind, Tokenizer};
@@ -358,6 +358,92 @@ pub(super) fn parse_rate_limit(t: &mut Tokenizer<'_>) -> Result<RateLimitDirecti
 
     Ok(RateLimitDirective {
         requests_per_second: rps,
+    })
+}
+
+/// `ip_filter { allow 10.0.0.0/8; deny 203.0.113.0/24; default allow }`
+pub(super) fn parse_ip_filter(
+    t: &mut Tokenizer<'_>,
+    dir_tok: &Token,
+) -> Result<IpFilterDirective, ParseError> {
+    if t.peek().kind != TokenKind::OpenBrace {
+        return Err(ParseError {
+            line: dir_tok.line,
+            col: dir_tok.col,
+            kind: ParseErrorKind::InvalidValue {
+                directive: "ip_filter".to_string(),
+                message: "expected '{' block".to_string(),
+            },
+        });
+    }
+    t.next_token(); // consume '{'
+
+    let mut allow = Vec::new();
+    let mut deny = Vec::new();
+    let mut default_allow = true; // blocklist mode by default
+
+    loop {
+        let tok = t.peek();
+        match &tok.kind {
+            TokenKind::CloseBrace => {
+                t.next_token();
+                break;
+            }
+            TokenKind::Eof => {
+                return Err(ParseError {
+                    line: tok.line,
+                    col: tok.col,
+                    kind: ParseErrorKind::UnexpectedEof {
+                        expected: "'}' to close ip_filter block".to_string(),
+                    },
+                });
+            }
+            TokenKind::Word(w) => {
+                let keyword = w.clone();
+                t.next_token();
+                match keyword.as_str() {
+                    "allow" => {
+                        while matches!(t.peek().kind, TokenKind::Word(_)) {
+                            if let TokenKind::Word(cidr) = t.next_token().kind {
+                                allow.push(cidr);
+                            }
+                        }
+                    }
+                    "deny" => {
+                        while matches!(t.peek().kind, TokenKind::Word(_)) {
+                            if let TokenKind::Word(cidr) = t.next_token().kind {
+                                deny.push(cidr);
+                            }
+                        }
+                    }
+                    "default" => {
+                        if let TokenKind::Word(policy) = &t.peek().kind {
+                            default_allow = policy.eq_ignore_ascii_case("allow");
+                            t.next_token();
+                        }
+                    }
+                    _ => {
+                        skip_to_next_line(t);
+                    }
+                }
+            }
+            _ => {
+                return Err(ParseError {
+                    line: tok.line,
+                    col: tok.col,
+                    kind: ParseErrorKind::Expected {
+                        expected: "ip_filter sub-directive (allow/deny/default) or '}'".to_string(),
+                        got: format!("{:?}", tok.kind),
+                    },
+                });
+            }
+        }
+    }
+
+    Ok(IpFilterDirective {
+        allow,
+        deny,
+        default_allow,
     })
 }
 

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -400,6 +400,11 @@ impl ProxyHttp for DwaarProxy {
                         ctx.copy_response_headers = Some(crh.clone());
                     }
 
+                    // IP filter config (ISSUE-071)
+                    if let Some(ref filter) = block.ip_filter {
+                        ctx.plugin_ctx.ip_filter = Some(filter.clone());
+                    }
+
                     // Body size limits (ISSUE-069, ISSUE-070)
                     if let Some(limit) = block.request_body_max_size {
                         ctx.request_body_max_size = limit;

--- a/crates/dwaar-core/src/route.rs
+++ b/crates/dwaar-core/src/route.rs
@@ -370,6 +370,8 @@ pub struct HandlerBlock {
     pub intercepts: Vec<CompiledIntercept>,
     /// Selective header copy config — controls which upstream headers reach the client.
     pub copy_response_headers: Option<CompiledCopyResponseHeaders>,
+    /// IP allowlist/blocklist config (ISSUE-071). Compiled CIDR trie + default policy.
+    pub ip_filter: Option<std::sync::Arc<dwaar_plugins::ip_filter::IpFilterConfig>>,
     /// Max request body size in bytes (ISSUE-069). `None` = use default (10 MB).
     pub request_body_max_size: Option<u64>,
     /// Max response body size in bytes (ISSUE-070). `None` = use default (100 MB).
@@ -512,6 +514,7 @@ impl Route {
                 handler: Handler::ReverseProxy { upstream },
                 intercepts: vec![],
                 copy_response_headers: None,
+                ip_filter: None,
                 request_body_max_size: None,
                 response_body_max_size: None,
             }],

--- a/crates/dwaar-plugins/src/ip_filter.rs
+++ b/crates/dwaar-plugins/src/ip_filter.rs
@@ -1,0 +1,413 @@
+// Copyright (C) 2026 Permanu
+// SPDX-License-Identifier: BSL-1.1
+//
+// This file is part of Dwaar — https://dwaar.dev
+// Licensed under the Business Source License 1.1
+
+//! IP allowlist/blocklist plugin using a binary CIDR trie (ISSUE-071).
+//!
+//! The trie provides O(prefix-length) lookups regardless of rule count.
+//! IPv4 addresses are stored as IPv4-mapped IPv6 (`::ffff:x.x.x.x`) so
+//! a single trie handles both address families.
+
+use std::net::IpAddr;
+
+use bytes::Bytes;
+
+use crate::plugin::{DwaarPlugin, PluginAction, PluginCtx, PluginResponse};
+
+// ── CIDR Trie ────────────────────────────────────────────────────────
+
+/// What to do when a CIDR rule matches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IpAction {
+    Allow,
+    Deny,
+}
+
+/// Default policy when no CIDR rule matches the client IP.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DefaultPolicy {
+    /// Blocklist mode: allow unless explicitly denied.
+    Allow,
+    /// Allowlist mode: deny unless explicitly allowed.
+    Deny,
+}
+
+/// Arena-allocated binary trie node. Index 0 is the root.
+/// Each node has optional left (bit=0) and right (bit=1) children,
+/// plus an optional action if this node marks the end of a CIDR prefix.
+#[derive(Debug, Clone)]
+struct TrieNode {
+    children: [Option<u32>; 2],
+    action: Option<IpAction>,
+}
+
+impl TrieNode {
+    fn new() -> Self {
+        Self {
+            children: [None, None],
+            action: None,
+        }
+    }
+}
+
+/// Binary CIDR trie with longest-prefix-match semantics.
+///
+/// Stores all rules in a flat `Vec<TrieNode>` (arena allocation) for
+/// cache locality. Lookups walk at most 128 levels (IPv6 bit length).
+#[derive(Debug, Clone)]
+pub struct CidrTrie {
+    nodes: Vec<TrieNode>,
+}
+
+impl CidrTrie {
+    pub fn new() -> Self {
+        Self {
+            nodes: vec![TrieNode::new()], // root at index 0
+        }
+    }
+
+    /// Insert a CIDR rule. IPv4 addresses are mapped to IPv4-mapped IPv6.
+    pub fn insert(&mut self, addr: IpAddr, prefix_len: u8, action: IpAction) {
+        let bits = ip_to_bits(addr);
+        let mut node_idx = 0;
+
+        for i in 0..prefix_len as usize {
+            let bit = ((bits[i / 8] >> (7 - (i % 8))) & 1) as usize;
+            if self.nodes[node_idx].children[bit].is_none() {
+                let new_idx = self.nodes.len() as u32;
+                self.nodes.push(TrieNode::new());
+                self.nodes[node_idx].children[bit] = Some(new_idx);
+            }
+            node_idx = self.nodes[node_idx].children[bit].expect("just inserted") as usize;
+        }
+        self.nodes[node_idx].action = Some(action);
+    }
+
+    /// Longest-prefix-match lookup. Returns the action of the most specific
+    /// matching CIDR rule, or `None` if no rule matches.
+    pub fn lookup(&self, addr: IpAddr) -> Option<IpAction> {
+        let bits = ip_to_bits(addr);
+        let mut node_idx: usize = 0;
+        let mut last_action = self.nodes[0].action;
+
+        for i in 0..128 {
+            let bit = ((bits[i / 8] >> (7 - (i % 8))) & 1) as usize;
+            match self.nodes[node_idx].children[bit] {
+                Some(child) => {
+                    node_idx = child as usize;
+                    if let Some(action) = self.nodes[node_idx].action {
+                        last_action = Some(action);
+                    }
+                }
+                None => break,
+            }
+        }
+        last_action
+    }
+
+    /// Number of nodes in the trie (for diagnostics).
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+}
+
+impl Default for CidrTrie {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Convert any IP address to a 128-bit (16-byte) representation.
+/// IPv4 maps to `::ffff:x.x.x.x` so both families share one trie.
+fn ip_to_bits(addr: IpAddr) -> [u8; 16] {
+    match addr {
+        IpAddr::V6(v6) => v6.octets(),
+        IpAddr::V4(v4) => v4.to_ipv6_mapped().octets(),
+    }
+}
+
+/// Parse a CIDR string like `10.0.0.0/8` or `2001:db8::/32`.
+/// Returns (address, `prefix_length`). Handles bare IPs as /32 or /128.
+pub fn parse_cidr(s: &str) -> Option<(IpAddr, u8)> {
+    if let Some((addr_str, len_str)) = s.split_once('/') {
+        let addr: IpAddr = addr_str.parse().ok()?;
+        let prefix_len: u8 = len_str.parse().ok()?;
+        let max = match addr {
+            IpAddr::V4(_) => 32,
+            IpAddr::V6(_) => 128,
+        };
+        if prefix_len > max {
+            return None;
+        }
+        // Adjust IPv4 prefix length to IPv6 space (add 96 for the ::ffff: prefix)
+        let effective_len = match addr {
+            IpAddr::V4(_) => prefix_len + 96,
+            IpAddr::V6(_) => prefix_len,
+        };
+        Some((addr, effective_len))
+    } else {
+        // Bare IP — treat as host route
+        let addr: IpAddr = s.parse().ok()?;
+        Some((addr, 128))
+    }
+}
+
+// ── Compiled IP Filter Config ────────────────────────────────────────
+
+/// Compiled IP filter configuration. Built once at config load, shared
+/// across requests via `Arc`. Contains the CIDR trie and default policy.
+#[derive(Debug, Clone)]
+pub struct IpFilterConfig {
+    pub trie: CidrTrie,
+    pub default_policy: DefaultPolicy,
+}
+
+impl IpFilterConfig {
+    /// Check whether a client IP should be allowed.
+    pub fn is_allowed(&self, ip: IpAddr) -> bool {
+        match self.trie.lookup(ip) {
+            Some(IpAction::Allow) => true,
+            Some(IpAction::Deny) => false,
+            None => matches!(self.default_policy, DefaultPolicy::Allow),
+        }
+    }
+}
+
+// ── Plugin ───────────────────────────────────────────────────────────
+
+/// IP allowlist/blocklist plugin. Reads per-route `IpFilterConfig` from
+/// `PluginCtx`, checks client IP against the CIDR trie, returns 403 on deny.
+#[derive(Debug)]
+pub struct IpFilterPlugin;
+
+impl IpFilterPlugin {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for IpFilterPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DwaarPlugin for IpFilterPlugin {
+    fn name(&self) -> &'static str {
+        "ip-filter"
+    }
+
+    fn priority(&self) -> u16 {
+        // Run early — block denied IPs before bot detection or rate limiting.
+        // After under_attack (5) but before bot_detect (10).
+        8
+    }
+
+    fn on_request(&self, _req: &pingora_http::RequestHeader, ctx: &mut PluginCtx) -> PluginAction {
+        let Some(ref filter) = ctx.ip_filter else {
+            return PluginAction::Continue;
+        };
+        let Some(ip) = ctx.client_ip else {
+            return PluginAction::Continue;
+        };
+
+        if filter.is_allowed(ip) {
+            PluginAction::Continue
+        } else {
+            PluginAction::Respond(PluginResponse {
+                status: 403,
+                headers: vec![("Content-Length", "0".to_string())],
+                body: Bytes::new(),
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use super::*;
+
+    #[test]
+    fn ipv4_exact_match() {
+        let mut trie = CidrTrie::new();
+        let (addr, len) = parse_cidr("192.168.1.1").unwrap();
+        trie.insert(addr, len, IpAction::Deny);
+
+        assert_eq!(
+            trie.lookup(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))),
+            Some(IpAction::Deny)
+        );
+        assert_eq!(trie.lookup(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 2))), None);
+    }
+
+    #[test]
+    fn ipv4_subnet_match() {
+        let mut trie = CidrTrie::new();
+        let (addr, len) = parse_cidr("10.0.0.0/8").unwrap();
+        trie.insert(addr, len, IpAction::Allow);
+
+        assert_eq!(
+            trie.lookup(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3))),
+            Some(IpAction::Allow)
+        );
+        assert_eq!(
+            trie.lookup(IpAddr::V4(Ipv4Addr::new(10, 255, 255, 255))),
+            Some(IpAction::Allow)
+        );
+        assert_eq!(trie.lookup(IpAddr::V4(Ipv4Addr::new(11, 0, 0, 1))), None);
+    }
+
+    #[test]
+    fn ipv4_catch_all() {
+        let mut trie = CidrTrie::new();
+        let (addr, len) = parse_cidr("0.0.0.0/0").unwrap();
+        trie.insert(addr, len, IpAction::Deny);
+
+        assert_eq!(
+            trie.lookup(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))),
+            Some(IpAction::Deny)
+        );
+        assert_eq!(
+            trie.lookup(IpAddr::V4(Ipv4Addr::BROADCAST)),
+            Some(IpAction::Deny)
+        );
+    }
+
+    #[test]
+    fn ipv4_longest_prefix_wins() {
+        let mut trie = CidrTrie::new();
+        let (addr, len) = parse_cidr("10.0.0.0/8").unwrap();
+        trie.insert(addr, len, IpAction::Allow);
+        let (addr, len) = parse_cidr("10.0.1.0/24").unwrap();
+        trie.insert(addr, len, IpAction::Deny);
+
+        // 10.0.1.50 matches both /8 (allow) and /24 (deny) — longest wins
+        assert_eq!(
+            trie.lookup(IpAddr::V4(Ipv4Addr::new(10, 0, 1, 50))),
+            Some(IpAction::Deny)
+        );
+        // 10.0.2.1 matches only /8 (allow)
+        assert_eq!(
+            trie.lookup(IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1))),
+            Some(IpAction::Allow)
+        );
+    }
+
+    #[test]
+    fn ipv6_subnet_match() {
+        let mut trie = CidrTrie::new();
+        let (addr, len) = parse_cidr("2001:db8::/32").unwrap();
+        trie.insert(addr, len, IpAction::Allow);
+
+        let test_ip: IpAddr = "2001:db8::1".parse().unwrap();
+        assert_eq!(trie.lookup(test_ip), Some(IpAction::Allow));
+
+        let other_ip: IpAddr = "2001:db9::1".parse().unwrap();
+        assert_eq!(trie.lookup(other_ip), None);
+    }
+
+    #[test]
+    fn ipv6_exact_match() {
+        let mut trie = CidrTrie::new();
+        let (addr, len) = parse_cidr("::1").unwrap();
+        trie.insert(addr, len, IpAction::Deny);
+
+        let loopback: IpAddr = "::1".parse().unwrap();
+        assert_eq!(trie.lookup(loopback), Some(IpAction::Deny));
+
+        let other: IpAddr = "::2".parse().unwrap();
+        assert_eq!(trie.lookup(other), None);
+    }
+
+    #[test]
+    fn parse_cidr_valid() {
+        assert!(parse_cidr("10.0.0.0/8").is_some());
+        assert!(parse_cidr("192.168.1.0/24").is_some());
+        assert!(parse_cidr("0.0.0.0/0").is_some());
+        assert!(parse_cidr("255.255.255.255/32").is_some());
+        assert!(parse_cidr("2001:db8::/32").is_some());
+        assert!(parse_cidr("::1").is_some());
+        assert!(parse_cidr("127.0.0.1").is_some());
+    }
+
+    #[test]
+    fn parse_cidr_invalid() {
+        assert!(parse_cidr("not-an-ip").is_none());
+        assert!(parse_cidr("10.0.0.0/33").is_none());
+        assert!(parse_cidr("10.0.0.0/-1").is_none());
+        assert!(parse_cidr("").is_none());
+    }
+
+    #[test]
+    fn ip_filter_config_default_allow() {
+        let config = IpFilterConfig {
+            trie: CidrTrie::new(),
+            default_policy: DefaultPolicy::Allow,
+        };
+        assert!(config.is_allowed(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))));
+    }
+
+    #[test]
+    fn ip_filter_config_default_deny() {
+        let config = IpFilterConfig {
+            trie: CidrTrie::new(),
+            default_policy: DefaultPolicy::Deny,
+        };
+        assert!(!config.is_allowed(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))));
+    }
+
+    #[test]
+    fn ip_filter_config_deny_overrides_default_allow() {
+        let mut trie = CidrTrie::new();
+        let (addr, len) = parse_cidr("203.0.113.0/24").unwrap();
+        trie.insert(addr, len, IpAction::Deny);
+
+        let config = IpFilterConfig {
+            trie,
+            default_policy: DefaultPolicy::Allow,
+        };
+
+        // Denied subnet → blocked
+        assert!(!config.is_allowed(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 50))));
+        // Everything else → allowed
+        assert!(config.is_allowed(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
+    }
+
+    #[test]
+    fn ip_filter_config_allow_overrides_default_deny() {
+        let mut trie = CidrTrie::new();
+        let (addr, len) = parse_cidr("10.0.0.0/8").unwrap();
+        trie.insert(addr, len, IpAction::Allow);
+
+        let config = IpFilterConfig {
+            trie,
+            default_policy: DefaultPolicy::Deny,
+        };
+
+        // Allowed subnet → passes
+        assert!(config.is_allowed(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3))));
+        // Everything else → denied
+        assert!(!config.is_allowed(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))));
+    }
+
+    #[test]
+    fn mixed_ipv4_ipv6_rules() {
+        let mut trie = CidrTrie::new();
+        let (addr, len) = parse_cidr("10.0.0.0/8").unwrap();
+        trie.insert(addr, len, IpAction::Allow);
+        let (addr, len) = parse_cidr("2001:db8::/32").unwrap();
+        trie.insert(addr, len, IpAction::Deny);
+
+        assert_eq!(
+            trie.lookup(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+            Some(IpAction::Allow)
+        );
+        let v6: IpAddr = "2001:db8::1".parse().unwrap();
+        assert_eq!(trie.lookup(v6), Some(IpAction::Deny));
+    }
+}

--- a/crates/dwaar-plugins/src/lib.rs
+++ b/crates/dwaar-plugins/src/lib.rs
@@ -10,6 +10,7 @@ pub mod basic_auth;
 pub mod bot_detect;
 pub mod compress;
 pub mod forward_auth;
+pub mod ip_filter;
 pub mod plugin;
 pub mod rate_limit;
 pub mod security_headers;

--- a/crates/dwaar-plugins/src/plugin.rs
+++ b/crates/dwaar-plugins/src/plugin.rs
@@ -59,6 +59,10 @@ pub struct PluginCtx {
     /// Whether Under Attack Mode is enabled for this route.
     pub under_attack: bool,
 
+    /// Per-route IP filter config. Populated from `HandlerBlock` during
+    /// route resolution. `None` means no IP filtering for this route.
+    pub ip_filter: Option<std::sync::Arc<crate::ip_filter::IpFilterConfig>>,
+
     // -- Fields written by plugins --
     pub is_bot: bool,
     pub bot_category: Option<BotCategory>,


### PR DESCRIPTION
## Summary

- **ISSUE-071a**: Binary radix trie for CIDR matching — O(prefix-length) lookups, IPv4/IPv6 unified via IPv4-mapped-IPv6, arena-allocated `Vec<TrieNode>` for cache locality
- **ISSUE-071b**: `IpFilterPlugin` implementing `DwaarPlugin` trait — reads per-route `IpFilterConfig` from `PluginCtx`, returns 403 for denied IPs
- **Dwaarfile syntax**: `ip_filter { allow 10.0.0.0/8; deny 203.0.113.0/24; default allow|deny }`
- Compiled at config load, shared via `Arc`, zero per-request allocation

## Test plan

- [x] Unit: IPv4 exact, subnet, /0 catch-all, longest-prefix-match
- [x] Unit: IPv6 exact, subnet
- [x] Unit: Mixed IPv4/IPv6, parse_cidr valid/invalid
- [x] Unit: IpFilterConfig default allow/deny, override behavior
- [x] Integration: denied IP → 403, allowed IP with default deny → 200
- [x] All 675+ workspace tests pass
- [x] clippy clean, fmt clean, release build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)