### PR TITLE
release: v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-04-13
+
+Dependency updates and a critical security fix for config size parsing.
+
+### Security
+
+- **Integer overflow in size parsing** — `parse_size` used wrapping multiplication
+  for GB/MB/KB suffixes, allowing a malicious config to produce silently incorrect
+  size limits (e.g., cache `max_size` wrapping to near-zero). Now uses `checked_mul`,
+  returning a parse error on overflow. (fixes #146)
+
+### Dependencies
+
+- Bump `rustls` 0.23.37 → 0.23.38
+- Bump `openssl` 0.10.76 → 0.10.77
+- Bump `openssl-sys` 0.9.112 → 0.9.113
+- Bump `daachorse` 1.0.1 → 2.0.0
+- Bump `softprops/action-gh-release` v2 → v3
+- Bump `actions/setup-node` v4 → v6
+- Bump `actions/upload-pages-artifact` v3 → v4
+- Bump `actions/deploy-pages` v4 → v5
+
 ## [0.2.4] - 2026-04-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.5] - 2026-04-13
 
-Dependency updates and a critical security fix for config size parsing.
+Critical security fix, parser hardening, and CLI improvements.
 
 ### Security
 
@@ -17,6 +17,16 @@ Dependency updates and a critical security fix for config size parsing.
   for GB/MB/KB suffixes, allowing a malicious config to produce silently incorrect
   size limits (e.g., cache `max_size` wrapping to near-zero). Now uses `checked_mul`,
   returning a parse error on overflow. (fixes #146)
+
+### Fixed
+
+- **Top-level `layer4 {}` blocks now parsed** — caddy-l4 syntax places `layer4`
+  at the top level alongside site blocks, not inside global options. The parser
+  now handles both placements correctly.
+- **`dwaar reload` supports Unix sockets** — the CLI admin client now connects
+  via Unix domain sockets (`/var/run/dwaar-admin.sock` or `unix:///path`).
+  When the default TCP address is used, the CLI auto-detects the well-known
+  UDS path and tries it first.
 
 ### Dependencies
 

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.2.4
+Licensed Work:        Dwaar 0.2.5
                       The Licensed Work is
                       (c) 2026 Permanu
 

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.2.4"
+version = "0.2.5"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-cli/src/admin_client.rs
+++ b/crates/dwaar-cli/src/admin_client.rs
@@ -6,7 +6,7 @@
 
 //! Minimal HTTP/1.1 client for querying the Dwaar Admin API.
 //!
-//! Uses raw `TcpStream` — no external HTTP library needed.
+//! Uses raw `TcpStream` or `UnixStream` — no external HTTP library needed.
 //! Only supports simple GET/POST to localhost, which is all CLI
 //! commands need for talking to the co-located admin API.
 
@@ -18,6 +18,18 @@ use std::time::Duration;
 pub(crate) struct AdminResponse {
     pub status: u16,
     pub body: String,
+}
+
+/// Returns `true` if `addr` looks like a Unix socket path rather than a TCP
+/// `host:port`. We accept both bare paths (`/var/run/dwaar-admin.sock`) and
+/// the explicit `unix://` scheme.
+fn is_unix_addr(addr: &str) -> bool {
+    addr.starts_with('/') || addr.starts_with("unix://")
+}
+
+/// Strip the `unix://` prefix if present, returning the bare filesystem path.
+fn unix_path(addr: &str) -> &str {
+    addr.strip_prefix("unix://").unwrap_or(addr)
 }
 
 /// Build an actionable error message for a failed connect to the admin API.
@@ -68,10 +80,58 @@ fn request(
     path: &str,
     body: Option<&str>,
 ) -> anyhow::Result<AdminResponse> {
+    if is_unix_addr(addr) {
+        request_unix(addr, method, path, body)
+    } else {
+        request_tcp(addr, method, path, body)
+    }
+}
+
+fn request_tcp(
+    addr: &str,
+    method: &str,
+    path: &str,
+    body: Option<&str>,
+) -> anyhow::Result<AdminResponse> {
     let mut stream = TcpStream::connect(addr).map_err(|e| friendly_connect_error(addr, &e))?;
     stream.set_read_timeout(Some(Duration::from_secs(5)))?;
     stream.set_write_timeout(Some(Duration::from_secs(5)))?;
+    send_and_parse(&mut stream, method, path, body)
+}
 
+#[cfg(unix)]
+fn request_unix(
+    addr: &str,
+    method: &str,
+    path: &str,
+    body: Option<&str>,
+) -> anyhow::Result<AdminResponse> {
+    use std::os::unix::net::UnixStream;
+
+    let socket_path = unix_path(addr);
+    let mut stream =
+        UnixStream::connect(socket_path).map_err(|e| friendly_connect_error(addr, &e))?;
+    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(5)))?;
+    send_and_parse(&mut stream, method, path, body)
+}
+
+#[cfg(not(unix))]
+fn request_unix(
+    addr: &str,
+    _method: &str,
+    _path: &str,
+    _body: Option<&str>,
+) -> anyhow::Result<AdminResponse> {
+    anyhow::bail!("Unix socket admin connections are not supported on this platform: {addr}")
+}
+
+fn send_and_parse(
+    stream: &mut (impl Read + Write),
+    method: &str,
+    path: &str,
+    body: Option<&str>,
+) -> anyhow::Result<AdminResponse> {
     // Add auth token if set
     let auth_header = std::env::var("DWAAR_ADMIN_TOKEN")
         .ok()
@@ -96,10 +156,10 @@ fn request(
     }
     stream.flush()?;
 
-    parse_response(&mut stream)
+    parse_response(stream)
 }
 
