### PR TITLE
feat(tls): mutual TLS for upstream connections (ISSUE-077)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,6 +1009,7 @@ dependencies = [
  "criterion",
  "dwaar-core",
  "dwaar-plugins",
+ "dwaar-tls",
  "notify",
  "openssl",
  "pingora-core",

--- a/crates/dwaar-config/Cargo.toml
+++ b/crates/dwaar-config/Cargo.toml
@@ -15,6 +15,7 @@ bytes = { workspace = true }
 compact_str = { workspace = true }
 dwaar-core = { workspace = true }
 dwaar-plugins = { workspace = true }
+dwaar-tls = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/dwaar-config/src/compile.rs
+++ b/crates/dwaar-config/src/compile.rs
@@ -803,7 +803,9 @@ fn compile_reverse_proxy_handler(rp: &ReverseProxyDirective, location: &str) -> 
         || rp.fail_duration.is_some()
         || rp.max_conns.is_some()
         || rp.transport_tls
-        || rp.tls_server_name.is_some();
+        || rp.tls_server_name.is_some()
+        || rp.tls_client_auth.is_some()
+        || rp.tls_trusted_ca_certs.is_some();
 
     if rp.upstreams.len() <= 1 && !is_block_form {
         // Common single-upstream case — zero overhead path.
@@ -822,6 +824,42 @@ fn compile_reverse_proxy_handler(rp: &ReverseProxyDirective, location: &str) -> 
     let tls = rp.transport_tls;
     let sni = rp.tls_server_name.clone().unwrap_or_default();
 
+    // Load and validate mTLS client cert+key at config time (Guardrail #18).
+    let client_cert_key = if let Some((ref cert_path, ref key_path)) = rp.tls_client_auth {
+        match dwaar_tls::mtls::load_client_cert_key(cert_path.as_ref(), key_path.as_ref()) {
+            Ok(ck) => Some(Arc::new(ck)),
+            Err(e) => {
+                warn!(
+                    location,
+                    cert = %cert_path,
+                    error = %e,
+                    "failed to load mTLS client cert, skipping site"
+                );
+                return None;
+            }
+        }
+    } else {
+        None
+    };
+
+    // Load custom CA bundle for upstream cert verification.
+    let trusted_ca = if let Some(ref ca_path) = rp.tls_trusted_ca_certs {
+        match dwaar_tls::mtls::load_ca_certs(ca_path.as_ref()) {
+            Ok(cas) => Some(cas),
+            Err(e) => {
+                warn!(
+                    location,
+                    ca_path = %ca_path,
+                    error = %e,
+                    "failed to load trusted CA certs, skipping site"
+                );
+                return None;
+            }
+        }
+    } else {
+        None
+    };
+
     let backends = addrs
         .into_iter()
         .map(|addr| BackendConfig {
@@ -829,6 +867,8 @@ fn compile_reverse_proxy_handler(rp: &ReverseProxyDirective, location: &str) -> 
             max_conns: rp.max_conns,
             tls,
             tls_server_name: sni.clone(),
+            client_cert_key: client_cert_key.clone(),
+            trusted_ca: trusted_ca.clone(),
         })
         .collect();
 
@@ -1193,6 +1233,8 @@ mod tests {
             max_conns: None,
             transport_tls: false,
             tls_server_name: None,
+            tls_client_auth: None,
+            tls_trusted_ca_certs: None,
         })
     }
 
@@ -1209,6 +1251,8 @@ mod tests {
             max_conns: None,
             transport_tls: false,
             tls_server_name: None,
+            tls_client_auth: None,
+            tls_trusted_ca_certs: None,
         })
     }
 
@@ -1222,6 +1266,8 @@ mod tests {
             max_conns: None,
             transport_tls: false,
             tls_server_name: None,
+            tls_client_auth: None,
+            tls_trusted_ca_certs: None,
         })
     }
 
@@ -1306,6 +1352,8 @@ mod tests {
                     max_conns: None,
                     transport_tls: false,
                     tls_server_name: None,
+                    tls_client_auth: None,
+                    tls_trusted_ca_certs: None,
                 })],
             }],
         };

