### PR TITLE
feat(analytics): Prometheus metrics export (ISSUE-072)

### DIFF
--- a/crates/dwaar-admin/src/service.rs
+++ b/crates/dwaar-admin/src/service.rs
@@ -13,6 +13,7 @@ use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use dashmap::DashMap;
 use dwaar_analytics::aggregation::DomainMetrics;
+use dwaar_analytics::prometheus::PrometheusMetrics;
 use dwaar_core::route::RouteTable;
 use http::Response;
 use pingora_core::apps::http_app::ServeHttp;
@@ -36,6 +37,9 @@ pub struct AdminService {
     /// Notifier to trigger config reload. When signaled, the `ConfigWatcher`
     /// re-reads the Dwaarfile and updates the route table.
     reload_notify: Option<Arc<Notify>>,
+    /// Prometheus metrics registry. When set, `GET /metrics` serves the
+    /// Prometheus text exposition format.
+    prometheus: Option<Arc<PrometheusMetrics>>,
 }
 
 impl AdminService {
@@ -54,6 +58,7 @@ impl AdminService {
             start_time,
             auth: Auth::new(admin_token),
             reload_notify: None,
+            prometheus: None,
         }
     }
 
@@ -61,6 +66,13 @@ impl AdminService {
     #[must_use]
     pub fn with_reload_notify(mut self, notify: Arc<Notify>) -> Self {
         self.reload_notify = Some(notify);
+        self
+    }
+
+    /// Enable the Prometheus `/metrics` endpoint.
+    #[must_use]
+    pub fn with_prometheus(mut self, prom: Arc<PrometheusMetrics>) -> Self {
+        self.prometheus = Some(prom);
         self
     }
 }
@@ -164,6 +176,13 @@ impl ServeHttp for AdminService {
                     None => json_response(404, r#"{"error":"no analytics for domain"}"#),
                 }
             }