-fn parse_response(stream: &mut TcpStream) -> anyhow::Result<AdminResponse> {
+fn parse_response(stream: &mut impl Read) -> anyhow::Result<AdminResponse> {
     let mut reader = BufReader::new(stream);
 
     // Parse status line

--- a/crates/dwaar-cli/src/cli.rs
+++ b/crates/dwaar-cli/src/cli.rs
@@ -153,7 +153,7 @@ pub(crate) enum Commands {
     /// Trigger config reload on the running Dwaar instance
     Reload {
         /// Admin API address. Use a TCP address (127.0.0.1:6190) or a
-        /// Unix socket path (/var/run/dwaar-admin.sock or unix:///path).
+        /// Unix socket path (`/var/run/dwaar-admin.sock` or `unix:///path`).
         #[arg(long, default_value = "127.0.0.1:6190")]
         admin: String,
     },

--- a/crates/dwaar-cli/src/cli.rs
+++ b/crates/dwaar-cli/src/cli.rs
@@ -152,7 +152,8 @@ pub(crate) enum Commands {
     },
     /// Trigger config reload on the running Dwaar instance
     Reload {
-        /// Admin API address (default: 127.0.0.1:6190)
+        /// Admin API address. Use a TCP address (127.0.0.1:6190) or a
+        /// Unix socket path (/var/run/dwaar-admin.sock or unix:///path).
         #[arg(long, default_value = "127.0.0.1:6190")]
         admin: String,
     },

--- a/crates/dwaar-cli/src/main.rs
+++ b/crates/dwaar-cli/src/main.rs
@@ -1383,10 +1383,28 @@ fn parse_cert_info(pem_data: &[u8], path: &std::path::Path) -> anyhow::Result<Ce
 }
 
 /// `dwaar reload` — trigger config reload on the running instance.
+///
+/// If the user-supplied `admin_addr` is the default TCP address, also try the
+/// well-known Unix socket path first — deploy agents typically start Dwaar with
+/// `--admin-socket` and the TCP listener may not be reachable.
 fn cmd_reload(admin_addr: &str) -> anyhow::Result<()> {
     use std::io::Write;
 
-    let resp = admin_client::post(admin_addr, "/reload", "")?;
+    let resp = if admin_addr == "127.0.0.1:6190" {
+        // Try the conventional UDS path first — it's more reliable when Dwaar
+        // is managed by a deploy agent that passes --admin-socket.
+        const DEFAULT_UDS: &str = "/var/run/dwaar-admin.sock";
+        if std::path::Path::new(DEFAULT_UDS).exists() {
+            match admin_client::post(DEFAULT_UDS, "/reload", "") {
+                Ok(r) => r,
+                Err(_) => admin_client::post(admin_addr, "/reload", "")?,
+            }
+        } else {
+            admin_client::post(admin_addr, "/reload", "")?
+        }
+    } else {
+        admin_client::post(admin_addr, "/reload", "")?
+    };
 
     match resp.status {
         200 => {

--- a/crates/dwaar-config/src/parser/helpers.rs
+++ b/crates/dwaar-config/src/parser/helpers.rs
@@ -19,21 +19,30 @@ pub(super) fn parse_size(s: &str) -> Option<u64> {
         .or_else(|| s.strip_suffix("G"))
         .or_else(|| s.strip_suffix("g"))
     {
-        n.trim().parse::<u64>().ok().map(|n| n * 1024 * 1024 * 1024)
+        n.trim()
+            .parse::<u64>()
+            .ok()
+            .and_then(|n| n.checked_mul(1024 * 1024 * 1024))
     } else if let Some(n) = s
         .strip_suffix("MB")
         .or_else(|| s.strip_suffix("mb"))
         .or_else(|| s.strip_suffix("M"))
         .or_else(|| s.strip_suffix("m"))
     {
-        n.trim().parse::<u64>().ok().map(|n| n * 1024 * 1024)
+        n.trim()
+            .parse::<u64>()
+            .ok()
+            .and_then(|n| n.checked_mul(1024 * 1024))
     } else if let Some(n) = s
         .strip_suffix("KB")
         .or_else(|| s.strip_suffix("kb"))
         .or_else(|| s.strip_suffix("K"))
         .or_else(|| s.strip_suffix("k"))
     {
-        n.trim().parse::<u64>().ok().map(|n| n * 1024)
+        n.trim()
+            .parse::<u64>()
+            .ok()
+            .and_then(|n| n.checked_mul(1024))
     } else {
         s.parse().ok()
     }

--- a/crates/dwaar-config/src/parser/mod.rs
+++ b/crates/dwaar-config/src/parser/mod.rs
@@ -74,16 +74,24 @@ fn parse_config(t: &mut Tokenizer<'_>) -> Result<DwaarConfig, ParseError> {
     let mut sites = Vec::new();
 
     // A leading bare `{` is the global options block.
-    let global_options = if t.peek().kind == TokenKind::OpenBrace {
+    let mut global_options = if t.peek().kind == TokenKind::OpenBrace {
         Some(parse_global_options(t)?)
     } else {
         None
     };
 
+    // Top-level `layer4 { ... }` block (caddy-l4 app syntax).
+    // Can appear alongside site blocks and is stored in global options.
+    let mut top_level_layer4 = None;
+
     loop {
         let tok = t.peek();
-        match tok.kind {
+        match &tok.kind {
             TokenKind::Eof => break,
+            TokenKind::Word(w) if w == "layer4" => {
+                let l4_tok = t.next_token();
+                top_level_layer4 = Some(layer4::parse_layer4_config(t, &l4_tok)?);
+            }
             TokenKind::Word(_) => {
                 sites.push(parse_site_block(t)?);
             }
@@ -98,6 +106,11 @@ fn parse_config(t: &mut Tokenizer<'_>) -> Result<DwaarConfig, ParseError> {
                 });
             }
         }
+    }
+
+    // Merge top-level layer4 into global options (creating the struct if needed).
+    if let Some(l4) = top_level_layer4 {
+        global_options.get_or_insert_with(GlobalOptions::default).layer4 = Some(l4);
     }
 
     Ok(DwaarConfig {

--- a/crates/dwaar-config/src/parser/mod.rs
+++ b/crates/dwaar-config/src/parser/mod.rs
@@ -110,7 +110,9 @@ fn parse_config(t: &mut Tokenizer<'_>) -> Result<DwaarConfig, ParseError> {
 
     // Merge top-level layer4 into global options (creating the struct if needed).
     if let Some(l4) = top_level_layer4 {
-        global_options.get_or_insert_with(GlobalOptions::default).layer4 = Some(l4);
+        global_options
+            .get_or_insert_with(GlobalOptions::default)
+            .layer4 = Some(l4);
     }
 
     Ok(DwaarConfig {


### PR DESCRIPTION
## Summary

- **Security fix:** Integer overflow in `parse_size` — wrapping `*` replaced with `checked_mul` (fixes #146)
- **Version bump:** 0.2.4 → 0.2.5 (Cargo.toml, LICENSE, CHANGELOG)
- **Dependencies already on main:** rustls 0.23.38, openssl 0.10.77, openssl-sys 0.9.113, daachorse 2.0.0

## Test plan

- [x] `cargo build` — clean, zero warnings
- [x] 261 config parser tests pass
- [x] 1,094+ workspace unit tests pass
- [x] Overflow values now return `None` → parse error instead of wrapping to garbage
