### PR TITLE
feat(config): slow loris protection via connection timeouts (ISSUE-076)

### DIFF
--- a/crates/dwaar-cli/src/main.rs
+++ b/crates/dwaar-cli/src/main.rs
@@ -391,6 +391,8 @@ fn run_server(
         "feature flags resolved"
     );
 
+    let timeouts = extract_timeouts(dwaar_config);
+
     let proxy = DwaarProxy::new(
         route_table,
         challenge_solver.clone(),
@@ -401,9 +403,24 @@ fn run_server(
         plugin_chain,
         prometheus.clone(),
         cache_backend,
+        u64::from(timeouts.keepalive_secs),
+        u64::from(timeouts.body_secs),
     );
 
     let mut proxy_service = pingora_proxy::http_proxy_service(&server.configuration, proxy);
+
+    // Slow loris protection (ISSUE-076): set max keepalive requests via Pingora's
+    // HttpServerOptions. This caps how many requests a single kept-alive connection
+    // can serve before Dwaar forces a reconnect — prevents per-connection memory
+    // accumulation from long-lived connections.
+    {
+        use pingora_core::apps::HttpServerOptions;
+        let mut opts = HttpServerOptions::default();
+        opts.keepalive_request_limit = Some(timeouts.max_requests);
+        if let Some(app) = proxy_service.app_logic_mut() {
+            app.server_options = Some(opts);
+        }
+    }
 
     // Bind listeners from the `bind` directive, falling back to 0.0.0.0:6188
     // when no site specifies one. Multiple workers each bind the same TCP
@@ -671,6 +688,18 @@ fn extract_drain_timeout(config: &dwaar_config::model::DwaarConfig) -> u64 {
         .as_ref()
         .and_then(|g| g.drain_timeout_secs)
         .unwrap_or(30)
+}
+
+/// Extract connection timeouts from the global options.
+/// Returns defaults (matching nginx) when not specified.
+fn extract_timeouts(
+    config: &dwaar_config::model::DwaarConfig,
+) -> dwaar_config::model::TimeoutsConfig {
+    config
+        .global_options
+        .as_ref()
+        .and_then(|g| g.timeouts.clone())
+        .unwrap_or_default()
 }
 
 fn setup_tls_listener(

--- a/crates/dwaar-config/src/model.rs
+++ b/crates/dwaar-config/src/model.rs
@@ -33,9 +33,40 @@ pub struct GlobalOptions {
     /// How long to wait for in-flight requests before force-closing a
     /// removed route (ISSUE-075). Default: 30 seconds.
     pub drain_timeout_secs: Option<u64>,
+    /// Connection-level timeouts for slow loris protection (ISSUE-076).
+    pub timeouts: Option<TimeoutsConfig>,
     /// Options we recognized but don't act on — stored so we never error
     /// on valid Caddyfile syntax we haven't implemented yet.
     pub passthrough: Vec<(String, Vec<String>)>,
+}
+
+/// Connection-level timeouts for slow loris protection (ISSUE-076).
+///
+/// Controls how long Dwaar waits for slow or idle client connections.
+/// Values that map to Pingora's session-level APIs are applied per-request;
+/// `max_requests` maps to `HttpServerOptions::keepalive_request_limit`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TimeoutsConfig {
+    /// Max seconds to receive complete request headers. Pingora's `read_timeout`
+    /// covers this phase on a fresh connection (default: 60s in Pingora).
+    pub header_secs: u32,
+    /// Max seconds to receive complete request body.
+    pub body_secs: u32,
+    /// Max idle seconds on a keep-alive connection between requests.
+    pub keepalive_secs: u32,
+    /// Max requests per keep-alive connection before forcing a reconnect.
+    pub max_requests: u32,
+}
+
+impl Default for TimeoutsConfig {
+    fn default() -> Self {
+        Self {
+            header_secs: 10,
+            body_secs: 30,
+            keepalive_secs: 60,
+            max_requests: 1000,
+        }
+    }
 }
 
 /// A fully parsed Dwaarfile — an optional global options block followed

--- a/crates/dwaar-config/src/parser/mod.rs
+++ b/crates/dwaar-config/src/parser/mod.rs
@@ -41,8 +41,8 @@ mod transforms;
 mod tests;
 
 use crate::error::{ParseError, ParseErrorKind, suggest_directive};
-use crate::model::{Directive, DwaarConfig, GlobalOptions, SiteBlock};
-use crate::token::{TokenKind, Tokenizer};
+use crate::model::{Directive, DwaarConfig, GlobalOptions, SiteBlock, TimeoutsConfig};
+use crate::token::{Token, TokenKind, Tokenizer};
 
 use helpers::skip_brace_block;
 
@@ -195,6 +195,9 @@ fn parse_global_option_line(
             })?;
             opts.drain_timeout_secs = Some(secs);
         }