+            ("GET", "/metrics") => match &self.prometheus {
+                Some(prom) => prometheus_response(&prom.render()),
+                None => json_response(
+                    404,
+                    r#"{"error":"metrics not enabled — start with --no-metrics=false"}"#,
+                ),
+            },
             ("POST", "/reload") => match &self.reload_notify {
                 Some(notify) => {
                     notify.notify_one();
@@ -178,6 +197,15 @@ impl ServeHttp for AdminService {
             _ => json_response(405, r#"{"error":"method not allowed"}"#),
         }
     }
+}
+
+/// Build a Prometheus text exposition response.
+fn prometheus_response(body: &str) -> Response<Vec<u8>> {
+    Response::builder()
+        .status(200)
+        .header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+        .body(body.as_bytes().to_vec())
+        .expect("valid response")
 }
 
 /// Build a JSON HTTP response.

--- a/crates/dwaar-analytics/src/lib.rs
+++ b/crates/dwaar-analytics/src/lib.rs
@@ -20,6 +20,7 @@ pub mod aggregation;
 pub mod beacon;
 pub mod decompress;
 pub mod injector;
+pub mod prometheus;
 
 #[cfg(test)]
 mod tests {

--- a/crates/dwaar-analytics/src/prometheus.rs
+++ b/crates/dwaar-analytics/src/prometheus.rs
@@ -1,0 +1,707 @@
+// Copyright (C) 2026 Permanu
+// SPDX-License-Identifier: BSL-1.1
+//
+// This file is part of Dwaar — https://dwaar.dev
+// Licensed under the Business Source License 1.1
+
+//! Prometheus metrics — atomic counters, histograms, and text exposition.
+//!
+//! All metric types use lock-free atomics. Per-domain metrics are keyed by
+//! `CompactString` in `DashMap` for concurrent access without allocation
+//! after the first request per domain.
+
+use std::fmt::Write;
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering::Relaxed};
+
+use compact_str::CompactString;
+use dashmap::DashMap;
+
+// -- Histogram bucket bounds (microseconds) ----------------------------------
+// Matches the issue spec: 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s,
+// 2.5s, 5s, 10s. Stored as microseconds to avoid atomic-float issues.
+const BUCKET_BOUNDS_US: &[u64] = &[
+    5_000, 10_000, 25_000, 50_000, 100_000, 250_000, 500_000, 1_000_000, 2_500_000, 5_000_000,
+    10_000_000,
+];
+
+// Bucket bounds as seconds (for rendering)
+const BUCKET_BOUNDS_SECS: &[f64] = &[
+    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];
+
+/// A Prometheus histogram with pre-allocated buckets.
+///
+/// Observations are recorded in microseconds internally and converted to
+/// seconds during text rendering. Each bucket count and the sum/total are
+/// atomic — no locks, no allocation per observation.
+pub struct Histogram {
+    /// One counter per bucket boundary, plus one for +Inf.
+    bucket_counts: Box<[AtomicU64]>,
+    /// Running sum of all observed values in microseconds.
+    sum_us: AtomicU64,
+    /// Total number of observations.
+    count: AtomicU64,
+}
+
+impl std::fmt::Debug for Histogram {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Histogram")
+            .field("count", &self.count.load(Relaxed))
+            .field("sum_us", &self.sum_us.load(Relaxed))
+            .finish_non_exhaustive()
+    }
+}
+
+impl Default for Histogram {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Histogram {
+    pub fn new() -> Self {
+        // +1 for the +Inf bucket
+        let num_buckets = BUCKET_BOUNDS_US.len() + 1;
+        let mut buckets = Vec::with_capacity(num_buckets);
+        for _ in 0..num_buckets {
+            buckets.push(AtomicU64::new(0));
+        }
+        Self {
+            bucket_counts: buckets.into_boxed_slice(),
+            sum_us: AtomicU64::new(0),
+            count: AtomicU64::new(0),
+        }
+    }
+
+    /// Record an observation in microseconds.
+    pub fn observe(&self, value_us: u64) {
+        // Linear scan — 11 buckets, faster than binary search at this size
+        for (i, &bound) in BUCKET_BOUNDS_US.iter().enumerate() {
+            if value_us <= bound {
+                self.bucket_counts[i].fetch_add(1, Relaxed);
+            }
+        }
+        // +Inf bucket always incremented
+        self.bucket_counts[BUCKET_BOUNDS_US.len()].fetch_add(1, Relaxed);
+
+        self.sum_us.fetch_add(value_us, Relaxed);
+        self.count.fetch_add(1, Relaxed);
+    }
+
+    /// Snapshot bucket counts (cumulative), sum (seconds), and count.
+    fn snapshot(&self) -> HistogramSnapshot {
+        let buckets: Vec<u64> = self.bucket_counts.iter().map(|c| c.load(Relaxed)).collect();
+        HistogramSnapshot {
+            buckets,
+            sum_secs: self.sum_us.load(Relaxed) as f64 / 1_000_000.0,
+            count: self.count.load(Relaxed),
+        }
+    }
+}
+
+struct HistogramSnapshot {
+    /// Cumulative counts per bucket (last entry is +Inf).
+    buckets: Vec<u64>,
+    sum_secs: f64,
+    count: u64,
+}
+
+// -- Status × Method counters ------------------------------------------------
+
+/// HTTP method slots — 8 covers all standard methods plus OTHER.
+const METHOD_COUNT: usize = 8;
+/// Status group slots — 1xx through 5xx.
+const STATUS_GROUP_COUNT: usize = 5;
+const COUNTER_SLOTS: usize = STATUS_GROUP_COUNT * METHOD_COUNT;
+
+fn method_index(method: &str) -> usize {
+    match method {
+        "GET" => 0,
+        "POST" => 1,
+        "PUT" => 2,
+        "DELETE" => 3,
+        "PATCH" => 4,
+        "HEAD" => 5,
+        "OPTIONS" => 6,
+        _ => 7, // OTHER
+    }
+}
+
+fn status_group(status: u16) -> usize {
+    match status {
+        100..=199 => 0,
+        200..=299 => 1,
+        300..=399 => 2,
+        400..=499 => 3,
+        _ => 4, // 5xx and anything unexpected
+    }
+}
+
+const METHODS: &[&str] = &[
+    "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "OTHER",
+];
+const STATUS_CODES: &[&str] = &["1xx", "2xx", "3xx", "4xx", "5xx"];
+
+/// Pre-allocated counters for every (`status_group`, method) combination.
+///
+/// 5 status groups × 8 methods = 40 `AtomicU64` slots. Zero allocation
+/// per request — just index math and an atomic increment.
+pub struct StatusMethodCounters {
+    counts: [AtomicU64; COUNTER_SLOTS],
+}
+
+impl std::fmt::Debug for StatusMethodCounters {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StatusMethodCounters")
+            .field("total", &self.total())
+            .finish()
+    }
+}
+
+impl Default for StatusMethodCounters {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StatusMethodCounters {
+    pub fn new() -> Self {
+        Self {
+            counts: std::array::from_fn(|_| AtomicU64::new(0)),
+        }
+    }
+
+    /// Increment the counter for the given status code and method.
+    pub fn increment(&self, status: u16, method: &str) {
+        let idx = status_group(status) * METHOD_COUNT + method_index(method);
+        self.counts[idx].fetch_add(1, Relaxed);
+    }
+
+    fn total(&self) -> u64 {
+        self.counts.iter().map(|c| c.load(Relaxed)).sum()
+    }
+}
+
+// -- Top-level metrics registry ----------------------------------------------
+
+/// All Prometheus metrics for the Dwaar proxy.
+///
+/// Created once in `main()`, passed as `Arc<PrometheusMetrics>` to both
+/// `DwaarProxy` (writes in `logging()`) and `AdminService` (reads on
+/// `GET /metrics`).
+pub struct PrometheusMetrics {
+    // Per-domain counters (DashMap key = domain)
+    pub requests: DashMap<CompactString, StatusMethodCounters>,
+    pub request_duration: DashMap<CompactString, Histogram>,
+    pub bytes_sent: DashMap<CompactString, AtomicU64>,
+    pub bytes_received: DashMap<CompactString, AtomicU64>,
+    pub active_connections: DashMap<CompactString, AtomicI64>,
+
+    // Per-upstream
+    pub upstream_connect_duration: DashMap<CompactString, Histogram>,
+    pub upstream_health: DashMap<CompactString, AtomicU64>,
+
+    // Global
+    pub tls_handshake_duration: Histogram,
+    pub config_reloads_success: AtomicU64,
+    pub config_reloads_failure: AtomicU64,
+}
+
+impl std::fmt::Debug for PrometheusMetrics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PrometheusMetrics")
+            .field("domains_tracked", &self.requests.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Default for PrometheusMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PrometheusMetrics {
+    pub fn new() -> Self {
+        Self {
+            requests: DashMap::new(),
+            request_duration: DashMap::new(),
+            bytes_sent: DashMap::new(),
+            bytes_received: DashMap::new(),
+            active_connections: DashMap::new(),
+            upstream_connect_duration: DashMap::new(),
+            upstream_health: DashMap::new(),
+            tls_handshake_duration: Histogram::new(),
+            config_reloads_success: AtomicU64::new(0),
+            config_reloads_failure: AtomicU64::new(0),
+        }
+    }
+
+    /// Record all per-request metrics from the `logging()` callback.
+    ///
+    /// Called once per completed request. All operations are atomic
+    /// increments on pre-allocated structures — zero heap allocation.
+    pub fn record_request(
+        &self,
+        domain: &CompactString,
+        method: &str,
+        status: u16,
+        duration_us: u64,
+        bytes_tx: u64,
+        bytes_rx: u64,
+    ) {
+        self.requests
+            .entry(domain.clone())
+            .or_default()
+            .increment(status, method);
+
+        self.request_duration
+            .entry(domain.clone())
+            .or_default()
+            .observe(duration_us);
+
+        self.bytes_sent
+            .entry(domain.clone())
+            .or_default()
+            .fetch_add(bytes_tx, Relaxed);
+
+        self.bytes_received
+            .entry(domain.clone())
+            .or_default()
+            .fetch_add(bytes_rx, Relaxed);
+    }
+
+    /// Increment active connections gauge for a domain.
+    pub fn connection_start(&self, domain: &CompactString) {
+        self.active_connections
+            .entry(domain.clone())
+            .or_default()
+            .fetch_add(1, Relaxed);
+    }
+
+    /// Decrement active connections gauge for a domain.
+    pub fn connection_end(&self, domain: &CompactString) {
+        self.active_connections
+            .entry(domain.clone())
+            .or_default()
+            .fetch_sub(1, Relaxed);
+    }
+
+    /// Render all metrics in Prometheus text exposition format.
+    ///
+    /// Called on `GET /metrics` — iterates `DashMap` entries and formats
+    /// each metric with HELP, TYPE, and value lines.
+    pub fn render(&self) -> String {
+        // Pre-allocate generously — typical output for 10 domains is ~8 KB
+        let mut out = String::with_capacity(8192);
+
+        self.render_requests(&mut out);
+        self.render_request_duration(&mut out);
+        self.render_bytes(&mut out);
+        self.render_active_connections(&mut out);
+        self.render_upstream_connect_duration(&mut out);
+        self.render_upstream_health(&mut out);
+        self.render_tls_handshake_duration(&mut out);
+        self.render_config_reloads(&mut out);
+
+        out
+    }
+
+    fn render_requests(&self, out: &mut String) {
+        out.push_str("# HELP dwaar_requests_total Total HTTP requests processed.\n");
+        out.push_str("# TYPE dwaar_requests_total counter\n");
+        for entry in &self.requests {
+            let domain = entry.key();
+            let counters = entry.value();
+            for (si, &status_label) in STATUS_CODES.iter().enumerate() {
+                for (mi, &method_label) in METHODS.iter().enumerate() {
+                    let val = counters.counts[si * METHOD_COUNT + mi].load(Relaxed);
+                    if val > 0 {
+                        let _ = writeln!(
+                            out,
+                            "dwaar_requests_total{{domain=\"{domain}\",method=\"{method_label}\",status=\"{status_label}\"}} {val}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    fn render_request_duration(&self, out: &mut String) {
+        out.push_str("# HELP dwaar_request_duration_seconds Request duration in seconds.\n");
+        out.push_str("# TYPE dwaar_request_duration_seconds histogram\n");
+        for entry in &self.request_duration {
+            render_histogram(
+                out,
+                "dwaar_request_duration_seconds",
+                entry.key(),
+                &entry.value().snapshot(),
+            );
+        }
+    }
+
+    fn render_bytes(&self, out: &mut String) {
+        out.push_str("# HELP dwaar_bytes_sent_total Total response bytes sent.\n");
+        out.push_str("# TYPE dwaar_bytes_sent_total counter\n");
+        for entry in &self.bytes_sent {
+            let val = entry.value().load(Relaxed);
+            if val > 0 {
+                let _ = writeln!(
+                    out,
+                    "dwaar_bytes_sent_total{{domain=\"{}\"}} {val}",
+                    entry.key()
+                );
+            }
+        }
+
+        out.push_str("# HELP dwaar_bytes_received_total Total request bytes received.\n");
+        out.push_str("# TYPE dwaar_bytes_received_total counter\n");
+        for entry in &self.bytes_received {
+            let val = entry.value().load(Relaxed);
+            if val > 0 {
+                let _ = writeln!(
+                    out,
+                    "dwaar_bytes_received_total{{domain=\"{}\"}} {val}",
+                    entry.key()
+                );
+            }
+        }
+    }
+
+    fn render_active_connections(&self, out: &mut String) {
+        out.push_str("# HELP dwaar_active_connections Currently active connections.\n");
+        out.push_str("# TYPE dwaar_active_connections gauge\n");
+        for entry in &self.active_connections {
+            let val = entry.value().load(Relaxed);
+            let _ = writeln!(
+                out,
+                "dwaar_active_connections{{domain=\"{}\"}} {val}",
+                entry.key()
+            );
+        }
+    }
+
+    fn render_upstream_connect_duration(&self, out: &mut String) {
+        out.push_str(
+            "# HELP dwaar_upstream_connect_duration_seconds Upstream connection time in seconds.\n",
+        );
+        out.push_str("# TYPE dwaar_upstream_connect_duration_seconds histogram\n");
+        for entry in &self.upstream_connect_duration {
+            render_histogram(
+                out,
+                "dwaar_upstream_connect_duration_seconds",
+                entry.key(),
+                &entry.value().snapshot(),
+            );
+        }
+    }
+
+    fn render_upstream_health(&self, out: &mut String) {
+        out.push_str(
+            "# HELP dwaar_upstream_health Upstream health status (1=healthy, 0=unhealthy).\n",
+        );
+        out.push_str("# TYPE dwaar_upstream_health gauge\n");
+        for entry in &self.upstream_health {
+            let val = entry.value().load(Relaxed);
+            let _ = writeln!(
+                out,
+                "dwaar_upstream_health{{upstream=\"{}\"}} {val}",
+                entry.key()
+            );
+        }
+    }
+
+    fn render_tls_handshake_duration(&self, out: &mut String) {
+        let snap = self.tls_handshake_duration.snapshot();
+        if snap.count == 0 {
+            return;
+        }
+        out.push_str(
+            "# HELP dwaar_tls_handshake_duration_seconds TLS handshake duration in seconds.\n",
+        );
+        out.push_str("# TYPE dwaar_tls_handshake_duration_seconds histogram\n");
+        render_histogram_no_labels(out, "dwaar_tls_handshake_duration_seconds", &snap);
+    }
+
+    fn render_config_reloads(&self, out: &mut String) {
+        let success = self.config_reloads_success.load(Relaxed);
+        let failure = self.config_reloads_failure.load(Relaxed);
+        if success == 0 && failure == 0 {
+            return;
+        }
+        out.push_str("# HELP dwaar_config_reload_total Config reload attempts.\n");
+        out.push_str("# TYPE dwaar_config_reload_total counter\n");
+        if success > 0 {
+            let _ = writeln!(
+                out,
+                "dwaar_config_reload_total{{result=\"success\"}} {success}"
+            );
+        }
+        if failure > 0 {
+            let _ = writeln!(
+                out,
+                "dwaar_config_reload_total{{result=\"failure\"}} {failure}"
+            );
+        }
+    }
+}
+
+/// Write a histogram with a `domain` label.
+fn render_histogram(out: &mut String, name: &str, domain: &str, snap: &HistogramSnapshot) {
+    for (i, &le) in BUCKET_BOUNDS_SECS.iter().enumerate() {
+        let _ = writeln!(
+            out,
+            "{name}_bucket{{domain=\"{domain}\",le=\"{le}\"}} {}",
+            snap.buckets[i]
+        );
+    }
+    let _ = writeln!(
+        out,
+        "{name}_bucket{{domain=\"{domain}\",le=\"+Inf\"}} {}",
+        snap.buckets[BUCKET_BOUNDS_SECS.len()]
+    );
+    let _ = writeln!(out, "{name}_sum{{domain=\"{domain}\"}} {}", snap.sum_secs);
+    let _ = writeln!(out, "{name}_count{{domain=\"{domain}\"}} {}", snap.count);
+}
+
+/// Write a histogram without labels (global metrics like TLS handshake).
+fn render_histogram_no_labels(out: &mut String, name: &str, snap: &HistogramSnapshot) {
+    for (i, &le) in BUCKET_BOUNDS_SECS.iter().enumerate() {
+        let _ = writeln!(out, "{name}_bucket{{le=\"{le}\"}} {}", snap.buckets[i]);
+    }
+    let _ = writeln!(
+        out,
+        "{name}_bucket{{le=\"+Inf\"}} {}",
+        snap.buckets[BUCKET_BOUNDS_SECS.len()]
+    );
+    let _ = writeln!(out, "{name}_sum {}", snap.sum_secs);
+    let _ = writeln!(out, "{name}_count {}", snap.count);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn histogram_observe_correct_bucket() {
+        let h = Histogram::new();
+        // 3ms = 3000us — should land in the 5ms (5000us) bucket
+        h.observe(3_000);
+
+        let snap = h.snapshot();
+        assert_eq!(snap.buckets[0], 1, "le=5ms bucket should have 1");
+        // All higher buckets are cumulative — they should also have 1
+        for b in &snap.buckets[1..] {
+            assert_eq!(*b, 1, "cumulative bucket should have 1");
+        }
+        assert_eq!(snap.count, 1);
+        assert!((snap.sum_secs - 0.003).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn histogram_observe_highest_bucket() {
+        let h = Histogram::new();
+        // 15s = 15_000_000us — exceeds all bounds, only +Inf
+        h.observe(15_000_000);
+
+        let snap = h.snapshot();
+        for (i, &count) in snap.buckets.iter().enumerate() {
+            if i < BUCKET_BOUNDS_US.len() {
+                assert_eq!(count, 0, "bounded bucket {i} should be 0");
+            } else {
+                assert_eq!(count, 1, "+Inf bucket should be 1");
+            }
+        }
+        assert_eq!(snap.count, 1);
+    }
+
+    #[test]
+    fn histogram_sum_and_count_accumulate() {
+        let h = Histogram::new();
+        h.observe(1_000); // 1ms
+        h.observe(2_000); // 2ms
+        h.observe(3_000); // 3ms
+
+        let snap = h.snapshot();
+        assert_eq!(snap.count, 3);
+        // 6000us = 0.006s
+        assert!((snap.sum_secs - 0.006).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn histogram_exact_boundary() {
+        let h = Histogram::new();
+        // Exactly 5ms — should be <= 5ms bucket
+        h.observe(5_000);
+
+        let snap = h.snapshot();
+        assert_eq!(snap.buckets[0], 1, "le=5ms should include exact boundary");
+    }
+
+    /// Helper: get counter value by status group index and method index.
+    fn counter_at(c: &StatusMethodCounters, sg: usize, mi: usize) -> u64 {
+        c.counts[sg * METHOD_COUNT + mi].load(Relaxed)
+    }
+
+    #[test]
+    fn status_method_counters_basic() {
+        let c = StatusMethodCounters::new();
+        c.increment(200, "GET");
+        c.increment(200, "GET");
+        c.increment(404, "POST");
+
+        assert_eq!(counter_at(&c, 1, 0), 2); // 2xx GET
+        assert_eq!(counter_at(&c, 3, 1), 1); // 4xx POST
+        assert_eq!(c.total(), 3);
+    }
+
+    #[test]
+    fn status_method_counters_unknown_method() {
+        let c = StatusMethodCounters::new();
+        c.increment(200, "PROPFIND");
+
+        assert_eq!(counter_at(&c, 1, 7), 1); // 2xx OTHER
+    }
+
+    #[test]
+    fn status_method_counters_edge_statuses() {
+        let c = StatusMethodCounters::new();
+        c.increment(100, "GET"); // 1xx
+        c.increment(199, "GET"); // 1xx
+        c.increment(500, "GET"); // 5xx
+        c.increment(599, "GET"); // 5xx
+        c.increment(999, "GET"); // mapped to 5xx (catch-all)
+
+        assert_eq!(counter_at(&c, 0, 0), 2); // 1xx GET
+        assert_eq!(counter_at(&c, 4, 0), 3); // 5xx GET
+    }
+
+    #[test]
+    fn prometheus_metrics_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<PrometheusMetrics>();
+    }
+
+    #[test]
+    fn record_request_populates_all_maps() {
+        let m = PrometheusMetrics::new();
+        let domain = CompactString::from("test.example.com");
+        m.record_request(&domain, "GET", 200, 5_000, 1024, 256);
+
+        assert!(m.requests.contains_key(&domain));
+        assert!(m.request_duration.contains_key(&domain));
+        assert_eq!(
+            m.bytes_sent.get(&domain).expect("bytes_sent").load(Relaxed),
+            1024
+        );
+        assert_eq!(
+            m.bytes_received
+                .get(&domain)
+                .expect("bytes_received")
+                .load(Relaxed),
+            256
+        );
+    }
+
+    #[test]
+    fn active_connections_increment_decrement() {
+        let m = PrometheusMetrics::new();
+        let domain = CompactString::from("test.com");
+
+        m.connection_start(&domain);
+        m.connection_start(&domain);
+        assert_eq!(
+            m.active_connections
+                .get(&domain)
+                .expect("gauge")
+                .load(Relaxed),
+            2
+        );
+
+        m.connection_end(&domain);
+        assert_eq!(
+            m.active_connections
+                .get(&domain)
+                .expect("gauge")
+                .load(Relaxed),
+            1
+        );
+    }
+
+    #[test]
+    fn render_empty_registry() {
+        let m = PrometheusMetrics::new();
+        let text = m.render();
+        // Should still have HELP/TYPE lines but no data lines
+        assert!(text.contains("# HELP dwaar_requests_total"));
+        assert!(text.contains("# TYPE dwaar_requests_total counter"));
+        // No data values since no requests recorded
+        assert!(!text.contains("domain="));
+    }
+
+    #[test]
+    fn render_counter_values() {
+        let m = PrometheusMetrics::new();
+        let domain = CompactString::from("app.example.com");
+        m.record_request(&domain, "GET", 200, 1_000, 512, 64);
+        m.record_request(&domain, "GET", 200, 2_000, 512, 64);
+        m.record_request(&domain, "POST", 404, 3_000, 0, 128);
+
+        let text = m.render();
+        assert!(text.contains(
+            "dwaar_requests_total{domain=\"app.example.com\",method=\"GET\",status=\"2xx\"} 2"
+        ));
+        assert!(text.contains(
+            "dwaar_requests_total{domain=\"app.example.com\",method=\"POST\",status=\"4xx\"} 1"
+        ));
+        assert!(text.contains("dwaar_bytes_sent_total{domain=\"app.example.com\"} 1024"));
+    }
+
+    #[test]
+    fn render_histogram_format() {
+        let m = PrometheusMetrics::new();
+        let domain = CompactString::from("h.test");
+        m.record_request(&domain, "GET", 200, 3_000, 0, 0); // 3ms
+
+        let text = m.render();
+        // Check bucket format
+        assert!(
+            text.contains(
+                "dwaar_request_duration_seconds_bucket{domain=\"h.test\",le=\"0.005\"} 1"
+            )
+        );
+        assert!(
+            text.contains("dwaar_request_duration_seconds_bucket{domain=\"h.test\",le=\"+Inf\"} 1")
+        );
+        assert!(text.contains("dwaar_request_duration_seconds_sum{domain=\"h.test\"} 0.003"));
+        assert!(text.contains("dwaar_request_duration_seconds_count{domain=\"h.test\"} 1"));
+    }
+
+    #[test]
+    fn render_config_reload_counters() {
+        let m = PrometheusMetrics::new();
+        m.config_reloads_success.fetch_add(3, Relaxed);
+        m.config_reloads_failure.fetch_add(1, Relaxed);
+
+        let text = m.render();
+        assert!(text.contains("dwaar_config_reload_total{result=\"success\"} 3"));
+        assert!(text.contains("dwaar_config_reload_total{result=\"failure\"} 1"));
+    }
+
+    #[test]
+    fn render_skips_zero_config_reloads() {
+        let m = PrometheusMetrics::new();
+        let text = m.render();
+        assert!(!text.contains("dwaar_config_reload_total"));
+    }
+
+    #[test]
+    fn render_active_connections_gauge() {
+        let m = PrometheusMetrics::new();
+        let domain = CompactString::from("gauge.test");
+        m.connection_start(&domain);
+
+        let text = m.render();
+        assert!(text.contains("dwaar_active_connections{domain=\"gauge.test\"} 1"));
+    }
+}

--- a/crates/dwaar-cli/src/cli.rs
+++ b/crates/dwaar-cli/src/cli.rs
@@ -100,6 +100,10 @@ pub(crate) struct Cli {
     #[arg(long)]
     pub no_geoip: bool,
 
+    /// Disable Prometheus metrics collection and `/metrics` endpoint
+    #[arg(long)]
+    pub no_metrics: bool,
+
     /// Number of worker processes to spawn. "auto" uses all available CPU cores.
     /// Each worker gets its own Pingora server and binds independently via `SO_REUSEPORT`.
     #[arg(long, default_value = "auto")]
@@ -185,6 +189,10 @@ impl Cli {
 
     pub(crate) fn geoip_enabled(&self) -> bool {
         !self.bare && !self.no_geoip
+    }
+
+    pub(crate) fn metrics_enabled(&self) -> bool {
+        !self.bare && !self.no_metrics
     }
 }
 

--- a/crates/dwaar-cli/src/main.rs
+++ b/crates/dwaar-cli/src/main.rs
@@ -343,11 +343,21 @@ fn run_server(
         Arc::new(dwaar_plugins::plugin::PluginChain::new(vec![]))
     };
 
+    // Prometheus metrics registry (ISSUE-072)
+    let prometheus = if cli.metrics_enabled() {
+        Some(std::sync::Arc::new(
+            dwaar_analytics::prometheus::PrometheusMetrics::new(),
+        ))
+    } else {
+        None
+    };
+
     info!(
         logging = cli.logging_enabled(),
         plugins = cli.plugins_enabled(),
         analytics = cli.analytics_enabled(),
         geoip = cli.geoip_enabled(),
+        metrics = cli.metrics_enabled(),
         "feature flags resolved"
     );
 
@@ -359,6 +369,7 @@ fn run_server(
         agg_sender,
         geo_lookup,
         plugin_chain,
+        prometheus.clone(),
     );
 
     let mut proxy_service = pingora_proxy::http_proxy_service(&server.configuration, proxy);
@@ -414,6 +425,13 @@ fn run_server(
         admin_token,
     )
     .with_reload_notify(Arc::clone(&config_notify));
+
+    let admin_service = if let Some(ref prom) = prometheus {
+        admin_service.with_prometheus(Arc::clone(prom))
+    } else {
+        admin_service
+    };
+
     let mut admin_listening =
         pingora_core::services::listening::Service::new("admin API".to_string(), admin_service);
     admin_listening.add_tcp("127.0.0.1:6190");

--- a/crates/dwaar-config/src/compile.rs
+++ b/crates/dwaar-config/src/compile.rs
@@ -1031,11 +1031,8 @@ fn warn_pending_runtime(address: &str, directives: &[Directive]) {
                 directive = "acme_server",
                 "directive parsed but not yet implemented by Dwaar, ignoring"
             ),
-            Directive::Metrics(_) => warn!(
-                address = %address,
-                directive = "metrics",
-                "directive parsed but not yet implemented by Dwaar, ignoring"
-            ),
+            // Metrics directive recognized — ISSUE-072 handles collection
+            // via PrometheusMetrics registry, not per-route config.
             Directive::Tracing(_) => warn!(
                 address = %address,
                 directive = "tracing",

--- a/crates/dwaar-core/src/context.rs
+++ b/crates/dwaar-core/src/context.rs
@@ -154,6 +154,11 @@ pub struct RequestContext {
 
     /// Accumulated response body bytes received so far (ISSUE-070).
     pub response_body_sent: u64,
+
+    /// Domain key for Prometheus active connection tracking (ISSUE-072).
+    /// Set in `request_filter()` after host resolution, used in `logging()` to
+    /// decrement the gauge with the exact same key.
+    pub metrics_domain: Option<CompactString>,
 }
 
 impl RequestContext {
@@ -190,6 +195,7 @@ impl RequestContext {
             request_body_received: 0,
             response_body_max_size: 100 * 1024 * 1024, // 100 MB default
             response_body_sent: 0,
+            metrics_domain: None,
         }
     }
 

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -78,6 +78,8 @@ pub struct DwaarProxy {
     geo_lookup: Option<Arc<dwaar_geo::GeoLookup>>,
     /// Plugin chain — holds all feature plugins sorted by priority.
     plugin_chain: Arc<PluginChain>,
+    /// Prometheus metrics registry (ISSUE-072). `None` when `--no-metrics`.
+    prometheus: Option<Arc<dwaar_analytics::prometheus::PrometheusMetrics>>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -90,6 +92,7 @@ impl DwaarProxy {
         agg_sender: Option<AggSender>,
         geo_lookup: Option<Arc<dwaar_geo::GeoLookup>>,
         plugin_chain: Arc<PluginChain>,
+        prometheus: Option<Arc<dwaar_analytics::prometheus::PrometheusMetrics>>,
     ) -> Self {
         Self {
             route_table,
@@ -99,6 +102,7 @@ impl DwaarProxy {
             agg_sender,
             geo_lookup,
             plugin_chain,
+            prometheus,
         }
     }
 }
@@ -481,6 +485,15 @@ impl ProxyHttp for DwaarProxy {
                     }
                 }
             }
+        }
+
+        // --- Prometheus active connection tracking (ISSUE-072) ---
+        if let Some(ref prom) = self.prometheus
+            && let Some(ref host) = ctx.plugin_ctx.host
+        {
+            let domain = host.clone();
+            prom.connection_start(&domain);
+            ctx.metrics_domain = Some(domain);
         }
 
         // --- Request body size check (ISSUE-069) ---
@@ -1268,12 +1281,29 @@ impl ProxyHttp for DwaarProxy {
     ) where
         Self::CTX: Send + Sync,
     {
+        let response_time_us = ctx.start_time.elapsed().as_micros() as u64;
+        let status = session.response_written().map_or(0, |r| r.status.as_u16());
+        let bytes_sent = session.body_bytes_sent() as u64;
+        let bytes_received = session.body_bytes_read() as u64;
+
+        // Prometheus metrics (ISSUE-072) — recorded before host.take() moves it
+        if let Some(ref prom) = self.prometheus
+            && let Some(ref domain) = ctx.metrics_domain
+        {
+            prom.record_request(
+                domain,
+                ctx.plugin_ctx.method.as_str(),
+                status,
+                response_time_us,
+                bytes_sent,
+                bytes_received,
+            );
+            prom.connection_end(domain);
+        }
+
         let Some(ref sender) = self.log_sender else {
             return;
         };
-
-        let response_time_us = ctx.start_time.elapsed().as_micros() as u64;
-        let status = session.response_written().map_or(0, |r| r.status.as_u16());
 
         // Split path and query without allocating when there's no query string.
         // std::mem::take moves the CompactString out of ctx, avoiding clone.
@@ -1310,7 +1340,6 @@ impl ProxyHttp for DwaarProxy {
             .get("referer")
             .and_then(|v| v.to_str().ok())
             .map(CompactString::from);
-        let bytes_sent = session.body_bytes_sent() as u64;
 
         if let Some(ref agg) = self.agg_sender {
             let event = AggEvent {
@@ -1352,7 +1381,7 @@ impl ProxyHttp for DwaarProxy {
                 .map(CompactString::from),
             referer,
             bytes_sent,
-            bytes_received: session.body_bytes_read() as u64,
+            bytes_received,
             tls_version: session
                 .downstream_session
                 .digest()
@@ -1394,6 +1423,7 @@ mod tests {
             None,
             None,
             chain,
+            None,
         )
     }
 


### PR DESCRIPTION
## Summary

- Add `PrometheusMetrics` registry with atomic counters, histograms, and gauges — zero new dependencies, zero per-request allocation after first request per domain
- `GET /metrics` endpoint on Admin API (`:6190`) serving Prometheus text exposition format
- Metrics wired into `logging()` callback: `dwaar_requests_total`, `dwaar_request_duration_seconds`, `dwaar_bytes_sent/received_total`, `dwaar_active_connections`, `dwaar_tls_handshake_duration_seconds`, `dwaar_config_reload_total`, `dwaar_upstream_health`
- `--no-metrics` CLI flag (also disabled by `--bare`)

## Test plan

- [x] 16 new unit tests: histogram bucketing, counter indexing, text rendering, empty registry, gauge inc/dec
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 689 tests passing
- [x] `cargo build --workspace --release` succeeds