### PR TITLE
fix: namespace-scoped secrets RBAC, file_server pre-check, QUIC buffer cap, test readiness

### DIFF
--- a/crates/dwaar-admin/tests/uds_integration.rs
+++ b/crates/dwaar-admin/tests/uds_integration.rs
@@ -60,8 +60,10 @@ fn send_http_request(stream: &mut (impl Read + Write), request: &str) -> String 
 /// Start a Pingora service with TCP + UDS, return the thread handle.
 /// `run_forever()` blocks, so we use a thread.
 fn start_test_server(socket_path: &str, tcp_port: u16) -> std::thread::JoinHandle<()> {
-    let socket_path = socket_path.to_string();
+    let socket_path_owned = socket_path.to_string();
+    let socket_path_poll = socket_path.to_string();
     let handle = std::thread::spawn(move || {
+        let socket_path = socket_path_owned;
         use pingora_core::server::Server;
         use pingora_core::server::configuration::{Opt as PingoraOpt, ServerConf};
 
@@ -94,8 +96,15 @@ fn start_test_server(socket_path: &str, tcp_port: u16) -> std::thread::JoinHandl
         server.run_forever();
     });
 
-    // Give the server time to bind
-    std::thread::sleep(std::time::Duration::from_secs(2));
+    // Poll until the UDS is accepting connections (or timeout after 10s).
+    let start = std::time::Instant::now();
+    while start.elapsed() < std::time::Duration::from_secs(10) {
+        if std::os::unix::net::UnixStream::connect(&socket_path_poll).is_ok() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }
+
     handle
 }
 

--- a/crates/dwaar-core/src/file_server.rs
+++ b/crates/dwaar-core/src/file_server.rs
@@ -13,10 +13,34 @@
 //! - Dotfiles: hidden by default (`.env`, `.htpasswd`, etc.)
 //! - MIME type: derived from extension only, never from client input
 
-use std::path::Path;
+use std::path::{Component, Path};
 use std::time::SystemTime;
 
 use bytes::Bytes;
+
+/// Cheap lexical check: does `candidate` stay within `root` after resolving
+/// `.` and `..`? Catches obvious traversal without a syscall.
+/// Symlink-based escapes still need `canonicalize()`.
+fn lexically_within(candidate: &Path, root: &Path) -> bool {
+    // Walk components after the root prefix. If `..` ever takes us
+    // above the root level, it's a traversal attempt.
+    let suffix = match candidate.strip_prefix(root) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    let mut depth: i32 = 0;
+    for component in suffix.components() {
+        match component {
+            Component::ParentDir => depth -= 1,
+            Component::Normal(_) => depth += 1,
+            _ => {}
+        }
+        if depth < 0 {
+            return false;
+        }
+    }
+    true
+}
 
 /// Result of resolving a file request.
 #[derive(Debug)]
@@ -59,20 +83,25 @@ pub fn serve_file(root: &Path, request_path: &str, browse: bool) -> FileResponse
         return FileResponse::Forbidden;
     }
 
-    // Root is expected to be pre-canonicalized at config compile time
-    // (see compile.rs). Use it directly to avoid a redundant syscall on
-    // every request. The candidate path below is still canonicalized to
-    // prevent traversal via symlinks inside the root.
+    // Root is pre-canonicalized at config compile time (see compile.rs).
     let canonical_root = root;
 
-    // Build candidate path and canonicalize to resolve symlinks + `..`
+    // Build the candidate path. First do a cheap lexical traversal check —
+    // if the normalized components escape the root, reject without a syscall.
     let candidate = canonical_root.join(clean_path);
+    if !lexically_within(&candidate, canonical_root) {
+        return FileResponse::Forbidden;
+    }
+
+    // Canonicalize to resolve symlinks that could escape the root.
+    // This is the only per-request syscall and can't be skipped — a
+    // symlink inside the root could point anywhere.
     let Ok(resolved) = candidate.canonicalize() else {
         return FileResponse::NotFound;
     };
 
-    // Critical security check — prevents path traversal
-    if !resolved.starts_with(&canonical_root) {
+    // Final security check after symlink resolution.
+    if !resolved.starts_with(canonical_root) {
         return FileResponse::Forbidden;
     }
 

--- a/crates/dwaar-core/src/quic.rs
+++ b/crates/dwaar-core/src/quic.rs
@@ -74,9 +74,12 @@ const DEFAULT_MAX_STREAMS: u32 = 100;
 /// Cap on client request body size. Clients exceeding this receive 413.
 const MAX_REQUEST_BODY: usize = 10 * 1024 * 1024; // 10 MB
 
-/// Cap on upstream response body size. Upstream responses exceeding this are
-/// dropped and the client receives 502.
-const MAX_UPSTREAM_RESPONSE: usize = 100 * 1024 * 1024; // 100 MB
+/// Cap on upstream response body size over the QUIC scaffold path.
+/// Intentionally lower than the HTTP/1-2 path (100 MB) because this path
+/// buffers the full response in memory. Streaming (ISSUE-108) removes
+/// this limit entirely. Until then, 10 MB matches the request body cap
+/// and prevents excessive memory use per H3 request.
+const MAX_UPSTREAM_RESPONSE: usize = 10 * 1024 * 1024; // 10 MB
 
 /// Timeout for the full upstream round-trip (connect + write + read).
 const UPSTREAM_TIMEOUT_SECS: u64 = 30;

--- a/deploy/helm/dwaar-ingress/templates/clusterrole.yaml
+++ b/deploy/helm/dwaar-ingress/templates/clusterrole.yaml
@@ -24,13 +24,14 @@ rules:
     verbs: ["get", "list", "watch"]
 
   # Read Secrets to load TLS certificates referenced by Ingress rules.
-  # Requires cluster-wide access because Ingresses in any namespace can
-  # reference Secrets. This matches the RBAC model used by nginx-ingress
-  # and Traefik controllers. To limit scope, use --namespace to restrict
-  # the controller to a single namespace, then use a namespaced Role instead.
+  # When watchNamespace is set, secrets access is scoped to that namespace
+  # via a separate Role (see role-secrets.yaml). Cluster-wide access is
+  # only granted when watching all namespaces.
+  {{- if not .Values.controller.watchNamespace }}
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
+  {{- end }}
 
   # Leader election: create, read, and update Lease objects in kube-system.
   - apiGroups: ["coordination.k8s.io"]

--- a/deploy/helm/dwaar-ingress/templates/role-secrets.yaml
+++ b/deploy/helm/dwaar-ingress/templates/role-secrets.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.controller.watchNamespace }}
+# Namespace-scoped secrets access — only created when watchNamespace is set.
+# This scopes TLS secret reads to the watched namespace instead of
+# granting cluster-wide access via the ClusterRole.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "dwaar-ingress.fullname" . }}-secrets
+  namespace: {{ .Values.controller.watchNamespace }}
+  labels:
+    {{- include "dwaar-ingress.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "dwaar-ingress.fullname" . }}-secrets
+  namespace: {{ .Values.controller.watchNamespace }}
+  labels:
+    {{- include "dwaar-ingress.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "dwaar-ingress.fullname" . }}-secrets
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "dwaar-ingress.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}


### PR DESCRIPTION
## Summary

- **ClusterRole secrets** → namespace-scoped Role when `watchNamespace` is set
- **file_server** → lexical traversal pre-check before canonicalize syscall
- **QUIC response buffer** → reduced from 100MB to 10MB (scaffold buffers fully)
- **UDS test** → poll-based readiness instead of fixed 2s sleep