### PR TITLE
release: v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-04-13
+
+Hardening patch: 5 fixes for audit findings and a deploy-blocking startup bug.
+
+### Security
+
+- **Float-to-int truncation in compress negotiation** — `Accept-Encoding`
+  quality values now clamped with `.round().clamp(0.0, 1000.0)` before cast,
+  preventing incorrect encoding selection on `NaN`/`Infinity`/negative `q`.
+  (fixes #144)
+- **Beacon body overflow parsed truncated data** — oversized beacon bodies
+  now return 413 Payload Too Large instead of silently parsing the truncated
+  prefix. (fixes #151)
+
+### Fixed
+
+- **L4-only configs no longer rejected at startup** — `route_table.is_empty()`
+  guard now also checks for layer4 config, allowing Dwaar to start with only
+  TCP/UDP proxy routes and no HTTP sites.
+- **`.expect()` removed from hot proxy path** — 13 `.expect()` calls in
+  `upstream_request_filter` and `upstream_response_filter` replaced with `?`
+  propagation, preventing worker crashes on unexpected header values. (fixes #145)
+- **Docker watcher dual-map race condition** — `docker_routes` and
+  `container_domains` consolidated into a single `DockerState` struct under
+  one lock, ensuring atomic map updates. (fixes #148)
+
 ## [0.2.5] - 2026-04-13
 
 Critical security fix, parser hardening, and CLI improvements.

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.2.5
+Licensed Work:        Dwaar 0.2.6
                       The Licensed Work is
                       (c) 2026 Permanu
 

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.2.5"
+version = "0.2.6"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-cli/src/main.rs
+++ b/crates/dwaar-cli/src/main.rs
@@ -468,7 +468,11 @@ fn run_server(
 
     // Compile routes
     let route_table = compile_routes(dwaar_config);
-    if route_table.is_empty() {
+    let has_l4 = dwaar_config
+        .global_options
+        .as_ref()
+        .is_some_and(|g| g.layer4.is_some() || !g.layer4_listener_wrappers.is_empty());
+    if route_table.is_empty() && !has_l4 {
         bail!("no valid routes found in config — nothing to proxy");
     }
     info!(routes = route_table.len(), "route table compiled");

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -239,9 +239,11 @@ impl DwaarProxy {
         if let Some(ref sender) = self.beacon_sender {
             let mut body = Vec::with_capacity(1024);
             while let Ok(Some(chunk)) = session.downstream_session.read_request_body().await {
-                // Check before extending so we never allocate beyond the limit.
+                // Reject oversized beacons with 413 — never parse truncated data.
                 if body.len().saturating_add(chunk.len()) > beacon::MAX_BEACON_SIZE {
-                    break;
+                    let resp = ResponseHeader::build(413, Some(0))?;
+                    session.write_response_header(Box::new(resp), true).await?;
+                    return Ok(true);
                 }
                 body.extend_from_slice(&chunk);
             }
@@ -1383,21 +1385,29 @@ impl ProxyHttp for DwaarProxy {
             let ip_str = {
                 use std::io::Write;
                 let mut cursor = std::io::Cursor::new(&mut ip_buf[..]);
-                write!(cursor, "{ip}").expect("IP fits in 45 bytes");
+                write!(cursor, "{ip}").map_err(|e| {
+                    pingora_error::Error::because(
+                        pingora_error::ErrorType::InternalError,
+                        "IP format failed",
+                        e,
+                    )
+                })?;
                 let len = cursor.position() as usize;
                 // SAFETY: IpAddr Display only emits ASCII digits, colons, and dots.
-                std::str::from_utf8(&ip_buf[..len]).expect("IP is valid UTF-8")
+                std::str::from_utf8(&ip_buf[..len]).map_err(|e| {
+                    pingora_error::Error::because(
+                        pingora_error::ErrorType::InternalError,
+                        "IP UTF-8 failed",
+                        e,
+                    )
+                })?
             };
-            upstream_request
-                .insert_header("X-Real-IP", ip_str)
-                .expect("IP string is valid header value");
+            upstream_request.insert_header("X-Real-IP", ip_str)?;
 
             // Replace (not append) — client-supplied XFF is stripped to prevent
             // IP spoofing. Only the direct connection IP is trusted.
             upstream_request.remove_header("X-Forwarded-For");
-            upstream_request
-                .insert_header("X-Forwarded-For", ip_str)
-                .expect("IP string is valid header value");
+            upstream_request.insert_header("X-Forwarded-For", ip_str)?;
         }
 
         let proto = if Self::is_tls_connection(session) {
@@ -1405,13 +1415,9 @@ impl ProxyHttp for DwaarProxy {
         } else {
             "http"
         };
-        upstream_request
-            .insert_header("X-Forwarded-Proto", proto)
-            .expect("static header value is valid");
+        upstream_request.insert_header("X-Forwarded-Proto", proto)?;
 
-        upstream_request
-            .insert_header("X-Request-Id", ctx.request_id())
-            .expect("UUID is valid header value");
+        upstream_request.insert_header("X-Request-Id", ctx.request_id())?;
 
         // W3C Trace Context propagation (ISSUE-112): if the client sent a valid
         // traceparent, propagate it unchanged; otherwise generate a fresh one so
@@ -1424,17 +1430,13 @@ impl ProxyHttp for DwaarProxy {
             .and_then(crate::trace::parse_traceparent)
             .unwrap_or_else(crate::trace::generate_traceparent);
 
-        upstream_request
-            .insert_header("traceparent", trace_ctx.traceparent())
-            .expect("traceparent is valid header value");
+        upstream_request.insert_header("traceparent", trace_ctx.traceparent())?;
 
         // Pass through tracestate if present — we don't parse it, just relay.
         if let Some(ts) = session.req_header().headers.get("tracestate")
             && let Ok(v) = ts.to_str()
         {
-            upstream_request
-                .insert_header("tracestate", v)
-                .expect("tracestate is valid header value");
+            upstream_request.insert_header("tracestate", v)?;
         }
 
         ctx.trace_ctx = Some(trace_ctx);
@@ -1518,9 +1520,7 @@ impl ProxyHttp for DwaarProxy {
         Self::CTX: Send + Sync,
     {
         // --- Request tracing (ISSUE-006) ---
-        upstream_response
-            .insert_header("X-Request-Id", ctx.request_id())
-            .expect("UUID is valid header value");
+        upstream_response.insert_header("X-Request-Id", ctx.request_id())?;
 
         // Advertise HTTP/3 only for routes the QUIC bridge can serve
         // (ReverseProxy and ReverseProxyPool). FileServer, StaticResponse,
@@ -1528,16 +1528,12 @@ impl ProxyHttp for DwaarProxy {
         // advertising Alt-Svc for those routes would cause clients to
         // attempt QUIC and get a 502.
         if self.h3_enabled && ctx.quic_capable {
-            upstream_response
-                .insert_header("Alt-Svc", r#"h3=":443"; ma=86400"#)
-                .expect("static str is valid header value");
+            upstream_response.insert_header("Alt-Svc", r#"h3=":443"; ma=86400"#)?;
         }
 
         // --- Cache status header (ISSUE-073f) ---
         if let Some(status) = ctx.cache_status {
-            upstream_response
-                .insert_header("X-Cache", status)
-                .expect("static str is valid header value");
+            upstream_response.insert_header("X-Cache", status)?;
         }
 
         // --- Intercept check (ISSUE-067) ---
@@ -1566,18 +1562,13 @@ impl ProxyHttp for DwaarProxy {
                 }
             });
             if let Some((new_status, set_headers, replace_body)) = matched {
-                if let Some(code) = new_status {
-                    upstream_response
-                        .set_status(
-                            pingora_http::StatusCode::from_u16(code)
-                                .expect("intercept status must be a valid HTTP code"),
-                        )
-                        .expect("failed to set intercept status");
+                if let Some(code) = new_status
+                    && let Ok(status) = pingora_http::StatusCode::from_u16(code)
+                {
+                    upstream_response.set_status(status)?;
                 }
                 for (name, value) in set_headers {
-                    upstream_response
-                        .insert_header(name.into_string(), value.into_string())
-                        .expect("intercept header name/value must be valid");
+                    upstream_response.insert_header(name.into_string(), value.into_string())?;
                 }
                 if let Some(body) = replace_body {
                     // Signal body replacement to response_body_filter().
@@ -1630,9 +1621,7 @@ impl ProxyHttp for DwaarProxy {
                 limit = ctx.response_body_max_size,
                 "upstream response body exceeds limit — replacing with 502"
             );
-            upstream_response
-                .set_status(pingora_http::StatusCode::from_u16(502).expect("502 is valid"))
-                .expect("failed to set 502 status");
+            upstream_response.set_status(http::StatusCode::BAD_GATEWAY)?;
             upstream_response.remove_header("Content-Length");
             ctx.intercept_body = Some(bytes::Bytes::from_static(b"upstream response too large"));
         }

--- a/crates/dwaar-docker/src/watcher.rs
+++ b/crates/dwaar-docker/src/watcher.rs
@@ -31,6 +31,17 @@ use tracing::{debug, error, info, warn};
 use crate::client::{DockerClient, DockerError};
 use crate::labels;
 
+/// Mutable state for Docker-discovered routes, protected by a single lock
+/// so both maps are always consistent (no window where one is updated but
+/// the other is stale).
+#[derive(Debug, Default)]
+struct DockerState {
+    /// Docker routes keyed by domain.
+    routes: HashMap<String, Route>,
+    /// Reverse map: container ID -> domain, for efficient cleanup on `die` events.
+    domains: HashMap<String, String>,
+}
+
 /// Watches the Docker daemon for containers with `dwaar.*` labels and
 /// maintains a merged route table combining Dwaarfile and Docker routes.
 #[derive(Debug)]
@@ -39,11 +50,9 @@ pub struct DockerWatcher {
     route_table: Arc<ArcSwap<RouteTable>>,
     dwaarfile_routes: Arc<ArcSwap<Vec<Route>>>,
     config_notify: Arc<Notify>,
-    /// Docker routes keyed by domain. Single-writer (event loop), so the
-    /// mutex never contends — it exists only for interior mutability from `&self`.
-    docker_routes: parking_lot::Mutex<HashMap<String, Route>>,
-    /// Reverse map: container ID -> domain, for efficient cleanup on `die` events.
-    container_domains: parking_lot::Mutex<HashMap<String, String>>,
+    /// Single lock protecting both route and domain maps — mutations are
+    /// always atomic with respect to both maps.
+    state: parking_lot::Mutex<DockerState>,
 }
 
 impl DockerWatcher {
@@ -58,8 +67,7 @@ impl DockerWatcher {
             route_table,
             dwaarfile_routes,
             config_notify,
-            docker_routes: parking_lot::Mutex::new(HashMap::new()),
-            container_domains: parking_lot::Mutex::new(HashMap::new()),
+            state: parking_lot::Mutex::new(DockerState::default()),
         }
     }
 
@@ -69,9 +77,13 @@ impl DockerWatcher {
         let containers = self.client.list_containers("dwaar.domain").await?;
         info!(count = containers.len(), "bootstrapping Docker containers");
 
-        // Clear stale state from any previous connection
-        self.docker_routes.lock().clear();
-        self.container_domains.lock().clear();
+        // Clear stale state from any previous connection — single lock
+        // ensures both maps are cleared atomically.
+        {
+            let mut st = self.state.lock();
+            st.routes.clear();
+            st.domains.clear();
+        }
 
         for container in &containers {
             let Some(id) = container.get("Id").and_then(|v| v.as_str()) else {
@@ -88,17 +100,17 @@ impl DockerWatcher {
                             upstream = ?cr.route.upstream(),
                             "discovered Docker route"
                         );
-                        let mut docker = self.docker_routes.lock();
-                        let mut domains = self.container_domains.lock();
-                        if docker.contains_key(&cr.route.domain) {
+                        let mut st = self.state.lock();
+                        if st.routes.contains_key(&cr.route.domain) {
                             warn!(
                                 domain = %cr.route.domain,
                                 container_id = %cr.container_id,
                                 "duplicate Docker domain — keeping first container"
                             );
                         } else {
-                            domains.insert(cr.container_id.clone(), cr.route.domain.clone());
-                            docker.insert(cr.route.domain.clone(), cr.route);
+                            st.domains
+                                .insert(cr.container_id.clone(), cr.route.domain.clone());
+                            st.routes.insert(cr.route.domain.clone(), cr.route);
                         }
                     }
                 }
@@ -136,24 +148,22 @@ impl DockerWatcher {
             "adding Docker route"
         );
 
-        let mut docker = self.docker_routes.lock();
-        let mut domains = self.container_domains.lock();
+        {
+            let mut st = self.state.lock();
 
-        if docker.contains_key(&cr.route.domain) {
-            warn!(
-                domain = %cr.route.domain,
-                container_id = %cr.container_id,
-                "duplicate Docker domain — keeping existing container"
-            );
-            return;
+            if st.routes.contains_key(&cr.route.domain) {
+                warn!(
+                    domain = %cr.route.domain,
+                    container_id = %cr.container_id,
+                    "duplicate Docker domain — keeping existing container"
+                );
+                return;
+            }
+
+            st.domains
+                .insert(cr.container_id.clone(), cr.route.domain.clone());
+            st.routes.insert(cr.route.domain.clone(), cr.route);
         }
-
-        domains.insert(cr.container_id.clone(), cr.route.domain.clone());
-        docker.insert(cr.route.domain.clone(), cr.route);
-
-        // Drop locks before merge (merge acquires docker_routes lock)
-        drop(docker);
-        drop(domains);
 
         self.merge_and_store();
     }
@@ -163,8 +173,12 @@ impl DockerWatcher {
         debug!(container_id, "container die event");
 
         let domain = {
-            let mut domains = self.container_domains.lock();
-            domains.remove(container_id)
+            let mut st = self.state.lock();
+            let domain = st.domains.remove(container_id);
+            if let Some(ref d) = domain {
+                st.routes.remove(d);
+            }
+            domain
         };
 
         let Some(domain) = domain else {
@@ -173,21 +187,20 @@ impl DockerWatcher {
         };
 
         info!(container_id, domain = %domain, "removing Docker route");
-        self.docker_routes.lock().remove(&domain);
         self.merge_and_store();
     }
 
     /// Merge Dwaarfile routes with Docker routes. Dwaarfile wins on conflict.
     fn merge_and_store(&self) {
         let dwaarfile = self.dwaarfile_routes.load();
-        let docker = self.docker_routes.lock();
+        let st = self.state.lock();
 
         let dwaarfile_routes: &[Route] = dwaarfile.as_ref();
         let dwaarfile_domains: std::collections::HashSet<&str> =
             dwaarfile_routes.iter().map(|r| r.domain.as_str()).collect();
 
         let mut merged: Vec<Route> = dwaarfile_routes.to_vec();
-        for (domain, route) in docker.iter() {
+        for (domain, route) in &st.routes {
             if dwaarfile_domains.contains(domain.as_str()) {
                 warn!(domain, "Docker route shadowed by Dwaarfile");
             } else {
@@ -349,8 +362,8 @@ mod tests {
     fn merge_adds_docker_route() {
         let watcher = make_watcher();
         {
-            let mut docker = watcher.docker_routes.lock();
-            docker.insert(
+            let mut st = watcher.state.lock();
+            st.routes.insert(
                 "docker.example.com".to_string(),
                 Route::new("docker.example.com", addr(8080), false, None),
             );
@@ -370,8 +383,8 @@ mod tests {
             None,
         )]));
         {
-            let mut docker = watcher.docker_routes.lock();
-            docker.insert(
+            let mut st = watcher.state.lock();
+            st.routes.insert(
                 "example.com".to_string(),
                 Route::new("example.com", addr(9000), false, None),
             );
@@ -387,13 +400,14 @@ mod tests {
     fn handle_die_removes_route() {
         let watcher = make_watcher();
         {
-            let mut docker = watcher.docker_routes.lock();
-            docker.insert(
+            let mut st = watcher.state.lock();
+            st.routes.insert(
                 "app.example.com".to_string(),
                 Route::new("app.example.com", addr(8080), false, None),
             );
-            let mut domains = watcher.container_domains.lock();
-            domains.insert("container123".to_string(), "app.example.com".to_string());
+            // domains inserted through the same lock
+            st.domains
+                .insert("container123".to_string(), "app.example.com".to_string());
         }
         watcher.merge_and_store();
         assert!(
@@ -418,8 +432,8 @@ mod tests {
     fn handle_die_unknown_container_is_noop() {
         let watcher = make_watcher();
         {
-            let mut docker = watcher.docker_routes.lock();
-            docker.insert(
+            let mut st = watcher.state.lock();
+            st.routes.insert(
                 "app.example.com".to_string(),
                 Route::new("app.example.com", addr(8080), false, None),
             );
@@ -441,13 +455,14 @@ mod tests {
     fn duplicate_domain_first_wins() {
         let watcher = make_watcher();
         {
-            let mut docker = watcher.docker_routes.lock();
-            docker.insert(
+            let mut st = watcher.state.lock();
+            st.routes.insert(
                 "app.com".to_string(),
                 Route::new("app.com", addr(8080), false, None),
             );
-            let mut domains = watcher.container_domains.lock();
-            domains.insert("container1".to_string(), "app.com".to_string());
+            // domains inserted through the same lock
+            st.domains
+                .insert("container1".to_string(), "app.com".to_string());
         }
         // HashMap ensures one entry per domain — inserting again overwrites,
         // but handle_start checks for duplicates before inserting
@@ -469,12 +484,12 @@ mod tests {
     fn merge_preserves_multiple_docker_routes() {
         let watcher = make_watcher();
         {
-            let mut docker = watcher.docker_routes.lock();
-            docker.insert(
+            let mut st = watcher.state.lock();
+            st.routes.insert(
                 "a.example.com".to_string(),
                 Route::new("a.example.com", addr(8001), false, None),
             );
-            docker.insert(
+            st.routes.insert(
                 "b.example.com".to_string(),
                 Route::new("b.example.com", addr(8002), true, Some(50)),
             );
@@ -503,8 +518,8 @@ mod tests {
             None,
         )]));
         {
-            let mut docker = watcher.docker_routes.lock();
-            docker.insert(
+            let mut st = watcher.state.lock();
+            st.routes.insert(
                 "api.example.com".to_string(),
                 Route::new("api.example.com", addr(8080), false, None),
             );

--- a/crates/dwaar-plugins/src/compress.rs
+++ b/crates/dwaar-plugins/src/compress.rs
@@ -127,10 +127,10 @@ pub fn negotiate_encoding(accept_encoding: &str) -> Option<CompressEncoding> {
         // Compare quality as fixed-point to avoid float comparison lint.
         // Multiply by 1000 and compare as integers (q values have at most 3 decimal places).
         #[allow(clippy::cast_possible_truncation)]
-        let q_int = (quality * 1000.0) as i32;
+        let q_int = (quality * 1000.0).round().clamp(0.0, 1000.0) as i32;
         let dominated = best.as_ref().is_none_or(|(_, bq, bp)| {
             #[allow(clippy::cast_possible_truncation)]
-            let bq_int = (*bq * 1000.0) as i32;
+            let bq_int = (*bq * 1000.0).round().clamp(0.0, 1000.0) as i32;
             q_int > bq_int || (q_int == bq_int && priority > *bp)
         });
         if dominated {


### PR DESCRIPTION
## Summary

Hardening patch: 5 fixes for audit findings and a deploy-blocking startup bug.

- **L4-only startup** — `route_table.is_empty()` guard now checks for layer4 config too
- **#144** — float-to-int truncation in compress `Accept-Encoding` negotiation
- **#145** — 13 `.expect()` calls in hot proxy path replaced with `?` propagation
- **#148** — Docker watcher dual-map race condition fixed with single `DockerState` lock
- **#151** — Beacon body overflow now returns 413 instead of parsing truncated data

## Test plan

- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] 1,094 unit tests pass
- [x] Build clean, zero warnings

## Post-merge

```bash
git checkout main && git pull
git tag v0.2.6
git push origin v0.2.6
```

Closes #144, #145, #148, #151