### PR TITLE
feat(core): HTTP/3 QUIC scaffold with Alt-Svc header (ISSUE-079)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,7 +1048,10 @@ dependencies = [
  "pingora-http",
  "pingora-load-balancing",
  "pingora-proxy",
+ "quinn",
  "regex",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "tempfile",
@@ -1169,6 +1172,18 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+dependencies = [
+ "getrandom 0.3.4",
+ "libm",
+ "rand 0.9.2",
+ "siphasher",
 ]
 
 [[package]]
@@ -2003,6 +2018,12 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libz-ng-sys"
@@ -2903,6 +2924,7 @@ checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
+ "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
@@ -2910,6 +2932,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "slab",
  "thiserror 2.0.18",
  "tinyvec",
@@ -3287,6 +3310,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3961,6 +3993,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,12 @@ sonic-rs = "0.3"
 # Fast random number generation (no_std-compatible, used for Random LB policy)
 fastrand = "2"
 
+# QUIC / HTTP/3 (ISSUE-079) — quinn is the standard Rust QUIC implementation,
+# rustls provides TLS 1.3 for QUIC (OpenSSL doesn't support QUIC natively).
+quinn = "0.11"
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
+rustls-pemfile = "2"
+
 # Compression
 flate2 = "1.1.9"
 brotli = "8.0.2"

--- a/crates/dwaar-cli/src/main.rs
+++ b/crates/dwaar-cli/src/main.rs
@@ -393,6 +393,11 @@ fn run_server(
 
     let timeouts = extract_timeouts(dwaar_config);
 
+    let h3_enabled = dwaar_config
+        .global_options
+        .as_ref()
+        .is_some_and(|g| g.h3_enabled);
+
     let proxy = DwaarProxy::new(
         route_table,
         challenge_solver.clone(),
@@ -405,6 +410,7 @@ fn run_server(
         cache_backend,
         u64::from(timeouts.keepalive_secs),
         u64::from(timeouts.body_secs),
+        h3_enabled,
     );
 
     let mut proxy_service = pingora_proxy::http_proxy_service(&server.configuration, proxy);
@@ -458,6 +464,36 @@ fn run_server(
     }
 
     server.add_service(proxy_service);
+
+    // QUIC listener for HTTP/3 (ISSUE-079a). Uses the same PEM cert/key files
+    // as the TCP/TLS listener — both OpenSSL and rustls load PEM natively.
+    if h3_enabled {
+        let tls_configs = compile_tls_configs(dwaar_config);
+        if let Some((_domain, tls_cfg)) = tls_configs.iter().next() {
+            let quic_addr: std::net::SocketAddr =
+                "0.0.0.0:443".parse().expect("static addr is valid");
+            match dwaar_core::quic::QuicService::new(
+                quic_addr,
+                &tls_cfg.cert_path,
+                &tls_cfg.key_path,
+            ) {
+                Ok(quic_service) => {
+                    let quic_bg = pingora_core::services::background::background_service(
+                        "QUIC/HTTP3 listener",
+                        quic_service,
+                    );
+                    server.add_service(quic_bg);
+                    info!(listen = %quic_addr, protocol = "quic/h3", "QUIC listener registered");
+                }
+                Err(e) => {
+                    // QUIC is optional — warn but don't fail startup
+                    tracing::warn!(error = %e, "failed to start QUIC listener, HTTP/3 disabled");
+                }
+            }
+        } else {
+            tracing::warn!("h3 enabled but no TLS certs configured — QUIC listener not started");
+        }
+    }
 
     // Shared analytics metrics — created here so both AdminService and
     // AggregationService reference the same DashMap instance.

--- a/crates/dwaar-config/src/model.rs
+++ b/crates/dwaar-config/src/model.rs
@@ -35,6 +35,10 @@ pub struct GlobalOptions {
     pub drain_timeout_secs: Option<u64>,
     /// Connection-level timeouts for slow loris protection (ISSUE-076).
     pub timeouts: Option<TimeoutsConfig>,
+    /// Enable HTTP/3 (QUIC) alongside HTTP/2. Configured via `servers { h3 on }`.
+    /// When enabled, Dwaar binds a UDP listener and advertises `Alt-Svc: h3`
+    /// on HTTP/2 responses so browsers can upgrade (ISSUE-079).
+    pub h3_enabled: bool,
     /// Options we recognized but don't act on — stored so we never error
     /// on valid Caddyfile syntax we haven't implemented yet.
     pub passthrough: Vec<(String, Vec<String>)>,

--- a/crates/dwaar-config/src/parser/mod.rs
+++ b/crates/dwaar-config/src/parser/mod.rs
@@ -198,6 +198,9 @@ fn parse_global_option_line(
         "timeouts" => {
             opts.timeouts = Some(parse_timeouts_block(t, &key_tok)?);
         }
+        "servers" => {
+            parse_servers_block(t, opts, &key_tok)?;
+        }
         // Unknown option — collect args, consume sub-blocks
         _ => {
             let args = collect_global_passthrough_args(t);
@@ -405,6 +408,66 @@ fn parse_timeouts_block(
     }
 
     Ok(cfg)
+}
+
+/// Parse the `servers { h3 on }` block inside the global options.
+/// Caddy's `servers` block configures listener-level options.
+/// Currently we only extract `h3 on` to enable QUIC (ISSUE-079).
+fn parse_servers_block(
+    t: &mut Tokenizer<'_>,
+    opts: &mut GlobalOptions,
+    _key_tok: &Token,
+) -> Result<(), ParseError> {
+    let brace = t.peek();
+    if brace.kind != TokenKind::OpenBrace {
+        // `servers` without a sub-block — store as passthrough
+        let args = collect_global_passthrough_args(t);
+        opts.passthrough.push(("servers".to_string(), args));
+        return Ok(());
+    }
+    t.next_token(); // consume `{`
+
+    loop {
+        let tok = t.peek();
+        match &tok.kind {
+            TokenKind::CloseBrace => {
+                t.next_token();
+                break;
+            }
+            TokenKind::Eof => {
+                return Err(ParseError {
+                    line: tok.line,
+                    col: tok.col,
+                    kind: ParseErrorKind::UnexpectedEof {
+                        expected: "'}' to close servers block".to_string(),
+                    },
+                });
+            }
+            TokenKind::Word(_) => {
+                let sub_tok = t.next_token();
+                let sub_key = match &sub_tok.kind {
+                    TokenKind::Word(w) => w.clone(),
+                    _ => unreachable!(),
+                };
+                match sub_key.as_str() {
+                    "h3" => {
+                        let val = peek_consume_word_or_quoted(t);
+                        opts.h3_enabled = val.eq_ignore_ascii_case("on");
+                    }
+                    // Future server-level options go here.
+                    _ => {
+                        // Skip unknown keys inside servers block
+                        let _ = collect_global_passthrough_args(t);
+                    }
+                }
+            }
+            _ => {
+                t.next_token();
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Parse one site block: `address { directive* }`

--- a/crates/dwaar-config/src/parser/tests.rs
+++ b/crates/dwaar-config/src/parser/tests.rs
@@ -1649,3 +1649,49 @@ fn timeouts_unknown_key_errors() {
         "error should mention unknown key"
     );
 }
+
+// ── HTTP/3 global option (ISSUE-079) ────────────────────────────────
+
+#[test]
+fn h3_on_in_servers_block() {
+    let config =
+        parse("{\n    servers {\n        h3 on\n    }\n}\na.com {\n    reverse_proxy :3000\n}\n")
+            .expect("should parse");
+    let opts = config.global_options.as_ref().expect("has global options");
+    assert!(opts.h3_enabled);
+}
+
+#[test]
+fn h3_off_in_servers_block() {
+    let config =
+        parse("{\n    servers {\n        h3 off\n    }\n}\na.com {\n    reverse_proxy :3000\n}\n")
+            .expect("should parse");
+    let opts = config.global_options.as_ref().expect("has global options");
+    assert!(!opts.h3_enabled);
+}
+
+#[test]
+fn h3_default_is_disabled() {
+    let config =
+        parse("{\n    debug\n}\na.com {\n    reverse_proxy :3000\n}\n").expect("should parse");
+    let opts = config.global_options.as_ref().expect("has global options");
+    assert!(!opts.h3_enabled);
+}
+
+#[test]
+fn servers_block_empty() {
+    let config = parse("{\n    servers {\n    }\n}\na.com {\n    reverse_proxy :3000\n}\n")
+        .expect("should parse");
+    let opts = config.global_options.as_ref().expect("has global options");
+    assert!(!opts.h3_enabled);
+}
+
+#[test]
+fn servers_block_unknown_keys_skipped() {
+    let config = parse(
+        "{\n    servers {\n        h3 on\n        strict_sni_host on\n    }\n}\na.com {\n    reverse_proxy :3000\n}\n",
+    )
+    .expect("should parse");
+    let opts = config.global_options.as_ref().expect("has global options");
+    assert!(opts.h3_enabled);
+}

--- a/crates/dwaar-core/Cargo.toml
+++ b/crates/dwaar-core/Cargo.toml
@@ -36,6 +36,9 @@ async-trait = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["net", "io-util", "time"] }
 fastrand = { workspace = true }
+quinn = { workspace = true }
+rustls = { workspace = true }
+rustls-pemfile = { workspace = true }
 
 [dev-dependencies]
 tokio-test = { workspace = true }

--- a/crates/dwaar-core/src/lib.rs
+++ b/crates/dwaar-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod context;
 pub mod fastcgi;
 pub mod file_server;
 pub mod proxy;
+pub mod quic;
 pub mod route;
 pub mod template;
 pub mod upstream;

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -91,6 +91,9 @@ pub struct DwaarProxy {
     /// Downstream body read timeout (ISSUE-076). Applied after headers
     /// arrive so slow body senders get disconnected.
     body_timeout: std::time::Duration,
+    /// HTTP/3 (QUIC) enabled — when true, `response_filter` injects `Alt-Svc`
+    /// to advertise HTTP/3 availability to browsers (ISSUE-079b).
+    h3_enabled: bool,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -107,6 +110,7 @@ impl DwaarProxy {
         cache_backend: Option<crate::cache::CacheBackend>,
         keepalive_secs: u64,
         body_timeout_secs: u64,
+        h3_enabled: bool,
     ) -> Self {
         Self {
             route_table,
@@ -120,6 +124,7 @@ impl DwaarProxy {
             cache_backend,
             keepalive_secs,
             body_timeout: std::time::Duration::from_secs(body_timeout_secs),
+            h3_enabled,
         }
     }
 }
@@ -1316,6 +1321,14 @@ impl ProxyHttp for DwaarProxy {
             .insert_header("X-Request-Id", ctx.request_id())
             .expect("UUID is valid header value");
 
+        // Advertise HTTP/3 when enabled (ISSUE-079b). Browsers use this to
+        // upgrade future requests to QUIC. `ma=86400` caches the hint for 24h.
+        if self.h3_enabled {
+            upstream_response
+                .insert_header("Alt-Svc", r#"h3=":443"; ma=86400"#)
+                .expect("static str is valid header value");
+        }
+
         // --- Cache status header (ISSUE-073f) ---
         if let Some(status) = ctx.cache_status {
             upstream_response
@@ -1674,8 +1687,9 @@ mod tests {
             chain,
             None,
             None,
-            60, // keepalive_secs
-            30, // body_timeout_secs
+            60,    // keepalive_secs
+            30,    // body_timeout_secs
+            false, // h3_enabled
         )
     }
 

--- a/crates/dwaar-core/src/quic.rs
+++ b/crates/dwaar-core/src/quic.rs
@@ -1,0 +1,224 @@
+// Copyright (C) 2026 Permanu
+// SPDX-License-Identifier: BSL-1.1
+//
+// This file is part of Dwaar — https://dwaar.dev
+// Licensed under the Business Source License 1.1
+
+//! QUIC listener scaffold for HTTP/3 support (ISSUE-079a).
+//!
+//! Runs a `quinn::Endpoint` as a Pingora `BackgroundService`, accepting
+//! QUIC connections over UDP alongside the existing TCP/TLS listeners.
+//!
+//! Phase 1 accepts and logs connections. Full HTTP/3 request handling
+//! through the Pingora proxy engine is deferred to ISSUE-079 Phase 2.
+
+use std::net::SocketAddr;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use pingora_core::server::ShutdownWatch;
+use pingora_core::services::background::BackgroundService;
+use tracing::{debug, info};
+
+/// Background service that accepts QUIC connections.
+///
+/// Wraps a `quinn::Endpoint` and runs inside Pingora's runtime (Guardrail #20).
+/// The endpoint is stored in a `Mutex<Option<_>>` so `start()` can take
+/// ownership from `&self` — Pingora calls `start()` exactly once.
+pub struct QuicService {
+    endpoint: Mutex<Option<quinn::Endpoint>>,
+}
+
+impl std::fmt::Debug for QuicService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QuicService")
+            .field("endpoint", &"<quinn::Endpoint>")
+            .finish()
+    }
+}
+
+impl QuicService {
+    /// Create a new QUIC service bound to the given address.
+    ///
+    /// Loads TLS certs from the same PEM files used by the TCP/TLS listener
+    /// (ISSUE-079c — shared cert store). Both OpenSSL (Pingora) and rustls
+    /// (quinn) can independently load PEM, so no conversion is needed.
+    pub fn new(
+        bind_addr: SocketAddr,
+        cert_path: &Path,
+        key_path: &Path,
+    ) -> Result<Self, QuicSetupError> {
+        let rustls_config = build_rustls_config(cert_path, key_path)?;
+        let quic_crypto = quinn::crypto::rustls::QuicServerConfig::try_from(rustls_config)
+            .map_err(|e| QuicSetupError::QuicCrypto(e.to_string()))?;
+        let quinn_config = quinn::ServerConfig::with_crypto(Arc::new(quic_crypto));
+
+        let endpoint = quinn::Endpoint::server(quinn_config, bind_addr)
+            .map_err(|e| QuicSetupError::Bind(bind_addr, e))?;
+
+        info!(
+            listen = %bind_addr,
+            protocol = "quic",
+            "QUIC endpoint bound"
+        );
+
+        Ok(Self {
+            endpoint: Mutex::new(Some(endpoint)),
+        })
+    }
+}
+
+#[async_trait]
+impl BackgroundService for QuicService {
+    async fn start(&self, mut shutdown: ShutdownWatch) {
+        let endpoint = self
+            .endpoint
+            .lock()
+            .expect("QuicService lock poisoned")
+            .take()
+            .expect("QuicService::start called more than once");
+
+        info!("QUIC listener accepting connections");
+
+        loop {
+            tokio::select! {
+                incoming = endpoint.accept() => {
+                    let Some(connecting) = incoming else {
+                        // Endpoint closed — nothing left to accept
+                        break;
+                    };
+                    // Spawn each connection handler inside Pingora's runtime
+                    tokio::spawn(async move {
+                        match connecting.await {
+                            Ok(conn) => {
+                                info!(
+                                    remote = %conn.remote_address(),
+                                    "QUIC connection established"
+                                );
+                                // Full HTTP/3 request handling is Phase 2 (ISSUE-079 Phase 2).
+                                // For now, the connection will idle and eventually close.
+                            }
+                            Err(e) => {
+                                debug!(error = %e, "QUIC connection failed during handshake");
+                            }
+                        }
+                    });
+                }
+                _ = shutdown.changed() => {
+                    if *shutdown.borrow() {
+                        info!("QUIC listener shutting down");
+                        endpoint.close(quinn::VarInt::from_u32(0), b"server shutting down");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Load PEM cert and key into a rustls `ServerConfig` for QUIC.
+///
+/// Uses the same PEM files as Pingora's OpenSSL listener — both libraries
+/// parse PEM natively, so the cert store is shared at the filesystem level.
+fn build_rustls_config(
+    cert_path: &Path,
+    key_path: &Path,
+) -> Result<rustls::ServerConfig, QuicSetupError> {
+    let cert_pem = std::fs::read(cert_path)
+        .map_err(|e| QuicSetupError::CertRead(cert_path.to_path_buf(), e))?;
+    let key_pem =
+        std::fs::read(key_path).map_err(|e| QuicSetupError::KeyRead(key_path.to_path_buf(), e))?;
+
+    let certs: Vec<rustls::pki_types::CertificateDer<'static>> =
+        rustls_pemfile::certs(&mut cert_pem.as_slice())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(QuicSetupError::CertParse)?;
+
+    if certs.is_empty() {
+        return Err(QuicSetupError::NoCerts(cert_path.to_path_buf()));
+    }
+
+    let key = rustls_pemfile::private_key(&mut key_pem.as_slice())
+        .map_err(QuicSetupError::KeyParse)?
+        .ok_or_else(|| QuicSetupError::NoKey(key_path.to_path_buf()))?;
+
+    let mut config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .map_err(QuicSetupError::Rustls)?;
+
+    // ALPN for HTTP/3 — quinn requires this to negotiate the protocol.
+    config.alpn_protocols = vec![b"h3".to_vec()];
+
+    Ok(config)
+}
+
+/// Errors that can occur during QUIC endpoint setup.
+#[derive(Debug, thiserror::Error)]
+pub enum QuicSetupError {
+    #[error("failed to bind QUIC endpoint to {0}: {1}")]
+    Bind(SocketAddr, std::io::Error),
+
+    #[error("failed to read TLS cert from {0}: {1}")]
+    CertRead(std::path::PathBuf, std::io::Error),
+
+    #[error("failed to read TLS key from {0}: {1}")]
+    KeyRead(std::path::PathBuf, std::io::Error),
+
+    #[error("failed to parse PEM certificates: {0}")]
+    CertParse(std::io::Error),
+
+    #[error("no certificates found in {0}")]
+    NoCerts(std::path::PathBuf),
+
+    #[error("failed to parse PEM private key: {0}")]
+    KeyParse(std::io::Error),
+
+    #[error("no private key found in {0}")]
+    NoKey(std::path::PathBuf),
+
+    #[error("rustls configuration error: {0}")]
+    Rustls(rustls::Error),
+
+    #[error("QUIC crypto setup error: {0}")]
+    QuicCrypto(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quic_setup_error_display() {
+        // Verify error messages are human-readable
+        let err = QuicSetupError::NoCerts("/etc/certs/cert.pem".into());
+        assert!(err.to_string().contains("no certificates found"));
+    }
+
+    #[test]
+    fn build_rustls_config_rejects_missing_cert() {
+        let result = build_rustls_config(
+            Path::new("/nonexistent/cert.pem"),
+            Path::new("/nonexistent/key.pem"),
+        );
+        assert!(result.is_err());
+        let err = result.expect_err("should fail");
+        assert!(
+            matches!(err, QuicSetupError::CertRead(..)),
+            "expected CertRead error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn build_rustls_config_rejects_missing_key() {
+        // Create a temp cert file but no key file
+        let dir = tempfile::tempdir().expect("temp dir");
+        let cert_path = dir.path().join("cert.pem");
+        // Write a minimal (invalid but present) cert PEM to pass the read check
+        std::fs::write(&cert_path, "not a real cert").expect("write cert");
+
+        let result = build_rustls_config(&cert_path, Path::new("/nonexistent/key.pem"));
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- Parse `servers { h3 on }` in Dwaarfile global block
- Inject `Alt-Svc: h3=":443"; ma=86400` in response_filter when h3 enabled
- QUIC endpoint scaffold via `quinn` as Pingora BackgroundService (UDP :443)
- Shared cert store: same PEM files loaded into both OpenSSL (Pingora) and rustls (quinn)
- Graceful degradation: QUIC bind failure is non-fatal (warns, continues HTTP/2 only)

## Scope note

This is Phase 1 of HTTP/3. The QUIC endpoint accepts connections and logs them. Full HTTP/3 request→response flow through Pingora's ProxyHttp is Phase 2 (requires bridging h3 ↔ Pingora session types).

## Test plan
- [x] 755 tests passing (8 new: 5 parser + 3 QUIC unit)
- [x] fmt, clippy verified independently
- [x] No unwrap() in library code