### PR TITLE
feat(core): gRPC transparent proxying (ISSUE-074)

### DIFF
--- a/crates/dwaar-cli/tests/proxy_integration.rs
+++ b/crates/dwaar-cli/tests/proxy_integration.rs
@@ -1149,3 +1149,141 @@ fn cache_respects_no_store() {
     std::fs::remove_file(&config_file).ok();
     thread::sleep(Duration::from_secs(1));
 }
+
+// ---------------------------------------------------------------------------
+// gRPC transparent proxying tests (ISSUE-074)
+// ---------------------------------------------------------------------------
+
+/// ISSUE-074: Upstream responses with `application/grpc` Content-Type are
+/// proxied without analytics script injection. The proxy detects gRPC
+/// content and skips HTML injection even though the upstream returned 200.
+/// Note: gRPC request-side detection forces H2 ALPN to the upstream, so
+/// this test verifies the response path with a plain HTTP request that
+/// gets a gRPC-typed response — proving the proxy never injects into
+/// non-HTML binary content types.
+#[test]
+fn grpc_response_proxied_without_injection() {
+    let _lock = PORT_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    let upstream = TcpListener::bind("127.0.0.1:8080").expect("bind upstream");
+
+    let proxy = start_dwaar_proxy();
+
+    // Upstream serves a gRPC-typed response with binary-framed body
+    let upstream_handle = thread::spawn(move || {
+        let (mut stream, _) = upstream.accept().expect("accept");
+        let mut reader = BufReader::new(stream.try_clone().expect("clone"));
+        let mut line = String::new();
+        loop {
+            line.clear();
+            if reader.read_line(&mut line).unwrap_or(0) == 0 || line == "\r\n" {
+                break;
+            }
+        }
+        let body = b"\x00\x00\x00\x00\x05hello";
+        let response = format!(
+            "HTTP/1.1 200 OK\r\n\
+             Content-Type: application/grpc\r\n\
+             Content-Length: {}\r\n\
+             Connection: close\r\n\
+             \r\n",
+            body.len()
+        );
+        let _ = stream.write_all(response.as_bytes());
+        let _ = stream.write_all(body);
+        let _ = stream.flush();
+    });
+
+    // Plain GET — no gRPC Content-Type on the request side, so no H2
+    // forcing. The upstream responds with application/grpc anyway.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+
+    let resp = rt.block_on(async {
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .expect("build client");
+        client
+            .get("http://127.0.0.1:6188/grpc.Service/Method")
+            .send()
+            .await
+            .expect("request should succeed")
+    });
+
+    assert_eq!(resp.status().as_u16(), 200);
+
+    let body_bytes = rt.block_on(resp.bytes()).expect("read body");
+    let body_str = String::from_utf8_lossy(&body_bytes);
+    assert!(
+        !body_str.contains("<script"),
+        "gRPC response must not have analytics injection"
+    );
+
+    upstream_handle.join().expect("upstream thread");
+    stop_dwaar(proxy);
+}
+
+/// ISSUE-074: gRPC requests bypass request body size limits for streaming.
+#[test]
+fn grpc_request_bypasses_body_limit() {
+    let _lock = PORT_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    let upstream = TcpListener::bind("127.0.0.1:8080").expect("bind upstream");
+
+    // Dwaarfile with very small body limit (1KB) — gRPC should bypass
+    let config_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    std::fs::create_dir_all(&config_path).ok();
+    let config_file = config_path.join("grpc_body_limit_test.dwaarfile");
+    std::fs::write(
+        &config_file,
+        "127.0.0.1 {\n    reverse_proxy 127.0.0.1:8080\n    request_body {\n        max_size 1KB\n    }\n}\n",
+    )
+    .expect("write test Dwaarfile");
+
+    let proxy = start_dwaar_with_config(Some(&config_file));
+
+    // Upstream just accepts and responds
+    let upstream_handle = thread::spawn(move || {
+        serve_one_request(&upstream, 200, "ok");
+    });
+
+    // Send gRPC POST with body larger than 1KB limit
+    let large_body = vec![0u8; 2048];
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+
+    let resp = rt.block_on(async {
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .expect("build client");
+        client
+            .post("http://127.0.0.1:6188/grpc.Service/Method")
+            .header("Content-Type", "application/grpc")
+            .body(large_body)
+            .send()
+            .await
+            .expect("request should succeed")
+    });
+
+    // Must NOT be 413 — gRPC bypasses body limits
+    assert_ne!(
+        resp.status().as_u16(),
+        413,
+        "gRPC should bypass body size limits"
+    );
+
+    upstream_handle.join().expect("upstream thread");
+    stop_dwaar(proxy);
+    std::fs::remove_file(&config_file).ok();
+    thread::sleep(Duration::from_secs(1));
+}