--- a/crates/dwaar-config/src/format.rs
+++ b/crates/dwaar-config/src/format.rs
@@ -150,6 +150,8 @@ fn format_reverse_proxy(out: &mut String, rp: &ReverseProxyDirective) {
         || rp.max_conns.is_some()
         || rp.transport_tls
         || rp.tls_server_name.is_some()
+        || rp.tls_client_auth.is_some()
+        || rp.tls_trusted_ca_certs.is_some()
         || rp.upstreams.len() > 1;
 
     if has_block_options {
@@ -196,14 +198,29 @@ fn format_reverse_proxy(out: &mut String, rp: &ReverseProxyDirective) {
             out.push_str(&max.to_string());
             out.push('\n');
         }
-        if rp.transport_tls || rp.tls_server_name.is_some() {
+        let has_transport = rp.transport_tls
+            || rp.tls_server_name.is_some()
+            || rp.tls_client_auth.is_some()
+            || rp.tls_trusted_ca_certs.is_some();
+        if has_transport {
             out.push_str("\t\ttransport {\n");
+            out.push_str("\t\t\ttls\n");
             if let Some(ref sni) = rp.tls_server_name {
                 out.push_str("\t\t\ttls_server_name ");
                 out.push_str(sni);
                 out.push('\n');
-            } else {
-                out.push_str("\t\t\ttls\n");
+            }
+            if let Some((ref cert, ref key)) = rp.tls_client_auth {
+                out.push_str("\t\t\ttls_client_auth ");
+                out.push_str(cert);
+                out.push(' ');
+                out.push_str(key);
+                out.push('\n');
+            }
+            if let Some(ref ca) = rp.tls_trusted_ca_certs {
+                out.push_str("\t\t\ttls_trusted_ca_certs ");
+                out.push_str(ca);
+                out.push('\n');
             }
             out.push_str("\t\t}\n");
         }

--- a/crates/dwaar-config/src/model.rs
+++ b/crates/dwaar-config/src/model.rs
@@ -427,6 +427,11 @@ pub struct ReverseProxyDirective {
     pub transport_tls: bool,
     /// SNI hostname to use for upstream TLS connections.
     pub tls_server_name: Option<String>,
+    /// Client cert+key paths for mutual TLS with the upstream.
+    /// `(cert_path, key_path)` — loaded and validated at compile time.
+    pub tls_client_auth: Option<(String, String)>,
+    /// Custom CA bundle path for upstream cert verification.
+    pub tls_trusted_ca_certs: Option<String>,
 }
 
 /// An upstream address — either a socket address or a host:port string
@@ -886,6 +891,8 @@ mod tests {
                     max_conns: None,
                     transport_tls: false,
                     tls_server_name: None,
+                    tls_client_auth: None,
+                    tls_trusted_ca_certs: None,
                 }),
                 Directive::Tls(TlsDirective::Auto),
             ],

--- a/crates/dwaar-config/src/parser/directives.rs
+++ b/crates/dwaar-config/src/parser/directives.rs
@@ -89,6 +89,8 @@ fn parse_reverse_proxy_inline(t: &mut Tokenizer<'_>) -> Result<ReverseProxyDirec
         max_conns: None,
         transport_tls: false,
         tls_server_name: None,
+        tls_client_auth: None,
+        tls_trusted_ca_certs: None,
     })
 }
 
@@ -122,6 +124,8 @@ fn parse_reverse_proxy_block(t: &mut Tokenizer<'_>) -> Result<ReverseProxyDirect
     let mut max_conns: Option<u32> = None;
     let mut transport_tls = false;
     let mut tls_server_name: Option<String> = None;
+    let mut tls_client_auth: Option<(String, String)> = None;
+    let mut tls_trusted_ca_certs: Option<String> = None;
 
     loop {
         let tok = t.next_token();
@@ -242,6 +246,27 @@ fn parse_reverse_proxy_block(t: &mut Tokenizer<'_>) -> Result<ReverseProxyDirect
                                         tls_server_name = Some(sni);
                                     }
                                 }
+                                TokenKind::Word(ref kw) if kw == "tls_client_auth" => {
+                                    transport_tls = true;
+                                    let cert_tok = t.next_token();
+                                    let key_tok = t.next_token();
+                                    if let (
+                                        TokenKind::Word(cert) | TokenKind::QuotedString(cert),
+                                        TokenKind::Word(key) | TokenKind::QuotedString(key),
+                                    ) = (cert_tok.kind, key_tok.kind)
+                                    {
+                                        tls_client_auth = Some((cert, key));
+                                    }
+                                }
+                                TokenKind::Word(ref kw) if kw == "tls_trusted_ca_certs" => {
+                                    transport_tls = true;
+                                    let ca_tok = t.next_token();
+                                    if let TokenKind::Word(ca) | TokenKind::QuotedString(ca) =
+                                        ca_tok.kind
+                                    {
+                                        tls_trusted_ca_certs = Some(ca);
+                                    }
+                                }
                                 // Skip unknown transport sub-directives gracefully
                                 _ => {}
                             }
