### PR TITLE
chore(analytics): scrub internal tracker references from doc comments

### DIFF
--- a/crates/dwaar-analytics/src/aggregation/mod.rs
+++ b/crates/dwaar-analytics/src/aggregation/mod.rs
@@ -43,10 +43,9 @@ pub struct AggEvent {
     pub client_ip: IpAddr,
     pub country: Option<CompactString>,
     pub referer: Option<CompactString>,
-    /// BUG-020: bot classification from the bot-detect plugin (priority 10)
-    /// flows through the aggregation pipeline so the snapshot can surface
-    /// bot-vs-human pageview ratios. Default `false` for callers that
-    /// haven't migrated — treated as a human request.
+    /// Bot classification from the bot-detect plugin (priority 10),
+    /// propagated so the aggregation snapshot can surface bot-vs-human
+    /// pageview ratios. Default `false` is treated as a human request.
     pub is_bot: bool,
 }
 const TOP_PAGES_K: usize = 100;
@@ -67,10 +66,10 @@ pub struct DomainMetrics {
     pub status_codes: [u64; 6],
     pub bytes_sent: u64,
     pub web_vitals: WebVitals,
-    /// BUG-020: cumulative bot vs human pageview counters. The page_views
-    /// MinuteBuckets counter is the union of both — these counters answer
-    /// "what fraction of traffic is bot?" without needing a separate
-    /// time-windowed structure.
+    /// Cumulative bot vs human pageview counters. The page_views
+    /// MinuteBuckets counter is the union of both — these counters
+    /// answer "what fraction of traffic is bot?" without needing a
+    /// separate time-windowed structure.
     pub bot_views: u64,
     pub human_views: u64,
 }