--- a/crates/dwaar-core/src/context.rs
+++ b/crates/dwaar-core/src/context.rs
@@ -63,6 +63,7 @@ use crate::upstream::UpstreamPool;
 /// - `request_id`: inline `[u8; 36]` instead of `String` (avoids 1 heap alloc)
 /// - `plugin_ctx` fields are populated from request headers (unavoidable allocs)
 #[derive(Debug)]
+#[allow(clippy::struct_excessive_bools)] // Protocol flags (tls, websocket, grpc, cache) are independent booleans, not a state machine
 pub struct RequestContext {
     /// When this request started processing. Uses `Instant` (monotonic clock)
     /// because we need elapsed time, not wall-clock time.
@@ -139,6 +140,10 @@ pub struct RequestContext {
     /// analytics injection so Pingora can establish the bidirectional tunnel.
     pub is_websocket: bool,
 
+    /// gRPC request detected — forces HTTP/2 upstream, disables body limits,
+    /// skips analytics injection. gRPC has its own compression and framing.
+    pub is_grpc: bool,
+
     /// Max request body size in bytes (ISSUE-069). Enforced in `request_filter()`
     /// (Content-Length) and `request_body_filter()` (chunked streaming).
     /// Default: 10 MB. Set to `u64::MAX` for unlimited.
@@ -201,6 +206,7 @@ impl RequestContext {
             copy_response_headers: None,
             upstream_pool: None,
             is_websocket: false,
+            is_grpc: false,
             request_body_max_size: 10 * 1024 * 1024, // 10 MB default
             request_body_received: 0,
             response_body_max_size: 100 * 1024 * 1024, // 100 MB default
@@ -287,5 +293,6 @@ mod tests {
         assert!(ctx.plugin_ctx.country.is_none());
         assert!(ctx.plugin_ctx.compressor.is_none());
         assert!(!ctx.is_websocket);
+        assert!(!ctx.is_grpc);
     }
 }

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -21,7 +21,7 @@ use pingora_cache::cache_control::CacheControl;
 use pingora_cache::filters::resp_cacheable;
 use pingora_cache::{CacheKey, NoCacheReason, RespCacheable};
 use pingora_core::Result;
-use pingora_core::upstreams::peer::HttpPeer;
+use pingora_core::upstreams::peer::{HttpPeer, ALPN};
 use pingora_error::{Error, ErrorType::HTTPStatus};
 use pingora_http::{RequestHeader, ResponseHeader};
 use pingora_proxy::{ProxyHttp, Session};
@@ -428,6 +428,16 @@ impl ProxyHttp for DwaarProxy {
                         .any(|token| token.trim().eq_ignore_ascii_case("upgrade"))
                 });
 
+        // gRPC detection (ISSUE-074): Content-Type starting with "application/grpc"
+        // covers application/grpc, application/grpc+proto, application/grpc-web
+        if !ctx.is_websocket {
+            ctx.is_grpc = header
+                .headers
+                .get(http::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .is_some_and(|ct| ct.starts_with("application/grpc"));
+        }
+
         debug!(
             request_id = %ctx.request_id(),
             client_ip = ?ctx.plugin_ctx.client_ip,
@@ -435,6 +445,7 @@ impl ProxyHttp for DwaarProxy {
             method = %ctx.plugin_ctx.method,
             path = %ctx.plugin_ctx.path,
             is_websocket = ctx.is_websocket,
+            is_grpc = ctx.is_grpc,
             "request metadata extracted"
         );
 
@@ -525,6 +536,12 @@ impl ProxyHttp for DwaarProxy {
                     }
                     if let Some(limit) = block.response_body_max_size {
                         ctx.response_body_max_size = limit;
+                    }
+
+                    // gRPC streaming RPCs have unbounded body — disable limits
+                    if ctx.is_grpc {
+                        ctx.request_body_max_size = u64::MAX;
+                        ctx.response_body_max_size = u64::MAX;
                     }
 
                     // Cache config (ISSUE-073) — only for GET requests on matching paths
@@ -1044,6 +1061,11 @@ impl ProxyHttp for DwaarProxy {
         // Set slightly below common upstream keepalive_timeout (nginx default: 75s)
         // to avoid sending requests on connections the upstream is about to close.
         peer.options.idle_timeout = Some(std::time::Duration::from_secs(60));
+
+        // gRPC requires HTTP/2 end-to-end — force h2 ALPN negotiation
+        if ctx.is_grpc {
+            peer.options.alpn = ALPN::H2;
+        }
 
         Ok(Box::new(peer))
     }

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -549,6 +549,7 @@ impl ProxyHttp for DwaarProxy {
                         let path = ctx.effective_path.as_deref().unwrap_or(&request_path);
                         if cache_cfg.path_matches(path)
                             && !ctx.is_websocket
+                            && !ctx.is_grpc
                             && ctx.plugin_ctx.method == "GET"
                         {
                             ctx.cache_enabled = true;
@@ -1332,7 +1333,7 @@ impl ProxyHttp for DwaarProxy {
         // Skip for WebSocket upgrades — the 101 response body is a bidirectional
         // stream, not HTML (ISSUE-068).
         let status = upstream_response.status.as_u16();
-        if !ctx.is_websocket && (200..300).contains(&status) {
+        if !ctx.is_websocket && !ctx.is_grpc && (200..300).contains(&status) {
             let is_html = upstream_response
                 .headers
                 .get(http::header::CONTENT_TYPE)

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -21,7 +21,7 @@ use pingora_cache::cache_control::CacheControl;
 use pingora_cache::filters::resp_cacheable;
 use pingora_cache::{CacheKey, NoCacheReason, RespCacheable};
 use pingora_core::Result;
-use pingora_core::upstreams::peer::{HttpPeer, ALPN};
+use pingora_core::upstreams::peer::{ALPN, HttpPeer};
 use pingora_error::{Error, ErrorType::HTTPStatus};
 use pingora_http::{RequestHeader, ResponseHeader};
 use pingora_proxy::{ProxyHttp, Session};

--- a/crates/dwaar-plugins/src/compress.rs
+++ b/crates/dwaar-plugins/src/compress.rs
@@ -114,6 +114,8 @@ fn parse_encoding_with_quality(part: &str) -> (&str, f32) {
 
 /// Content types eligible for compression. Binary formats (images, video,
 /// fonts) are already compressed and re-compressing wastes CPU.
+/// `application/grpc` is intentionally absent — gRPC has its own compression
+/// protocol (`grpc-encoding` header). Double-compressing breaks gRPC framing.
 const COMPRESSIBLE_TYPES: &[&str] = &[
     "text/html",
     "text/css",
@@ -530,6 +532,13 @@ mod tests {
     #[test]
     fn octet_stream_is_not_compressible() {
         assert!(!is_compressible("application/octet-stream"));
+    }
+
+    #[test]
+    fn grpc_is_not_compressible() {
+        assert!(!is_compressible("application/grpc"));
+        assert!(!is_compressible("application/grpc+proto"));
+        assert!(!is_compressible("application/grpc-web"));
     }
 
     // ── Should-compress logic ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- Auto-detect gRPC requests via `Content-Type: application/grpc*` header
- Force HTTP/2 upstream via `ALPN::H2` on `HttpPeer` (gRPC requires H2)
- Disable request/response body size limits for gRPC (streaming RPCs are unbounded)
- Skip analytics injection for gRPC responses (binary, not HTML)
- Skip caching for gRPC requests (POST-based, not cacheable)
- Verify compression already skips gRPC (`application/grpc` not in COMPRESSIBLE_TYPES)

## Architecture

Follows the exact same pattern as WebSocket detection (ISSUE-068): detect in `request_filter()`, set `ctx.is_grpc = true`, use that flag to skip incompatible middleware. No new Dwaarfile directive needed — detection is fully automatic. Pingora natively preserves HTTP/2 trailers at the protocol level (gRPC `grpc-status`/`grpc-message`).

## Test plan

- [x] `grpc_response_proxied_without_injection` — verifies no `<script>` in gRPC responses
- [x] `grpc_request_bypasses_body_limit` — 2KB body passes through 1KB limit
- [x] `grpc_is_not_compressible` — confirms application/grpc excluded from compression
- [x] 699 workspace tests passing (3 new)
- [x] `cargo fmt`, `cargo clippy`, `cargo build --release` all clean

**Completes Phase 17 (Production Viability).** All 7 issues (068-074) done.