+        "timeouts" => {
+            opts.timeouts = Some(parse_timeouts_block(t, &key_tok)?);
+        }
         // Unknown option — collect args, consume sub-blocks
         _ => {
             let args = collect_global_passthrough_args(t);
@@ -286,6 +289,7 @@ fn is_global_option_key(w: &str) -> bool {
             | "events"
             | "filesystem"
             | "drain_timeout"
+            | "timeouts"
     )
 }
 
@@ -299,6 +303,108 @@ fn parse_duration_secs(s: &str) -> Option<u64> {
     } else {
         s.parse().ok()
     }
+}
+
+/// Parse a duration value for a `timeouts` sub-key like `header 10s`.
+fn parse_timeout_duration(val: &str, directive: &str, tok: &Token) -> Result<u32, ParseError> {
+    let secs = parse_duration_secs(val).ok_or(ParseError {
+        line: tok.line,
+        col: tok.col,
+        kind: ParseErrorKind::InvalidValue {
+            directive: directive.to_string(),
+            message: format!("'{val}' is not a valid duration (e.g. '10s', '1m')"),
+        },
+    })?;
+    Ok(u32::try_from(secs).unwrap_or(u32::MAX))
+}
+
+/// Parse the `timeouts { header 10s; body 30s; keepalive 60s; max_requests 1000 }` block.
+/// Starts with defaults matching nginx, then overrides with whatever the user specifies.
+fn parse_timeouts_block(
+    t: &mut Tokenizer<'_>,
+    _key_tok: &Token,
+) -> Result<TimeoutsConfig, ParseError> {
+    let brace = t.peek();
+    if brace.kind != TokenKind::OpenBrace {
+        return Err(ParseError {
+            line: brace.line,
+            col: brace.col,
+            kind: ParseErrorKind::InvalidValue {
+                directive: "timeouts".to_string(),
+                message: "expected '{' after 'timeouts'".to_string(),
+            },
+        });
+    }
+    t.next_token();
+
+    let mut cfg = TimeoutsConfig::default();
+
+    loop {
+        let tok = t.peek();
+        match &tok.kind {
+            TokenKind::CloseBrace => {
+                t.next_token();
+                break;
+            }
+            TokenKind::Eof => {
+                return Err(ParseError {
+                    line: tok.line,
+                    col: tok.col,
+                    kind: ParseErrorKind::UnexpectedEof {
+                        expected: "'}' to close timeouts block".to_string(),
+                    },
+                });
+            }
+            TokenKind::Word(_) => {
+                let sub_tok = t.next_token();
+                let sub_key = match &sub_tok.kind {
+                    TokenKind::Word(w) => w.clone(),
+                    _ => unreachable!(),
+                };
+                let val = peek_consume_word_or_quoted(t);
+                match sub_key.as_str() {
+                    "header" => {
+                        cfg.header_secs =
+                            parse_timeout_duration(&val, "timeouts.header", &sub_tok)?;
+                    }
+                    "body" => {
+                        cfg.body_secs = parse_timeout_duration(&val, "timeouts.body", &sub_tok)?;
+                    }
+                    "keepalive" => {
+                        cfg.keepalive_secs =
+                            parse_timeout_duration(&val, "timeouts.keepalive", &sub_tok)?;
+                    }
+                    "max_requests" => {
+                        cfg.max_requests = val.parse::<u32>().map_err(|_| ParseError {
+                            line: sub_tok.line,
+                            col: sub_tok.col,
+                            kind: ParseErrorKind::InvalidValue {
+                                directive: "timeouts.max_requests".to_string(),
+                                message: format!("'{val}' is not a valid integer"),
+                            },
+                        })?;
+                    }
+                    other => {
+                        return Err(ParseError {
+                            line: sub_tok.line,
+                            col: sub_tok.col,
+                            kind: ParseErrorKind::InvalidValue {
+                                directive: "timeouts".to_string(),
+                                message: format!(
+                                    "unknown timeout key '{other}' — expected header, body, keepalive, or max_requests"
+                                ),
+                            },
+                        });
+                    }
+                }
+            }
+            _ => {
+                t.next_token();
+            }
+        }
+    }
+
+    Ok(cfg)
 }
 
 /// Parse one site block: `address { directive* }`

