### PR TITLE
feat(core): connection draining on route removal (ISSUE-075)

### DIFF
--- a/crates/dwaar-cli/src/main.rs
+++ b/crates/dwaar-cli/src/main.rs
@@ -187,6 +187,7 @@ fn main() -> anyhow::Result<()> {
 
     let config_path = &cli.config;
     let dwaar_config = load_config(config_path)?;
+    let drain_timeout = std::time::Duration::from_secs(extract_drain_timeout(&dwaar_config));
 
     if cli.test {
         info!("config valid");
@@ -204,12 +205,19 @@ fn main() -> anyhow::Result<()> {
 
     // Single-process mode skips forking — same behavior as before.
     if worker_count <= 1 {
-        return run_server(&cli, &dwaar_config, config_path, 0, 1);
+        return run_server(&cli, &dwaar_config, config_path, drain_timeout, 0, 1);
     }
 
     match fork_workers(worker_count)? {
         WorkerRole::Supervisor => Ok(()),
-        WorkerRole::Worker(id) => run_server(&cli, &dwaar_config, config_path, id, worker_count),
+        WorkerRole::Worker(id) => run_server(
+            &cli,
+            &dwaar_config,
+            config_path,
+            drain_timeout,
+            id,
+            worker_count,
+        ),
     }
 }
 
@@ -218,6 +226,7 @@ fn run_server(
     cli: &Cli,
     dwaar_config: &dwaar_config::model::DwaarConfig,
     config_path: &std::path::Path,
+    drain_timeout: std::time::Duration,
     worker_id: usize,
     worker_count: usize,
 ) -> anyhow::Result<()> {
@@ -500,6 +509,7 @@ fn run_server(
         &route_table_for_agg,
         &agg_metrics,
         health_pools,
+        drain_timeout,
     );
 
     info!("entering run loop, waiting for connections or signals");
@@ -524,6 +534,7 @@ fn register_background_services(
     route_table_for_agg: &Arc<ArcSwap<dwaar_core::route::RouteTable>>,
     agg_metrics: &Arc<DashMap<String, dwaar_analytics::aggregation::DomainMetrics>>,
     health_pools: Vec<Arc<dwaar_core::upstream::UpstreamPool>>,
+    drain_timeout: std::time::Duration,
 ) {
     // Upstream health checker — only registered when there are pools with health URIs.
     // Per Guardrail #20: all async background work must be a BackgroundService.
@@ -580,6 +591,7 @@ fn register_background_services(
         Arc::clone(route_table),
         initial_hash,
     )
+    .with_drain_timeout(drain_timeout)
     .with_reload_notify(Arc::clone(config_notify));
     let config_watcher = if cli.docker_socket.is_some() {
         config_watcher.with_docker_mode(Arc::clone(dwaarfile_snapshot), Arc::clone(config_notify))
@@ -649,6 +661,16 @@ fn load_config(path: &std::path::Path) -> anyhow::Result<dwaar_config::model::Dw
     );
 
     Ok(config)
+}
+
+/// Extract `drain_timeout` from the parsed config's global options.
+/// Defaults to 30 seconds when not specified.
+fn extract_drain_timeout(config: &dwaar_config::model::DwaarConfig) -> u64 {
+    config
+        .global_options
+        .as_ref()
+        .and_then(|g| g.drain_timeout_secs)
+        .unwrap_or(30)
 }
 
 fn setup_tls_listener(

--- a/crates/dwaar-config/src/model.rs
+++ b/crates/dwaar-config/src/model.rs
@@ -30,6 +30,9 @@ pub struct GlobalOptions {
     pub debug: bool,
     /// Auto HTTPS behavior. `auto_https off` / `auto_https disable_redirects`
     pub auto_https: Option<String>,
+    /// How long to wait for in-flight requests before force-closing a
+    /// removed route (ISSUE-075). Default: 30 seconds.
+    pub drain_timeout_secs: Option<u64>,
     /// Options we recognized but don't act on — stored so we never error
     /// on valid Caddyfile syntax we haven't implemented yet.
     pub passthrough: Vec<(String, Vec<String>)>,

--- a/crates/dwaar-config/src/parser/mod.rs
+++ b/crates/dwaar-config/src/parser/mod.rs
@@ -183,6 +183,18 @@ fn parse_global_option_line(
         "debug" => {
             opts.debug = true;
         }
+        "drain_timeout" => {
+            let val = peek_consume_word_or_quoted(t);
+            let secs = parse_duration_secs(&val).ok_or(ParseError {
+                line: key_tok.line,
+                col: key_tok.col,
+                kind: ParseErrorKind::InvalidValue {
+                    directive: "drain_timeout".to_string(),
+                    message: format!("'{val}' is not a valid duration (e.g. '30s', '1m', '60')"),
+                },
+            })?;
+            opts.drain_timeout_secs = Some(secs);
+        }
         // Unknown option — collect args, consume sub-blocks
         _ => {
             let args = collect_global_passthrough_args(t);
@@ -273,7 +285,20 @@ fn is_global_option_key(w: &str) -> bool {
             | "pki"
             | "events"
             | "filesystem"
+            | "drain_timeout"
     )
+}
+
+/// Parse a duration string like "30s", "1m", "60" into seconds.
+/// Supports bare numbers (seconds), `Ns` (seconds), and `Nm` (minutes).
+fn parse_duration_secs(s: &str) -> Option<u64> {
+    if let Some(rest) = s.strip_suffix('s') {
+        rest.parse().ok()
+    } else if let Some(rest) = s.strip_suffix('m') {
+        rest.parse::<u64>().ok().map(|m| m * 60)
+    } else {
+        s.parse().ok()
+    }
 }
 
 /// Parse one site block: `address { directive* }`

--- a/crates/dwaar-config/src/parser/tests.rs
+++ b/crates/dwaar-config/src/parser/tests.rs
@@ -1242,3 +1242,37 @@ fn parse_cache_directive_minimal() {
     assert_eq!(cache.default_ttl, None);
     assert_eq!(cache.stale_while_revalidate, None);
 }
+
+// ── drain_timeout (ISSUE-075) ───────────────────────────────────────────────
+
+#[test]
+fn drain_timeout_seconds() {
+    let config = parse("{\n    drain_timeout 30s\n}\na.com {\n    reverse_proxy :3000\n}\n")
+        .expect("should parse");
+    let opts = config.global_options.as_ref().expect("has global options");
+    assert_eq!(opts.drain_timeout_secs, Some(30));
+}
+
+#[test]
+fn drain_timeout_minutes() {
+    let config = parse("{\n    drain_timeout 2m\n}\na.com {\n    reverse_proxy :3000\n}\n")
+        .expect("should parse");
+    let opts = config.global_options.as_ref().expect("has global options");
+    assert_eq!(opts.drain_timeout_secs, Some(120));
+}
+
+#[test]
+fn drain_timeout_bare_number() {
+    let config = parse("{\n    drain_timeout 60\n}\na.com {\n    reverse_proxy :3000\n}\n")
+        .expect("should parse");
+    let opts = config.global_options.as_ref().expect("has global options");
+    assert_eq!(opts.drain_timeout_secs, Some(60));
+}
+
+#[test]
+fn drain_timeout_default_when_absent() {
+    let config =
+        parse("{\n    debug\n}\na.com {\n    reverse_proxy :3000\n}\n").expect("should parse");
+    let opts = config.global_options.as_ref().expect("has global options");
+    assert_eq!(opts.drain_timeout_secs, None);
+}

--- a/crates/dwaar-config/src/watcher.rs
+++ b/crates/dwaar-config/src/watcher.rs
@@ -39,6 +39,9 @@ pub struct ConfigWatcher {
     dwaarfile_snapshot: Option<Arc<ArcSwap<Vec<Route>>>>,
     /// Signal `DockerWatcher` to re-merge after a Dwaarfile change.
     config_notify: Option<Arc<tokio::sync::Notify>>,
+    /// How long to wait for in-flight requests on removed routes before
+    /// force-dropping them (ISSUE-075). Default: 30 seconds.
+    drain_timeout: Duration,
 }
 
 impl std::fmt::Debug for ConfigWatcher {
@@ -65,7 +68,15 @@ impl ConfigWatcher {
             last_hash: std::sync::Mutex::new(initial_hash),
             dwaarfile_snapshot: None,
             config_notify: None,
+            drain_timeout: Duration::from_secs(30),
         }
+    }
+
+    /// Set a custom drain timeout for removed routes (ISSUE-075).
+    #[must_use]
+    pub fn with_drain_timeout(mut self, timeout: Duration) -> Self {
+        self.drain_timeout = timeout;
+        self
     }
 
     /// Set a `Notify` that triggers an immediate config reload (for `POST /reload`).
@@ -146,6 +157,14 @@ impl ConfigWatcher {
             }
         };
 
+        // Use drain timeout from the new config if specified, else keep the
+        // startup default. Computed per-reload since the config might change it.
+        let drain_timeout = config
+            .global_options
+            .as_ref()
+            .and_then(|g| g.drain_timeout_secs)
+            .map_or(self.drain_timeout, Duration::from_secs);
+
         // Compile routes
         let new_table = compile_routes(&config);
 
@@ -171,6 +190,11 @@ impl ConfigWatcher {
         } else {
             // Standard mode: write directly to route table
             log_route_diff(&old_table, &new_table);
+
+            // Drain routes that were removed (ISSUE-075): mark them as draining
+            // so in-flight requests complete, then let them drop after timeout.
+            drain_removed_routes(&old_table, &new_table, drain_timeout);
+
             self.route_table.store(Arc::new(new_table));
             info!(path = %self.config_path.display(), "config reloaded successfully");
         }
@@ -272,6 +296,56 @@ async fn shutdown_signal(shutdown: &ShutdownWatch) {
 }
 
 /// Log differences between old and new route tables.
+/// Mark removed routes as draining and spawn background tasks that wait
+/// for in-flight requests to complete (or timeout), then drop them.
+///
+/// Called during standard-mode config reload. The old route's `draining`
+/// flag causes `request_filter()` to reject new connections with 502,
+/// while existing requests continue on the cloned `active_connections` counter.
+fn drain_removed_routes(old: &RouteTable, new: &RouteTable, timeout: Duration) {
+    let new_domains: std::collections::HashSet<&str> = new.domain_keys().collect();
+
+    for domain in old.domain_keys() {
+        if new_domains.contains(domain) {
+            continue;
+        }
+
+        let Some(route) = old.get_exact(domain) else {
+            continue;
+        };
+
+        route.mark_draining();
+
+        let active = route.active_connections.clone();
+        let draining = route.draining.clone();
+        let domain_owned = domain.to_owned();
+
+        tokio::spawn(async move {
+            let start = tokio::time::Instant::now();
+            let poll_interval = Duration::from_millis(100);
+
+            // Wait until all in-flight requests finish or we hit the timeout
+            while active.load(std::sync::atomic::Ordering::Relaxed) > 0 {
+                if start.elapsed() >= timeout {
+                    let remaining = active.load(std::sync::atomic::Ordering::Relaxed);
+                    warn!(
+                        domain = %domain_owned,
+                        remaining_connections = remaining,
+                        "drain timeout reached — force-closing"
+                    );
+                    break;
+                }
+                tokio::time::sleep(poll_interval).await;
+            }
+
+            // Reset draining flag (the route is now fully removed from the table,
+            // so this only matters if someone held an Arc reference to it)
+            draining.store(false, std::sync::atomic::Ordering::Relaxed);
+            info!(domain = %domain_owned, "route drain complete");
+        });
+    }
+}
+
 fn log_route_diff(old: &RouteTable, new: &RouteTable) {
     let old_routes = old.all_routes();
     let new_routes = new.all_routes();
@@ -400,5 +474,87 @@ mod tests {
         assert!(table.load().resolve("a.com").is_some());
 
         drop(shutdown_tx);
+    }
+
+    #[test]
+    fn drain_marks_removed_routes() {
+        let old_route = Route::new("old.com", addr(1000), false, None);
+        let active = old_route.active_connections.clone();
+        let draining = old_route.draining.clone();
+
+        let old = RouteTable::new(vec![
+            old_route,
+            Route::new("kept.com", addr(2000), false, None),
+        ]);
+        let new = RouteTable::new(vec![Route::new("kept.com", addr(2000), false, None)]);
+
+        // The removed route should be marked as draining after the drain call.
+        // We need a tokio runtime for the spawned tasks, but the marking itself
+        // happens synchronously before the spawn.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .expect("runtime");
+        rt.block_on(async {
+            drain_removed_routes(&old, &new, Duration::from_millis(100));
+            assert!(draining.load(std::sync::atomic::Ordering::Relaxed));
+
+            // With no active connections, the drain task should complete quickly
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            // Draining flag resets after completion
+            assert!(!draining.load(std::sync::atomic::Ordering::Relaxed));
+        });
+
+        // The kept route should NOT be draining
+        assert!(!old.get_exact("kept.com").expect("exists").is_draining());
+        drop(active);
+    }
+
+    #[tokio::test]
+    async fn drain_waits_for_active_connections() {
+        let old_route = Route::new("slow.com", addr(1000), false, None);
+        let active = old_route.active_connections.clone();
+        let draining = old_route.draining.clone();
+
+        // Simulate 2 in-flight requests
+        active.store(2, std::sync::atomic::Ordering::Relaxed);
+
+        let old = RouteTable::new(vec![old_route]);
+        let new = RouteTable::new(vec![]);
+
+        drain_removed_routes(&old, &new, Duration::from_secs(5));
+        assert!(draining.load(std::sync::atomic::Ordering::Relaxed));
+
+        // Simulate requests completing
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        active.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        active.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+
+        // Give the drain task time to notice
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(!draining.load(std::sync::atomic::Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn drain_timeout_force_closes() {
+        let old_route = Route::new("stuck.com", addr(1000), false, None);
+        let active = old_route.active_connections.clone();
+        let draining = old_route.draining.clone();
+
+        // Simulate a stuck request that never completes
+        active.store(1, std::sync::atomic::Ordering::Relaxed);
+
+        let old = RouteTable::new(vec![old_route]);
+        let new = RouteTable::new(vec![]);
+
+        drain_removed_routes(&old, &new, Duration::from_millis(200));
+        assert!(draining.load(std::sync::atomic::Ordering::Relaxed));
+
+        // After timeout, drain should complete even with active connections
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        assert!(!draining.load(std::sync::atomic::Ordering::Relaxed));
+        // The counter is still 1, but the route is force-closed
+        assert_eq!(active.load(std::sync::atomic::Ordering::Relaxed), 1);
     }
 }

--- a/crates/dwaar-core/src/context.rs
+++ b/crates/dwaar-core/src/context.rs
@@ -34,6 +34,7 @@
 
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU32;
 use std::time::Instant;
 
 use compact_str::CompactString;
@@ -165,6 +166,11 @@ pub struct RequestContext {
     /// decrement the gauge with the exact same key.
     pub metrics_domain: Option<CompactString>,
 
+    /// Active connection counter for the matched route (ISSUE-075).
+    /// Decremented in `logging()` when the request completes, enabling
+    /// graceful drain when a route is removed during hot-reload.
+    pub drain_counter: Option<Arc<AtomicU32>>,
+
     /// Whether caching is enabled for this request (ISSUE-073).
     pub cache_enabled: bool,
 
@@ -212,6 +218,7 @@ impl RequestContext {
             response_body_max_size: 100 * 1024 * 1024, // 100 MB default
             response_body_sent: 0,
             metrics_domain: None,
+            drain_counter: None,
             cache_enabled: false,
             cache_config: None,
             cache_status: None,

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -456,6 +456,30 @@ impl ProxyHttp for DwaarProxy {
             let host_stripped = host.split(':').next().unwrap_or(host);
             let table = self.route_table.load();
             if let Some(route) = table.resolve(host_stripped) {
+                // Route is being drained (removed in a config reload but still
+                // has in-flight requests) — reject new connections immediately.
+                if route.is_draining() {
+                    warn!(
+                        request_id = %ctx.request_id(),
+                        domain = %route.domain,
+                        "route is draining — rejecting new request with 502"
+                    );
+                    let mut resp = ResponseHeader::build(502, Some(2))?;
+                    resp.insert_header("Content-Length", "0")
+                        .map_err(|e| Error::explain(HTTPStatus(502), format!("bad header: {e}")))?;
+                    resp.insert_header("Connection", "close")
+                        .map_err(|e| Error::explain(HTTPStatus(502), format!("bad header: {e}")))?;
+                    session.write_response_header(Box::new(resp), true).await?;
+                    return Ok(true);
+                }
+
+                // Track this request for connection draining (ISSUE-075).
+                // Incremented here, decremented in logging() when the request completes.
+                route
+                    .active_connections
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                ctx.drain_counter = Some(route.active_connections.clone());
+
                 ctx.plugin_ctx.rate_limit_rps = route.rate_limit_rps();
                 ctx.plugin_ctx.route_domain = Some(CompactString::from(route.domain.as_str()));
                 ctx.plugin_ctx.under_attack = route.under_attack();
@@ -1433,6 +1457,13 @@ impl ProxyHttp for DwaarProxy {
     ) where
         Self::CTX: Send + Sync,
     {
+        // Decrement the route's active connection counter (ISSUE-075).
+        // This runs for every request, even failed ones, so the counter
+        // stays accurate for drain timeout decisions.
+        if let Some(ref counter) = ctx.drain_counter {
+            counter.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+        }
+
         let response_time_us = ctx.start_time.elapsed().as_micros() as u64;
         let status = session.response_written().map_or(0, |r| r.status.as_u16());
         let bytes_sent = session.body_bytes_sent() as u64;

--- a/crates/dwaar-core/src/route.rs
+++ b/crates/dwaar-core/src/route.rs
@@ -52,6 +52,7 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use ahash::RandomState;
 use compact_str::CompactString;
@@ -489,6 +490,15 @@ pub struct Route {
     /// At request time, clone this and populate dynamic vars (from `map`).
     /// Empty when no `vars` or `map` directives are present.
     pub var_defaults: VarSlots,
+
+    /// Number of in-flight requests using this route. Incremented in
+    /// `request_filter()`, decremented in `logging()`. Used during
+    /// connection draining to know when it's safe to drop the route.
+    pub active_connections: Arc<AtomicU32>,
+
+    /// When true, this route is being drained — new requests get 502,
+    /// but in-flight requests continue until complete or drain timeout.
+    pub draining: Arc<AtomicBool>,
 }
 
 impl Route {
@@ -523,6 +533,8 @@ impl Route {
                 cache: None,
             }],
             var_defaults: VarSlots::default(),
+            active_connections: Arc::new(AtomicU32::new(0)),
+            draining: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -557,6 +569,8 @@ impl Route {
             default_under_attack,
             handlers,
             var_defaults,
+            active_connections: Arc::new(AtomicU32::new(0)),
+            draining: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -578,6 +592,23 @@ impl Route {
     #[inline]
     pub fn under_attack(&self) -> bool {
         self.default_under_attack
+    }
+
+    /// Check if this route is draining (rejecting new connections).
+    #[inline]
+    pub fn is_draining(&self) -> bool {
+        self.draining.load(Ordering::Relaxed)
+    }
+
+    /// Mark this route as draining — new requests will be rejected with 502.
+    pub fn mark_draining(&self) {
+        self.draining.store(true, Ordering::Relaxed);
+    }
+
+    /// Current number of in-flight requests on this route.
+    #[inline]
+    pub fn active_connection_count(&self) -> u32 {
+        self.active_connections.load(Ordering::Relaxed)
     }
 }
 
@@ -709,6 +740,17 @@ impl RouteTable {
     /// Returns all routes as a Vec, for serialization and admin API mutations.
     pub fn all_routes(&self) -> Vec<Route> {
         self.routes.values().cloned().collect()
+    }
+
+    /// Returns the set of domain keys, for comparing old vs new tables during drain.
+    pub fn domain_keys(&self) -> impl Iterator<Item = &str> {
+        self.routes.keys().map(String::as_str)
+    }
+
+    /// Look up a route by exact domain key (no wildcard fallback).
+    /// Used during drain to grab the old route's atomic counters.
+    pub fn get_exact(&self, domain: &str) -> Option<&Route> {
+        self.routes.get(domain)
     }
 }
 
@@ -1138,5 +1180,68 @@ mod tests {
         assert_eq!(crh.exclude.len(), 1);
         assert_eq!(crh.include[0].as_str(), "X-Custom");
         assert_eq!(crh.exclude[0].as_str(), "Set-Cookie");
+    }
+
+    // ── Connection draining (ISSUE-075) ─────────────────────
+
+    #[test]
+    fn route_starts_not_draining() {
+        let route = Route::new("api.example.com", addr(3000), false, None);
+        assert!(!route.is_draining());
+        assert_eq!(route.active_connection_count(), 0);
+    }
+
+    #[test]
+    fn mark_draining_sets_flag() {
+        let route = Route::new("api.example.com", addr(3000), false, None);
+        route.mark_draining();
+        assert!(route.is_draining());
+    }
+
+    #[test]
+    fn active_connections_increment_decrement() {
+        let route = Route::new("api.example.com", addr(3000), false, None);
+        route.active_connections.fetch_add(1, Ordering::Relaxed);
+        route.active_connections.fetch_add(1, Ordering::Relaxed);
+        assert_eq!(route.active_connection_count(), 2);
+
+        route.active_connections.fetch_sub(1, Ordering::Relaxed);
+        assert_eq!(route.active_connection_count(), 1);
+
+        route.active_connections.fetch_sub(1, Ordering::Relaxed);
+        assert_eq!(route.active_connection_count(), 0);
+    }
+
+    #[test]
+    fn cloned_route_shares_drain_state() {
+        let route = Route::new("api.example.com", addr(3000), false, None);
+        let cloned = route.clone();
+
+        // Marking the original draining should be visible through the clone
+        // because both share the same Arc<AtomicBool>.
+        route.mark_draining();
+        assert!(cloned.is_draining());
+
+        // Same for active connections
+        route.active_connections.fetch_add(1, Ordering::Relaxed);
+        assert_eq!(cloned.active_connection_count(), 1);
+    }
+
+    #[test]
+    fn domain_keys_returns_all_domains() {
+        let table = RouteTable::new(vec![
+            Route::new("a.example.com", addr(3000), false, None),
+            Route::new("b.example.com", addr(4000), false, None),
+        ]);
+        let mut keys: Vec<&str> = table.domain_keys().collect();
+        keys.sort_unstable();
+        assert_eq!(keys, vec!["a.example.com", "b.example.com"]);
+    }
+
+    #[test]
+    fn get_exact_finds_route() {
+        let table = RouteTable::new(vec![Route::new("api.example.com", addr(3000), false, None)]);
+        assert!(table.get_exact("api.example.com").is_some());
+        assert!(table.get_exact("other.com").is_none());
     }
 }


### PR DESCRIPTION
## Summary

- Track active connections per-route with `AtomicU32`, draining flag with `AtomicBool`
- `request_filter()` rejects new requests to draining routes with 502
- `logging()` decrements active connection counter on request completion
- `drain_removed_routes()` compares old/new route tables on reload, spawns background drain tasks
- Configurable `drain_timeout` in Dwaarfile global block (default 30s)

## Test plan

- [x] 712 workspace tests passing (13 new drain-specific)
- [x] fmt, clippy, full test suite verified independently