@@ -295,6 +320,8 @@ fn parse_reverse_proxy_block(t: &mut Tokenizer<'_>) -> Result<ReverseProxyDirect
         max_conns,
         transport_tls,
         tls_server_name,
+        tls_client_auth,
+        tls_trusted_ca_certs,
     })
 }
 

--- a/crates/dwaar-config/src/parser/tests.rs
+++ b/crates/dwaar-config/src/parser/tests.rs
@@ -1033,6 +1033,88 @@ fn reverse_proxy_block_transport_plain_tls() {
 }
 
 #[test]
+fn reverse_proxy_block_transport_tls_client_auth() {
+    let config = parse(
+        "a.com {
+            reverse_proxy {
+                to backend:8443
+                transport {
+                    tls
+                    tls_client_auth /path/to/client.pem /path/to/client-key.pem
+                    tls_server_name backend.internal
+                }
+            }
+        }",
+    )
+    .expect("should parse");
+    let Directive::ReverseProxy(rp) = &config.sites[0].directives[0] else {
+        panic!("expected ReverseProxy");
+    };
+    assert!(rp.transport_tls);
+    assert_eq!(rp.tls_server_name.as_deref(), Some("backend.internal"));
+    assert_eq!(
+        rp.tls_client_auth
+            .as_ref()
+            .map(|(c, k)| (c.as_str(), k.as_str())),
+        Some(("/path/to/client.pem", "/path/to/client-key.pem"))
+    );
+}
+
+#[test]
+fn reverse_proxy_block_transport_tls_trusted_ca() {
+    let config = parse(
+        "a.com {
+            reverse_proxy {
+                to backend:8443
+                transport {
+                    tls
+                    tls_trusted_ca_certs /path/to/ca.pem
+                }
+            }
+        }",
+    )
+    .expect("should parse");
+    let Directive::ReverseProxy(rp) = &config.sites[0].directives[0] else {
+        panic!("expected ReverseProxy");
+    };
+    assert!(rp.transport_tls);
+    assert_eq!(rp.tls_trusted_ca_certs.as_deref(), Some("/path/to/ca.pem"));
+}
+
+#[test]
+fn reverse_proxy_block_transport_full_mtls() {
+    let config = parse(
+        r#"a.com {
+            reverse_proxy {
+                to backend:8443
+                transport {
+                    tls
+                    tls_client_auth "/certs/client.pem" "/certs/client-key.pem"
+                    tls_server_name backend.internal
+                    tls_trusted_ca_certs "/certs/ca-bundle.pem"
+                }
+            }
+        }"#,
+    )
+    .expect("should parse");
+    let Directive::ReverseProxy(rp) = &config.sites[0].directives[0] else {
+        panic!("expected ReverseProxy");
+    };
+    assert!(rp.transport_tls);
+    assert_eq!(rp.tls_server_name.as_deref(), Some("backend.internal"));
+    assert_eq!(
+        rp.tls_client_auth
+            .as_ref()
+            .map(|(c, k)| (c.as_str(), k.as_str())),
+        Some(("/certs/client.pem", "/certs/client-key.pem"))
+    );
+    assert_eq!(
+        rp.tls_trusted_ca_certs.as_deref(),
+        Some("/certs/ca-bundle.pem")
+    );
+}
+
+#[test]
 fn reverse_proxy_block_multi_upstream() {
     let config = parse(
         "a.com {

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -1059,29 +1059,27 @@ impl ProxyHttp for DwaarProxy {
         // Determine TLS settings from the pool (if this is a pool-backed route).
         // Single-backend routes that were compiled as plain `ReverseProxy` use
         // no TLS by default — transport TLS must be configured explicitly.
-        let (use_tls, sni) = if let Some(ref pool) = ctx.upstream_pool {
-            // Re-select from the pool to get TLS metadata for the chosen backend.
+        let (use_tls, sni, client_cert_key, trusted_ca) = if let Some(ref pool) = ctx.upstream_pool
+        {
+            // Find the backend matching the selected address to get its TLS metadata.
             // The address was already selected in request_filter(), so this scan
-            // is a O(n) match on the small backends Vec — not on the hot path.
-            let tls = pool
-                .backends
-                .iter()
-                .find(|b| b.addr == upstream)
-                .is_some_and(|b| b.tls);
-            let sni = pool
-                .backends
-                .iter()
-                .find(|b| b.addr == upstream)
+            // is O(n) on the small backends Vec — not on the hot path.
+            let backend = pool.backends.iter().find(|b| b.addr == upstream);
+            let tls = backend.is_some_and(|b| b.tls);
+            let sni = backend
                 .map(|b| b.tls_server_name.clone())
                 .unwrap_or_default();
-            (tls, sni)
+            let ck = backend.and_then(|b| b.client_cert_key.clone());
+            let ca = backend.and_then(|b| b.trusted_ca.clone());
+            (tls, sni, ck, ca)
         } else {
-            (false, String::new())
+            (false, String::new(), None, None)
         };
 
         debug!(
             upstream = %upstream,
             tls = use_tls,
+            mtls = client_cert_key.is_some(),
             request_id = %ctx.request_id(),
             "route resolved"
         );
@@ -1090,6 +1088,15 @@ impl ProxyHttp for DwaarProxy {
         peer.options.connection_timeout = Some(std::time::Duration::from_secs(10));
         peer.options.read_timeout = Some(std::time::Duration::from_secs(30));
         peer.options.write_timeout = Some(std::time::Duration::from_secs(30));
+
+        // Wire mTLS client cert into the peer (ISSUE-077)
+        if let Some(ck) = client_cert_key {
+            peer.client_cert_key = Some(ck);
+        }
+        // Custom CA bundle for upstream server cert verification (ISSUE-077)
+        if let Some(ca) = trusted_ca {
+            peer.options.ca = Some(ca);
+        }
 
         // Detect dead upstream connections via TCP keepalive probes instead of
         // waiting for read_timeout (30s) on a silently broken connection.

--- a/crates/dwaar-core/src/upstream.rs
+++ b/crates/dwaar-core/src/upstream.rs
@@ -68,6 +68,10 @@ pub(crate) struct Backend {
     pub(crate) tls: bool,
     /// SNI hostname for TLS. Empty string = use `addr.ip()` as SNI.
     pub(crate) tls_server_name: String,
+    /// Client cert+key for mTLS handshake with this backend (ISSUE-077).
+    pub(crate) client_cert_key: Option<Arc<pingora_core::utils::tls::CertKey>>,
+    /// Custom CA certs for verifying this backend's server cert (ISSUE-077).
+    pub(crate) trusted_ca: Option<Arc<pingora_core::protocols::tls::CaType>>,
 }
 
 /// The result of a successful backend selection.
@@ -76,6 +80,10 @@ pub struct SelectedUpstream {
     pub addr: SocketAddr,
     pub tls: bool,
     pub sni: String,
+    /// Client cert+key for mTLS (ISSUE-077). `None` for plain TLS.
+    pub client_cert_key: Option<Arc<pingora_core::utils::tls::CertKey>>,
+    /// Custom CA for upstream server cert verification (ISSUE-077).
+    pub trusted_ca: Option<Arc<pingora_core::protocols::tls::CaType>>,
 }
 
 impl UpstreamPool {
@@ -98,6 +106,8 @@ impl UpstreamPool {
                 max_conns: b.max_conns,
                 tls: b.tls,
                 tls_server_name: b.tls_server_name,
+                client_cert_key: b.client_cert_key,
+                trusted_ca: b.trusted_ca,
             })
             .collect();
 
@@ -157,6 +167,8 @@ impl UpstreamPool {
             addr: b.addr,
             tls: b.tls,
             sni: b.tls_server_name.clone(),
+            client_cert_key: b.client_cert_key.clone(),
+            trusted_ca: b.trusted_ca.clone(),
         })
     }
 
@@ -192,6 +204,8 @@ impl UpstreamPool {
             addr: best.addr,
             tls: best.tls,
             sni: best.tls_server_name.clone(),
+            client_cert_key: best.client_cert_key.clone(),
+            trusted_ca: best.trusted_ca.clone(),
         })
     }
 
@@ -216,6 +230,8 @@ impl UpstreamPool {
             addr: b.addr,
             tls: b.tls,
             sni: b.tls_server_name.clone(),
+            client_cert_key: b.client_cert_key.clone(),
+            trusted_ca: b.trusted_ca.clone(),
         })
     }
 
