### PR TITLE
release: v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-04-13
+
+### Fixed
+
+- **Layer 4 parser was dead code** — `parse_layer4_config` (490+ lines) was
+  fully implemented but never wired into the global options dispatch.
+  Configs with `layer4 {}` blocks were silently ignored. Now parsed into
+  `GlobalOptions.layer4` and available at runtime.
+- Wire `listener_wrappers { layer4 {} }` parsing inside `servers` blocks
+  for shared-listener L4 protocol detection.
+- Remove `#![allow(dead_code)]` suppression from `parser/layer4.rs`.
+
 ## [0.2.3] - 2026-04-12
 
 Security and performance hardening patch. Addresses 51 findings from an

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.2.3
+Licensed Work:        Dwaar 0.2.4
                       The Licensed Work is
                       (c) 2026 Permanu
 
@@ -65,7 +65,7 @@ Additional Use Grant: You may use, copy, modify, create derivative works of,
                         of the Licensed Work as part of a commercial
                         infrastructure or platform product.
 
-Change Date:          2036-04-12
+Change Date:          2036-04-13
 
 Change License:       GNU Affero General Public License v3.0
 

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.2.3"
+version = "0.2.4"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false


### PR DESCRIPTION
## Summary

- Bump version to 0.2.4 (`dwaar-cli/Cargo.toml`, `LICENSE`)
- Add CHANGELOG entry for v0.2.4 — layer4 parser wiring fix

## What's in this release

- **fix(config):** Wire the layer4 parser into global options dispatch (merged in #177)
- Remove `#![allow(dead_code)]` from `parser/layer4.rs`

## Post-merge

After merging, tag `v0.2.4` on the merge commit and push to trigger the release workflow:

```bash
git checkout main && git pull
git tag v0.2.4
git push origin v0.2.4
```