### PR TITLE
feat(analytics): bot/human split + schema_version + window boundaries

### DIFF
--- a/crates/dwaar-admin/src/handlers.rs
+++ b/crates/dwaar-admin/src/handlers.rs
@@ -239,6 +239,7 @@ mod tests {
             client_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1)),
             country: None,
             referer: None,
+            is_bot: false,
         });
         map.insert("test.example.com".to_string(), dm);
         map

--- a/crates/dwaar-analytics/benches/aggregation.rs
+++ b/crates/dwaar-analytics/benches/aggregation.rs
@@ -35,6 +35,7 @@ fn sample_event(i: u32) -> AggEvent {
         } else {
             None
         },
+        is_bot: i.is_multiple_of(7),
     }
 }
 

--- a/crates/dwaar-analytics/src/aggregation/mod.rs
+++ b/crates/dwaar-analytics/src/aggregation/mod.rs
@@ -43,6 +43,11 @@ pub struct AggEvent {
     pub client_ip: IpAddr,
     pub country: Option<CompactString>,
     pub referer: Option<CompactString>,
+    /// BUG-020: bot classification from the bot-detect plugin (priority 10)
+    /// flows through the aggregation pipeline so the snapshot can surface
+    /// bot-vs-human pageview ratios. Default `false` for callers that
+    /// haven't migrated — treated as a human request.
+    pub is_bot: bool,
 }
 const TOP_PAGES_K: usize = 100;
 const TOP_REFERRERS_N: usize = 50;
@@ -62,6 +67,12 @@ pub struct DomainMetrics {
     pub status_codes: [u64; 6],
     pub bytes_sent: u64,
     pub web_vitals: WebVitals,
+    /// BUG-020: cumulative bot vs human pageview counters. The page_views
+    /// MinuteBuckets counter is the union of both — these counters answer
+    /// "what fraction of traffic is bot?" without needing a separate
+    /// time-windowed structure.
+    pub bot_views: u64,
+    pub human_views: u64,
 }
 
 impl DomainMetrics {
@@ -75,6 +86,8 @@ impl DomainMetrics {
             status_codes: [0; 6],
             bytes_sent: 0,
             web_vitals: WebVitals::new(),
+            bot_views: 0,
+            human_views: 0,
         }
     }
 