@@ -251,6 +267,8 @@ impl UpstreamPool {
                 addr: b.addr,
                 tls: b.tls,
                 sni: b.tls_server_name.clone(),
+                client_cert_key: b.client_cert_key.clone(),
+                trusted_ca: b.trusted_ca.clone(),
             });
         }
         None
@@ -356,6 +374,10 @@ pub struct BackendConfig {
     pub max_conns: Option<u32>,
     pub tls: bool,
     pub tls_server_name: String,
+    /// Pre-loaded client cert+key for mTLS (ISSUE-077). Compiled at config time.
+    pub client_cert_key: Option<Arc<pingora_core::utils::tls::CertKey>>,
+    /// Pre-loaded CA certs for upstream server verification (ISSUE-077).
+    pub trusted_ca: Option<Arc<pingora_core::protocols::tls::CaType>>,
 }
 
 // ── FNV-1a IP hash ────────────────────────────────────────────────────────────
@@ -558,6 +580,8 @@ mod tests {
                 max_conns: None,
                 tls: false,
                 tls_server_name: String::new(),
+                client_cert_key: None,
+                trusted_ca: None,
             })
             .collect();
         UpstreamPool::new(backends, policy, None, None)
@@ -570,6 +594,8 @@ mod tests {
                 max_conns: Some(max_conns),
                 tls: false,
                 tls_server_name: String::new(),
+                client_cert_key: None,
+                trusted_ca: None,
             }],
             LbPolicy::RoundRobin,
             None,