@@ -98,7 +97,7 @@ impl DomainMetrics {
         self.top_pages.insert(event.path.to_string());
         self.status_codes[status_bucket(event.status)] += 1;
         self.bytes_sent += event.bytes_sent;
-        // BUG-020: split bot vs human counters.
+        // Split bot vs human counters from the bot-detect classification.
         if event.is_bot {
             self.bot_views += 1;
         } else {

--- a/crates/dwaar-analytics/src/aggregation/service.rs
+++ b/crates/dwaar-analytics/src/aggregation/service.rs
@@ -187,32 +187,33 @@ impl<RT: RouteValidator> AggregationService<RT> {
 
 /// Current schema version of the per-domain flush snapshot.
 ///
-/// BUG-019: bumped on every breaking field rename so downstream readers
-/// (Permanu agent, third-party scrapers) reject mismatched messages
-/// instead of silently dropping data via serde unknown-field defaults.
+/// Bumped on every breaking field rename so downstream readers reject
+/// mismatched messages instead of silently dropping data via serde
+/// unknown-field defaults.
 const FLUSH_SCHEMA_VERSION: u32 = 1;
 
 /// JSON snapshot emitted per domain during flush.
 #[derive(Debug, Serialize)]
 struct FlushSnapshot {
     r#type: &'static str,
-    /// BUG-019: schema version. Permanu agent compares this against its
-    /// own constant and `slog.Error`s if they don't match.
+    /// Schema version. Consumers compare against their own constant
+    /// and reject mismatches loudly so a future field rename never
+    /// silently corrupts downstream data.
     schema_version: u32,
     domain: String,
-    /// Deprecated: use `window_end`. Kept for backwards compat with v0
-    /// readers that haven't migrated yet.
+    /// Deprecated: use `window_end`. Kept for one release cycle so
+    /// pre-window_end readers continue to receive a sane timestamp.
     timestamp: String,
-    /// BUG-028: explicit aggregation window so consumers can detect
-    /// heartbeat gaps. `window_end` mirrors `timestamp`; `window_start`
-    /// is `window_end - 60s` for the fixed flush cycle today.
+    /// Explicit aggregation window so consumers can detect heartbeat
+    /// gaps. `window_end` mirrors `timestamp`; `window_start` is
+    /// `window_end - 60s` for the fixed 60s flush cycle today.
     window_start: String,
     window_end: String,
     page_views_1m: u64,
     page_views_60m: u64,
     unique_visitors: u64,
-    /// BUG-020: bot vs human pageview split. Cumulative since the last
-    /// flush. `bot_views + human_views` ≈ `page_views_60m` modulo timing.
+    /// Bot vs human pageview split. Cumulative since the last flush.
+    /// `bot_views + human_views` ≈ `page_views_60m` modulo timing.
     bot_views: u64,
     human_views: u64,
     top_pages: Vec<PageCount>,

--- a/crates/dwaar-analytics/src/aggregation/snapshot.rs
+++ b/crates/dwaar-analytics/src/aggregation/snapshot.rs
@@ -63,11 +63,10 @@ pub struct VitalsSnapshot {
 
 /// Current schema version of the AnalyticsSnapshot wire format.
 ///
-/// BUG-019: consumers (Permanu agent and any external scraper) reject any
-/// snapshot whose `schema_version` doesn't match the version they were
-/// compiled against. Bumping this on a breaking field rename forces
-/// upstream code to re-test against the new shape rather than silently
-/// dropping data via `serde(deny_unknown_fields=false)` defaults.
+/// Consumers reject any snapshot whose `schema_version` doesn't match
+/// the version they were compiled against. Bumping this on a breaking
+/// field rename forces upstream code to re-test against the new shape
+/// rather than silently dropping data via serde defaults.
 pub const ANALYTICS_SCHEMA_VERSION: u32 = 1;
 
 /// Serializable read-only view of per-domain analytics.
@@ -76,7 +75,7 @@ pub const ANALYTICS_SCHEMA_VERSION: u32 = 1;
 /// the live aggregates. Safe to call on every Admin API GET.
 #[derive(Debug, Serialize)]
 pub struct AnalyticsSnapshot {
-    /// BUG-019: schema version for downstream readers.
+    /// Schema version for downstream readers.
     pub schema_version: u32,
     pub domain: String,
     /// May include stale counts if no traffic has arrived recently — the 60s flush cycle clears stale buckets.
@@ -89,19 +88,18 @@ pub struct AnalyticsSnapshot {
     pub status_codes: StatusCodeBreakdown,
     pub bytes_sent: u64,
     pub web_vitals: VitalsSnapshot,
-    /// BUG-020: bot vs human pageview split. Cumulative since the last
-    /// 60s aggregation flush. Both fields together sum to the page-view
-    /// counters above (`page_views_60m` modulo timing race).
+    /// Bot vs human pageview split. Cumulative since the last 60s
+    /// aggregation flush. Both fields together approximately sum to
+    /// the page-view counters above modulo timing race.
     pub bot_views: u64,
     pub human_views: u64,
-    /// BUG-028: explicit aggregation window so consumers can detect
-    /// heartbeat gaps. `window_end` is what the previous `timestamp`
-    /// field meant; `window_start` is `window_end - 60s` (the fixed
-    /// 60-second flush cycle today).
+    /// Explicit aggregation window so consumers can detect heartbeat
+    /// gaps. `window_end` is the cutoff for this snapshot; `window_start`
+    /// is `window_end - 60s` for the fixed 60-second flush cycle today.
     pub window_start: String,
     pub window_end: String,
-    /// Deprecated: use `window_end`. Kept for backwards compat with v0
-    /// readers that haven't migrated yet.
+    /// Deprecated alias of `window_end`. Kept for one release cycle
+    /// so pre-window_end readers continue to receive a sane timestamp.
     pub timestamp: String,
 }
 
@@ -150,7 +148,7 @@ impl AnalyticsSnapshot {
 
         let now = chrono::Utc::now();
         let window_end = now.to_rfc3339();
-        // BUG-028: 60-second flush cycle is the only supported window today.
+        // 60-second flush cycle is the only supported window today.
         // When variable windows ship, replace this with the real boundary.
         let window_start = (now - chrono::Duration::seconds(60)).to_rfc3339();
 

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -1769,9 +1769,8 @@ impl ProxyHttp for DwaarProxy {
                 client_ip,
                 country: country.clone(),
                 referer: referer.clone(),
-                // BUG-020: bot-detect plugin (priority 10) classifies the
-                // request on PluginCtx; the aggregator now splits bot vs
-                // human counters in DomainMetrics.
+                // bot-detect plugin classifies the request on PluginCtx;
+                // the aggregator splits bot vs human counters in DomainMetrics.
                 is_bot: ctx.plugin_ctx.is_bot,
             };
             agg.send(event);


### PR DESCRIPTION
Replaces inline BUG-### / PR # / Permanu BUG tags in code comments with descriptive text. Bug IDs and PR numbers belong in commit messages and `git blame`, not stamped on every doc-comment line. Behaviour unchanged.