@@ -85,6 +98,12 @@ impl DomainMetrics {
         self.top_pages.insert(event.path.to_string());
         self.status_codes[status_bucket(event.status)] += 1;
         self.bytes_sent += event.bytes_sent;
+        // BUG-020: split bot vs human counters.
+        if event.is_bot {
+            self.bot_views += 1;
+        } else {
+            self.human_views += 1;
+        }
 
         if let Some(domain) = event.referer.as_deref().and_then(extract_domain) {
             self.referrers.insert(domain);
@@ -226,6 +245,7 @@ mod tests {
             client_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
             country: None,
             referer: None,
+            is_bot: false,
         };
         // Should not panic — drops silently when full
         for _ in 0..10_000 {
@@ -284,6 +304,7 @@ mod tests {
             client_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
             country: Some("US".into()),
             referer: Some("https://google.com/search".into()),
+            is_bot: false,
         };
         dm.ingest_log(&event);
 

--- a/crates/dwaar-analytics/src/aggregation/service.rs
+++ b/crates/dwaar-analytics/src/aggregation/service.rs
@@ -185,15 +185,36 @@ impl<RT: RouteValidator> AggregationService<RT> {
 
 // ── Flush Serialization ──────────────────────────────────────────
 
+/// Current schema version of the per-domain flush snapshot.
+///
+/// BUG-019: bumped on every breaking field rename so downstream readers
+/// (Permanu agent, third-party scrapers) reject mismatched messages
+/// instead of silently dropping data via serde unknown-field defaults.
+const FLUSH_SCHEMA_VERSION: u32 = 1;
+
 /// JSON snapshot emitted per domain during flush.
 #[derive(Debug, Serialize)]
 struct FlushSnapshot {
     r#type: &'static str,
+    /// BUG-019: schema version. Permanu agent compares this against its
+    /// own constant and `slog.Error`s if they don't match.
+    schema_version: u32,
     domain: String,
+    /// Deprecated: use `window_end`. Kept for backwards compat with v0
+    /// readers that haven't migrated yet.
     timestamp: String,
+    /// BUG-028: explicit aggregation window so consumers can detect
+    /// heartbeat gaps. `window_end` mirrors `timestamp`; `window_start`
+    /// is `window_end - 60s` for the fixed flush cycle today.
+    window_start: String,
+    window_end: String,
     page_views_1m: u64,
     page_views_60m: u64,
     unique_visitors: u64,
+    /// BUG-020: bot vs human pageview split. Cumulative since the last
+    /// flush. `bot_views + human_views` ≈ `page_views_60m` modulo timing.
+    bot_views: u64,
+    human_views: u64,
     top_pages: Vec<PageCount>,
     referrers: Vec<ReferrerCount>,
     countries: Vec<CountryCount>,
@@ -244,13 +265,21 @@ struct VitalsSnapshot {
 
 impl FlushSnapshot {
     fn from_metrics(domain: &str, m: &mut DomainMetrics) -> Self {
+        let now = chrono::Utc::now();
+        let window_end = now.to_rfc3339();
+        let window_start = (now - chrono::Duration::seconds(60)).to_rfc3339();
         Self {
             r#type: "analytics",
+            schema_version: FLUSH_SCHEMA_VERSION,
             domain: domain.to_string(),
-            timestamp: chrono::Utc::now().to_rfc3339(),
+            timestamp: window_end.clone(),
+            window_start,
+            window_end,
             page_views_1m: m.page_views.count_last_n_now(1),
             page_views_60m: m.page_views.count_last_n_now(60),
             unique_visitors: m.unique_visitors.len() as u64,
+            bot_views: m.bot_views,
+            human_views: m.human_views,
             top_pages: m
                 .top_pages
                 .top()
@@ -313,6 +342,7 @@ mod tests {
             client_ip: std::net::IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
             country: Some("US".into()),
             referer: Some("https://google.com/search".into()),
+            is_bot: false,
         }
     }
 

--- a/crates/dwaar-analytics/src/aggregation/snapshot.rs
+++ b/crates/dwaar-analytics/src/aggregation/snapshot.rs
@@ -61,12 +61,23 @@ pub struct VitalsSnapshot {
     pub inp: Percentiles,
 }
 
+/// Current schema version of the AnalyticsSnapshot wire format.
+///
+/// BUG-019: consumers (Permanu agent and any external scraper) reject any
+/// snapshot whose `schema_version` doesn't match the version they were
+/// compiled against. Bumping this on a breaking field rename forces
+/// upstream code to re-test against the new shape rather than silently
+/// dropping data via `serde(deny_unknown_fields=false)` defaults.
+pub const ANALYTICS_SCHEMA_VERSION: u32 = 1;
+
 /// Serializable read-only view of per-domain analytics.
 ///
 /// Constructed from an immutable `&DomainMetrics` — never mutates
 /// the live aggregates. Safe to call on every Admin API GET.
 #[derive(Debug, Serialize)]
 pub struct AnalyticsSnapshot {
+    /// BUG-019: schema version for downstream readers.
+    pub schema_version: u32,
     pub domain: String,
     /// May include stale counts if no traffic has arrived recently — the 60s flush cycle clears stale buckets.
     pub page_views_1m: u64,
@@ -78,6 +89,19 @@ pub struct AnalyticsSnapshot {
     pub status_codes: StatusCodeBreakdown,
     pub bytes_sent: u64,
     pub web_vitals: VitalsSnapshot,
+    /// BUG-020: bot vs human pageview split. Cumulative since the last
+    /// 60s aggregation flush. Both fields together sum to the page-view
+    /// counters above (`page_views_60m` modulo timing race).
+    pub bot_views: u64,
+    pub human_views: u64,
+    /// BUG-028: explicit aggregation window so consumers can detect
+    /// heartbeat gaps. `window_end` is what the previous `timestamp`
+    /// field meant; `window_start` is `window_end - 60s` (the fixed
+    /// 60-second flush cycle today).
+    pub window_start: String,
+    pub window_end: String,
+    /// Deprecated: use `window_end`. Kept for backwards compat with v0
+    /// readers that haven't migrated yet.
     pub timestamp: String,
 }
 
@@ -124,7 +148,14 @@ impl AnalyticsSnapshot {
             inp: m.web_vitals.peek_inp_percentiles(),
         };
 
+        let now = chrono::Utc::now();
+        let window_end = now.to_rfc3339();
+        // BUG-028: 60-second flush cycle is the only supported window today.
+        // When variable windows ship, replace this with the real boundary.
+        let window_start = (now - chrono::Duration::seconds(60)).to_rfc3339();
+
         Self {
+            schema_version: ANALYTICS_SCHEMA_VERSION,
             domain: domain.to_owned(),
             page_views_1m: m.page_views.count_last_n_now(1),
             page_views_60m: m.page_views.count_last_n_now(60),
@@ -135,7 +166,11 @@ impl AnalyticsSnapshot {
             status_codes,
             bytes_sent: m.bytes_sent,
             web_vitals,
-            timestamp: chrono::Utc::now().to_rfc3339(),
+            bot_views: m.bot_views,
+            human_views: m.human_views,
+            window_start,
+            window_end: window_end.clone(),
+            timestamp: window_end, // deprecated alias
         }
     }
 }
@@ -155,6 +190,7 @@ mod tests {
             client_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
             country: Some("US".into()),
             referer: Some("https://google.com/search".into()),
+            is_bot: false,
         }
     }
 

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -1769,6 +1769,10 @@ impl ProxyHttp for DwaarProxy {
                 client_ip,
                 country: country.clone(),
                 referer: referer.clone(),
+                // BUG-020: bot-detect plugin (priority 10) classifies the
+                // request on PluginCtx; the aggregator now splits bot vs
+                // human counters in DomainMetrics.
+                is_bot: ctx.plugin_ctx.is_bot,
             };
             agg.send(event);
         }


### PR DESCRIPTION
Three Permanu BUG-### fixes in one Dwaar release.

**BUG-019** schema_version=1 on every flush snapshot.
**BUG-020** bot_views/human_views counters in DomainMetrics + sink JSON.
**BUG-028** window_start/window_end timestamps for heartbeat-gap detection.

All AggEvent constructors updated. 120 analytics tests pass, admin + core test suites green. Permanu companion PR will land on the consumer side once this merges.