--- a/crates/dwaar-tls/src/lib.rs
+++ b/crates/dwaar-tls/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod acme;
 pub mod cert_store;
+pub mod mtls;
 pub mod ocsp;
 pub mod sni;
 

--- a/crates/dwaar-tls/src/mtls.rs
+++ b/crates/dwaar-tls/src/mtls.rs
@@ -1,0 +1,181 @@
+// Copyright (C) 2026 Permanu
+// SPDX-License-Identifier: BSL-1.1
+//
+// This file is part of Dwaar — https://dwaar.dev
+// Licensed under the Business Source License 1.1
+
+//! Client certificate loading and validation for mutual TLS (mTLS).
+//!
+//! Used when a `reverse_proxy` transport block configures `tls_client_auth` —
+//! the upstream requires the proxy to present a client certificate during the
+//! TLS handshake. Certs and keys are loaded from PEM files at config time,
+//! validated for key/cert match (Guardrail #18), and compiled into Pingora's
+//! `CertKey` type for injection into `HttpPeer`.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use openssl::pkey::PKey;
+use openssl::x509::X509;
+use pingora_core::protocols::tls::CaType;
+use pingora_core::utils::tls::CertKey;
+use thiserror::Error;
+use tracing::{debug, warn};
+
+#[derive(Error, Debug)]
+pub enum MtlsError {
+    #[error("failed to read file: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("invalid PEM: {0}")]
+    Pem(#[from] openssl::error::ErrorStack),
+
+    #[error("cert PEM contains no certificates")]
+    EmptyCert,
+
+    #[error("cert/key mismatch — the private key does not match the certificate's public key")]
+    KeyMismatch,
+
+    #[error("certificate is expired")]
+    Expired,
+}
+
+/// Load a client cert+key pair from PEM files and validate they match.
+///
+/// Performs all Guardrail #18 checks: cert/key match via public key equality,
+/// expiry warning. Returns Pingora's `CertKey` ready for `HttpPeer`.
+pub fn load_client_cert_key(cert_path: &Path, key_path: &Path) -> Result<CertKey, MtlsError> {
+    let cert_pem = std::fs::read(cert_path)?;
+    let key_pem = std::fs::read(key_path)?;
+
+    let certs = X509::stack_from_pem(&cert_pem)?;
+    if certs.is_empty() {
+        return Err(MtlsError::EmptyCert);
+    }
+
+    let key = PKey::private_key_from_pem(&key_pem)?;
+
+    // Guardrail #18: validate cert/key match via public key equality
+    let cert_pubkey = certs[0].public_key()?;
+    if !cert_pubkey.public_eq(&key) {
+        return Err(MtlsError::KeyMismatch);
+    }
+
+    // Warn on expiry (still load — operators will see the warning)
+    if let Ok(now) = openssl::asn1::Asn1Time::days_from_now(0) {
+        if certs[0].not_after() < now {
+            warn!(cert = %cert_path.display(), "client certificate is expired");
+        } else if let Ok(soon) = openssl::asn1::Asn1Time::days_from_now(30)
+            && certs[0].not_after() < soon
+        {
+            warn!(cert = %cert_path.display(), "client certificate expires within 30 days");
+        }
+    }
+
+    // Log cert path at info level; key path is never logged (Guardrail #18)
+    debug!(cert = %cert_path.display(), "loaded mTLS client certificate");
+
+    Ok(CertKey::new(certs, key))
+}
+
+/// Load CA certificates from a PEM bundle for upstream server verification.
+///
+/// Returns the CA certs as an `Arc<CaType>` ready for `HttpPeer.options.ca`.
+pub fn load_ca_certs(ca_path: &Path) -> Result<Arc<CaType>, MtlsError> {
+    let ca_pem = std::fs::read(ca_path)?;
+    let cas = X509::stack_from_pem(&ca_pem)?;
+    if cas.is_empty() {
+        return Err(MtlsError::EmptyCert);
+    }
+
+    debug!(ca = %ca_path.display(), count = cas.len(), "loaded trusted CA certs");
+
+    Ok(Arc::new(cas.into_boxed_slice()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::generate_self_signed;
+
+    #[test]
+    fn load_valid_client_cert() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (cert_pem, key_pem) = generate_self_signed("client.test");
+
+        let cert_path = dir.path().join("client.pem");
+        let key_path = dir.path().join("client.key");
+        std::fs::write(&cert_path, &cert_pem).expect("write cert");
+        std::fs::write(&key_path, &key_pem).expect("write key");
+
+        let result = load_client_cert_key(&cert_path, &key_path);
+        assert!(result.is_ok(), "should load valid cert+key pair");
+    }
+
+    #[test]
+    fn reject_mismatched_cert_key() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (cert_pem, _) = generate_self_signed("client.test");
+        let (_, other_key_pem) = generate_self_signed("other.test");
+
+        let cert_path = dir.path().join("client.pem");
+        let key_path = dir.path().join("wrong.key");
+        std::fs::write(&cert_path, &cert_pem).expect("write cert");
+        std::fs::write(&key_path, &other_key_pem).expect("write key");
+
+        let result = load_client_cert_key(&cert_path, &key_path);
+        assert!(result.is_err());
+        let err = result.expect_err("should reject mismatched cert/key");
+        assert!(matches!(err, MtlsError::KeyMismatch));
+    }
+
+    #[test]
+    fn reject_empty_cert() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cert_path = dir.path().join("empty.pem");
+        let key_path = dir.path().join("some.key");
+
+        // Write a technically valid PEM file with no certs
+        std::fs::write(&cert_path, b"").expect("write empty");
+        let (_, key_pem) = generate_self_signed("x.test");
+        std::fs::write(&key_path, &key_pem).expect("write key");
+
+        let result = load_client_cert_key(&cert_path, &key_path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn reject_missing_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let result = load_client_cert_key(
+            &dir.path().join("nonexistent.pem"),
+            &dir.path().join("nonexistent.key"),
+        );
+        assert!(result.is_err());
+        let err = result.expect_err("should fail on missing file");
+        assert!(matches!(err, MtlsError::Io(_)));
+    }
+
+    #[test]
+    fn load_ca_certs_valid() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (_, _, ca_pem) = crate::test_util::generate_ca_signed("leaf.test");
+
+        let ca_path = dir.path().join("ca.pem");
+        std::fs::write(&ca_path, &ca_pem).expect("write ca");
+
+        let result = load_ca_certs(&ca_path);
+        assert!(result.is_ok());
+        assert!(!result.expect("loaded").is_empty());
+    }
+
+    #[test]
+    fn load_ca_certs_empty_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ca_path = dir.path().join("empty.pem");
+        std::fs::write(&ca_path, b"").expect("write empty");
+
+        let result = load_ca_certs(&ca_path);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- Parse `transport { tls_client_auth, tls_trusted_ca_certs, tls_server_name }` in reverse_proxy block
- Load + validate client cert/key match at config time (Guardrail #18)
- Wire `client_cert_key` and custom CA into `HttpPeer` in `upstream_peer()`
- New `dwaar-tls/src/mtls.rs` module for cert loading

## Test plan
- [x] All workspace tests passing (9 new mTLS tests)
- [x] fmt, clippy, tests verified independently
- [x] No key paths logged, no unwrap() in library code