--- a/crates/dwaar-config/src/parser/tests.rs
+++ b/crates/dwaar-config/src/parser/tests.rs
@@ -1276,3 +1276,106 @@ fn drain_timeout_default_when_absent() {
     let opts = config.global_options.as_ref().expect("has global options");
     assert_eq!(opts.drain_timeout_secs, None);
 }
+
+// ── timeouts (ISSUE-076) ────────────────────────────────────────────────────
+
+#[test]
+fn timeouts_all_fields() {
+    let input = r"
+{
+    timeouts {
+        header 10s
+        body 30s
+        keepalive 60s
+        max_requests 1000
+    }
+}
+a.com {
+    reverse_proxy :3000
+}
+";
+    let config = parse(input).expect("should parse");
+    let opts = config.global_options.as_ref().expect("has global options");
+    let t = opts.timeouts.as_ref().expect("has timeouts");
+    assert_eq!(t.header_secs, 10);
+    assert_eq!(t.body_secs, 30);
+    assert_eq!(t.keepalive_secs, 60);
+    assert_eq!(t.max_requests, 1000);
+}
+
+#[test]
+fn timeouts_partial_override() {
+    let input = "{\n    timeouts {\n        header 5s\n        max_requests 500\n    }\n}\na.com {\n    reverse_proxy :3000\n}\n";
+    let config = parse(input).expect("should parse");
+    let t = config
+        .global_options
+        .as_ref()
+        .expect("global")
+        .timeouts
+        .as_ref()
+        .expect("timeouts");
+    assert_eq!(t.header_secs, 5);
+    assert_eq!(t.body_secs, 30); // default
+    assert_eq!(t.keepalive_secs, 60); // default
+    assert_eq!(t.max_requests, 500);
+}
+
+#[test]
+fn timeouts_duration_minutes() {
+    let input = "{\n    timeouts {\n        keepalive 2m\n        body 1m\n    }\n}\na.com {\n    reverse_proxy :3000\n}\n";
+    let config = parse(input).expect("should parse");
+    let t = config
+        .global_options
+        .as_ref()
+        .expect("global")
+        .timeouts
+        .as_ref()
+        .expect("timeouts");
+    assert_eq!(t.keepalive_secs, 120);
+    assert_eq!(t.body_secs, 60);
+}
+
+#[test]
+fn timeouts_bare_number() {
+    let input =
+        "{\n    timeouts {\n        header 15\n    }\n}\na.com {\n    reverse_proxy :3000\n}\n";
+    let config = parse(input).expect("should parse");
+    let t = config
+        .global_options
+        .as_ref()
+        .expect("global")
+        .timeouts
+        .as_ref()
+        .expect("timeouts");
+    assert_eq!(t.header_secs, 15);
+}
+
+#[test]
+fn timeouts_absent_means_none() {
+    let input = "{\n    debug\n}\na.com {\n    reverse_proxy :3000\n}\n";
+    let config = parse(input).expect("should parse");
+    let opts = config.global_options.as_ref().expect("global");
+    assert!(opts.timeouts.is_none());
+}
+
+#[test]
+fn timeouts_invalid_duration_errors() {
+    let input =
+        "{\n    timeouts {\n        header abc\n    }\n}\na.com {\n    reverse_proxy :3000\n}\n";
+    let err = parse(input).expect_err("should fail");
+    assert!(
+        format!("{err:?}").contains("timeouts.header"),
+        "error should mention timeouts.header"
+    );
+}
+
+#[test]
+fn timeouts_unknown_key_errors() {
+    let input =
+        "{\n    timeouts {\n        unknown 10s\n    }\n}\na.com {\n    reverse_proxy :3000\n}\n";
+    let err = parse(input).expect_err("should fail");
+    assert!(
+        format!("{err:?}").contains("unknown timeout key"),
+        "error should mention unknown key"
+    );
+}

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -85,6 +85,12 @@ pub struct DwaarProxy {
     prometheus: Option<Arc<dwaar_analytics::prometheus::PrometheusMetrics>>,
     /// HTTP cache backend (ISSUE-073). `None` when no route has `cache {}` or `--no-cache`.
     cache_backend: Option<crate::cache::CacheBackend>,
+    /// Downstream keepalive timeout in seconds (ISSUE-076). Overrides
+    /// Pingora's hardcoded 60s default per keep-alive connection.
+    keepalive_secs: u64,
+    /// Downstream body read timeout (ISSUE-076). Applied after headers
+    /// arrive so slow body senders get disconnected.
+    body_timeout: std::time::Duration,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -99,6 +105,8 @@ impl DwaarProxy {
         plugin_chain: Arc<PluginChain>,
         prometheus: Option<Arc<dwaar_analytics::prometheus::PrometheusMetrics>>,
         cache_backend: Option<crate::cache::CacheBackend>,
+        keepalive_secs: u64,
+        body_timeout_secs: u64,
     ) -> Self {
         Self {
             route_table,
@@ -110,6 +118,8 @@ impl DwaarProxy {
             plugin_chain,
             prometheus,
             cache_backend,
+            keepalive_secs,
+            body_timeout: std::time::Duration::from_secs(body_timeout_secs),
         }
     }
 }
@@ -367,6 +377,16 @@ impl ProxyHttp for DwaarProxy {
     where
         Self::CTX: Send + Sync,
     {
+        // Slow loris protection (ISSUE-076): override Pingora defaults with
+        // user-configured keepalive and body read timeouts. Headers are already
+        // read by the time request_filter() runs, so `header` timeout is handled
+        // by Pingora's built-in read_timeout during read_request(). The body
+        // timeout applies to subsequent reads; keepalive applies between requests.
+        session.set_keepalive(Some(self.keepalive_secs));
+        session
+            .downstream_session
+            .set_read_timeout(Some(self.body_timeout));
+
         // --- Populate core identity fields ---
         ctx.plugin_ctx.client_ip = session
             .client_addr()
@@ -1608,6 +1628,8 @@ mod tests {
             chain,
             None,
             None,
+            60, // keepalive_secs
+            30, // body_timeout_secs
         )
     }
 


### PR DESCRIPTION
## Summary

- Parse `timeouts {}` block in Dwaarfile global options (header, body, keepalive, max_requests)
- Wire `keepalive_timeout` via `session.set_keepalive()` in request_filter
- Wire `body_timeout` via `session.downstream_session.set_read_timeout()` 
- Wire `max_requests` via `HttpServerOptions.keepalive_request_limit`
- `header` timeout parsed and stored (Pingora doesn't expose pre-header-read hook yet)

## Test plan
- [x] 719 tests passing (7 new parser tests)
- [x] fmt, clippy, tests verified independently