### PR TITLE
feat: Layer 4 hot-reload — bind/unbind TCP listeners on config change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.8] - 2026-04-13
+
+Layer 4 hot-reload — the last major gap for zero-touch deploy automation.
+
+### Added
+
+- **Layer 4 hot-reload** — `Layer4Service` now uses `ArcSwap` + `Notify` for
+  dynamic listener management. On config reload: new L4 ports are bound, removed
+  ports are cancelled, and routes on existing ports are swapped — no restart
+  needed. Follows the same proven pattern as health pools and ACME domains.
+- Added `tokio-util` dependency to `dwaar-core` for `CancellationToken` in
+  L4 listener lifecycle management.
+
 ## [0.2.7] - 2026-04-13
 
 Deploy agent compatibility patch.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-cli"
-version = "0.2.4"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1402,6 +1402,7 @@ dependencies = [
  "tokio",
  "tokio-openssl",
  "tokio-test",
+ "tokio-util",
  "tracing",
  "uuid",
 ]

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.2.7
+Licensed Work:        Dwaar 0.2.8
                       The Licensed Work is
                       (c) 2026 Permanu
 

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.2.7"
+version = "0.2.8"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-cli/src/main.rs
+++ b/crates/dwaar-cli/src/main.rs
@@ -800,6 +800,9 @@ fn run_server(
     server.add_service(admin_listening);
 
     // Layer 4 TCP proxy — bind separate listeners for non-HTTP protocols.
+    // Shared via ArcSwap so ConfigWatcher can hot-reload L4 config.
+    let l4_shared: dwaar_core::l4::SharedL4Servers;
+    let l4_reload_notify = Arc::new(tokio::sync::Notify::new());
     {
         use dwaar_config::compile::{compile_l4_servers, compile_l4_wrappers};
 
@@ -816,23 +819,27 @@ fn run_server(
         {
             l4_servers.extend(compile_l4_wrappers(&opts.layer4_listener_wrappers));
         }
-        if !l4_servers.is_empty() {
-            // Inject the shared cert store into any L4 TLS handlers so they
-            // can look up certs by SNI at accept time.
-            for server_cfg in &mut l4_servers {
-                for route in &mut server_cfg.routes {
-                    for handler in &mut route.handlers {
-                        if let dwaar_core::l4::CompiledL4Handler::Tls { cert_store: cs } = handler {
-                            *cs = Some(Arc::clone(&cert_store));
-                        }
+        // Inject the shared cert store into any L4 TLS handlers so they
+        // can look up certs by SNI at accept time.
+        for server_cfg in &mut l4_servers {
+            for route in &mut server_cfg.routes {
+                for handler in &mut route.handlers {
+                    if let dwaar_core::l4::CompiledL4Handler::Tls { cert_store: cs } = handler {
+                        *cs = Some(Arc::clone(&cert_store));
                     }
                 }
             }
-            let count = l4_servers.len();
-            let l4_service = dwaar_core::l4::Layer4Service::new(l4_servers);
-            let l4_bg =
-                pingora_core::services::background::background_service("layer4", l4_service);
-            server.add_service(l4_bg);
+        }
+
+        let count = l4_servers.len();
+        l4_shared = Arc::new(arc_swap::ArcSwap::from_pointee(l4_servers));
+        let l4_service = dwaar_core::l4::Layer4Service::new(
+            Arc::clone(&l4_shared),
+            Arc::clone(&l4_reload_notify),
+        );
+        let l4_bg = pingora_core::services::background::background_service("layer4", l4_service);
+        server.add_service(l4_bg);
+        if count > 0 {
             info!(listeners = count, "layer4 TCP proxy service registered");
         }
     }
@@ -858,6 +865,8 @@ fn run_server(
         sni_domain_map,
         cache_backend_for_watcher,
         dwaar_config,
+        l4_shared,
+        l4_reload_notify,
     );
 
     info!("entering run loop, waiting for connections or signals");
@@ -887,6 +896,8 @@ fn register_background_services(
     sni_domain_map: DomainConfigMap,
     cache_backend: Option<dwaar_core::cache::SharedCacheBackend>,
     config: &dwaar_config::model::DwaarConfig,
+    l4_servers: dwaar_core::l4::SharedL4Servers,
+    l4_reload_notify: Arc<tokio::sync::Notify>,
 ) {
     // Upstream health checker — runs as a BackgroundService (Guardrail #20).
     // Always registered; it will sleep if the pool list is empty and wake up
@@ -949,7 +960,8 @@ fn register_background_services(
     .with_sni_domain_map(sni_domain_map)
     .with_health_pools(health_pools)
     .with_acme_domains(acme_domains)
-    .with_cert_store(Arc::clone(cert_store));
+    .with_cert_store(Arc::clone(cert_store))
+    .with_l4_servers(l4_servers, l4_reload_notify);
     let config_watcher = if let Some(cb) = cache_backend {
         config_watcher.with_cache_backend(cb)
     } else {

--- a/crates/dwaar-config/src/watcher.rs
+++ b/crates/dwaar-config/src/watcher.rs
@@ -30,8 +30,13 @@ use dwaar_core::upstream::UpstreamPool;
 use dwaar_tls::cert_store::CertStore;
 
 use crate::MAX_CONFIG_SIZE;
-use crate::compile::{collect_pools, compile_acme_domains, compile_routes, compile_tls_configs};
+use crate::compile::{
+    collect_pools, compile_acme_domains, compile_l4_servers, compile_l4_wrappers, compile_routes,
+    compile_tls_configs,
+};
 use crate::parser;
+
+use dwaar_core::l4::SharedL4Servers;
 
 const DEBOUNCE_INTERVAL: Duration = Duration::from_millis(500);
 
@@ -79,6 +84,11 @@ pub struct ConfigWatcher {
     /// Shared cert store. On reload, domains removed from the SNI domain map
     /// are invalidated in the LRU cache so stale certs are never served.
     cert_store: Option<Arc<CertStore>>,
+    /// Shared L4 server list. On reload, recompiled and swapped so the
+    /// `Layer4Service` can bind new ports / drop removed ones / update routes.
+    l4_servers: Option<SharedL4Servers>,
+    /// Notify the `Layer4Service` that `l4_servers` was updated.
+    l4_notify: Option<Arc<tokio::sync::Notify>>,
     /// WASM module invalidation callback (ISSUE-120). Called for every path
     /// that was removed from the config or whose on-disk mtime changed since
     /// the previous reload. `None` leaves the cache untouched.
@@ -120,6 +130,8 @@ impl ConfigWatcher {
             acme_domains: None,
             cache_backend: None,
             cert_store: None,
+            l4_servers: None,
+            l4_notify: None,
             wasm_invalidator: None,
             wasm_mtimes: Mutex::new(HashMap::new()),
         }
@@ -180,6 +192,20 @@ impl ConfigWatcher {
     #[must_use]
     pub fn with_cert_store(mut self, store: Arc<CertStore>) -> Self {
         self.cert_store = Some(store);
+        self
+    }
+
+    /// Attach the shared L4 server list and reload notify for hot-reload.
+    /// When the config changes, the watcher recompiles L4 servers, stores
+    /// them via `ArcSwap`, and notifies the `Layer4Service` to rebind.
+    #[must_use]
+    pub fn with_l4_servers(
+        mut self,
+        servers: SharedL4Servers,
+        notify: Arc<tokio::sync::Notify>,
+    ) -> Self {
+        self.l4_servers = Some(servers);
+        self.l4_notify = Some(notify);
         self
     }
 
@@ -335,6 +361,29 @@ impl ConfigWatcher {
         // ISSUE-120: diff WASM module references against the previous reload
         // and invalidate anything that was removed or whose file changed.
         refresh_wasm_cache(self.wasm_invalidator.as_ref(), &self.wasm_mtimes, &config);
+
+        // Refresh L4 servers — recompile and notify the Layer4Service to
+        // diff listeners (bind new, drop removed, swap routes on existing).
+        if let Some(ref l4) = self.l4_servers {
+            let mut new_l4 = Vec::new();
+            if let Some(l4_cfg) = config
+                .global_options
+                .as_ref()
+                .and_then(|g| g.layer4.as_ref())
+            {
+                new_l4.extend(compile_l4_servers(l4_cfg));
+            }
+            if let Some(ref opts) = config.global_options
+                && !opts.layer4_listener_wrappers.is_empty()
+            {
+                new_l4.extend(compile_l4_wrappers(&opts.layer4_listener_wrappers));
+            }
+            l4.store(Arc::new(new_l4));
+            if let Some(ref notify) = self.l4_notify {
+                notify.notify_one();
+            }
+            debug!("layer4 servers refreshed");
+        }
 
         if let Some(ref snapshot) = self.dwaarfile_snapshot {
             // Docker mode: update snapshot, notify DockerWatcher to re-merge

--- a/crates/dwaar-core/Cargo.toml
+++ b/crates/dwaar-core/Cargo.toml
@@ -37,6 +37,7 @@ thiserror = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["net", "io-util", "time"] }
+tokio-util = "0.7"
 fastrand = { workspace = true }
 quinn = { workspace = true }
 rustls = { workspace = true }

--- a/crates/dwaar-core/src/l4.rs
+++ b/crates/dwaar-core/src/l4.rs
@@ -278,65 +278,153 @@ impl CompiledL4Handler {
 
 // ── Service ─────────────────────────────────────────────────────────────
 
-/// Background service that runs one or more Layer 4 TCP listeners.
+/// Shared L4 server config behind `ArcSwap`, used by both `Layer4Service`
+/// and `ConfigWatcher` for hot-reload.
+pub type SharedL4Servers = Arc<arc_swap::ArcSwap<Vec<CompiledL4Server>>>;
+
+/// Background service that runs Layer 4 TCP listeners with hot-reload support.
+///
+/// On startup, binds all configured listeners. When notified via `reload_notify`,
+/// diffs the new config against running listeners: binds new ports, drops removed
+/// ports, and swaps routes on existing ports — no restart needed.
 pub struct Layer4Service {
-    servers: Vec<CompiledL4Server>,
+    servers: SharedL4Servers,
+    reload_notify: Arc<tokio::sync::Notify>,
 }
 
 impl std::fmt::Debug for Layer4Service {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Layer4Service")
-            .field("servers", &self.servers.len())
+            .field("servers", &self.servers.load().len())
+            .field("reload_notify", &"Notify")
             .finish()
     }
 }
 
 impl Layer4Service {
-    pub fn new(servers: Vec<CompiledL4Server>) -> Self {
-        Self { servers }
+    pub fn new(servers: SharedL4Servers, reload_notify: Arc<tokio::sync::Notify>) -> Self {
+        Self {
+            servers,
+            reload_notify,
+        }
     }
+}
+
+/// State for a single running listener — tracks the cancel token so we can
+/// stop it on reload when its listen address is removed.
+struct LiveListener {
+    cancel: tokio_util::sync::CancellationToken,
+    /// The server config driving this listener, swappable for route updates.
+    server: Arc<arc_swap::ArcSwap<CompiledL4Server>>,
 }
 
 #[async_trait]
 impl BackgroundService for Layer4Service {
     async fn start(&self, shutdown: ShutdownWatch) {
-        let mut listeners = Vec::new();
+        let mut live: std::collections::HashMap<SocketAddr, LiveListener> =
+            std::collections::HashMap::new();
+        let mut tasks = tokio::task::JoinSet::new();
 
-        for server in &self.servers {
-            match TcpListener::bind(server.listen).await {
-                Ok(listener) => {
-                    info!(addr = %server.listen, routes = server.routes.len(), "L4 listener bound");
-                    listeners.push((listener, server.clone()));
+        // Initial bind
+        bind_new_listeners(&self.servers.load(), &mut live, &mut tasks, &shutdown);
+
+        if live.is_empty() {
+            info!("layer4 service started — no initial listeners, waiting for reload");
+        }
+
+        loop {
+            tokio::select! {
+                () = self.reload_notify.notified() => {
+                    let new_servers = self.servers.load();
+                    let new_addrs: std::collections::HashSet<SocketAddr> =
+                        new_servers.iter().map(|s| s.listen).collect();
+
+                    // Remove listeners for addresses no longer in config
+                    live.retain(|addr, ll| {
+                        if new_addrs.contains(addr) {
+                            true
+                        } else {
+                            info!(addr = %addr, "L4 listener removed by reload");
+                            ll.cancel.cancel();
+                            false
+                        }
+                    });
+
+                    // Update routes on existing listeners, bind new ones
+                    for server in new_servers.iter() {
+                        if let Some(ll) = live.get(&server.listen) {
+                            // Existing listener — swap routes
+                            ll.server.store(Arc::new(server.clone()));
+                            debug!(addr = %server.listen, "L4 listener routes updated");
+                        }
+                        // else: new address — bind below
+                    }
+                    bind_new_listeners(&new_servers, &mut live, &mut tasks, &shutdown);
                 }
-                Err(e) => {
-                    error!(addr = %server.listen, error = %e, "failed to bind L4 listener");
+                _ = tasks.join_next(), if !tasks.is_empty() => {
+                    // A listener task completed (cancelled or errored) — no action needed,
+                    // it was already removed from `live` by the reload branch.
+                }
+                () = shutdown_signal(&shutdown) => {
+                    info!("L4 service shutting down");
+                    // Cancel all listeners
+                    for ll in live.values() {
+                        ll.cancel.cancel();
+                    }
+                    // Drain remaining tasks
+                    while tasks.join_next().await.is_some() {}
+                    return;
                 }
             }
         }
+    }
+}
 
-        if listeners.is_empty() {
-            warn!("no L4 listeners bound — layer4 service idle");
-            return;
+/// Bind listeners for addresses not already in `live` and spawn accept loops.
+fn bind_new_listeners(
+    servers: &[CompiledL4Server],
+    live: &mut std::collections::HashMap<SocketAddr, LiveListener>,
+    tasks: &mut tokio::task::JoinSet<()>,
+    shutdown: &ShutdownWatch,
+) {
+    for server in servers {
+        if live.contains_key(&server.listen) {
+            continue;
         }
+        let addr = server.listen;
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let server_swap = Arc::new(arc_swap::ArcSwap::from_pointee(server.clone()));
 
-        let mut tasks = tokio::task::JoinSet::new();
+        let cancel_clone = cancel.clone();
+        let server_clone = Arc::clone(&server_swap);
+        let shutdown = shutdown.clone();
 
-        for (listener, server) in listeners {
-            let shutdown = shutdown.clone();
-            let server = Arc::new(server);
-            tasks.spawn(async move {
-                run_listener(listener, server, shutdown).await;
-            });
-        }
+        tasks.spawn(async move {
+            match TcpListener::bind(addr).await {
+                Ok(listener) => {
+                    info!(addr = %addr, "L4 listener bound");
+                    run_listener(listener, server_clone, cancel_clone, shutdown).await;
+                }
+                Err(e) => {
+                    error!(addr = %addr, error = %e, "failed to bind L4 listener");
+                }
+            }
+        });
 
-        // Wait for all listener tasks to complete (on shutdown).
-        while tasks.join_next().await.is_some() {}
+        live.insert(
+            addr,
+            LiveListener {
+                cancel,
+                server: server_swap,
+            },
+        );
     }
 }
 
 async fn run_listener(
     listener: TcpListener,
-    server: Arc<CompiledL4Server>,
+    server: Arc<arc_swap::ArcSwap<CompiledL4Server>>,
+    cancel: tokio_util::sync::CancellationToken,
     shutdown: ShutdownWatch,
 ) {
     loop {
@@ -344,7 +432,7 @@ async fn run_listener(
             result = listener.accept() => {
                 match result {
                     Ok((stream, peer)) => {
-                        let server = Arc::clone(&server);
+                        let server = Arc::clone(&server.load());
                         tokio::spawn(async move {
                             if let Err(e) = handle_connection(stream, peer, &server).await {
                                 debug!(peer = %peer, error = %e, "L4 connection error");
@@ -356,6 +444,10 @@ async fn run_listener(
                         tokio::time::sleep(Duration::from_millis(100)).await;
                     }
                 }
+            }
+            () = cancel.cancelled() => {
+                info!("L4 listener cancelled by reload");
+                return;
             }
             () = shutdown_signal(&shutdown) => {
                 info!("L4 listener shutting down");


### PR DESCRIPTION
## Summary

Layer 4 listeners were the last major hot-reload gap — TCP proxy config changes required a full restart. This PR makes them fully dynamic.

### What changed

**`dwaar-core/src/l4.rs`** — `Layer4Service` redesigned:
- `servers: Vec` → `servers: SharedL4Servers` (ArcSwap)
- New `reload_notify: Notify` channel from ConfigWatcher
- `LiveListener` tracks per-listener `CancellationToken` for clean teardown
- `bind_new_listeners()` diffs running listeners vs new config
- On reload: bind new ports, cancel removed ports, swap routes on existing

**`dwaar-config/src/watcher.rs`** — L4 reload in `try_reload()`:
- Recompiles `compile_l4_servers` + `compile_l4_wrappers` from new config
- Stores via ArcSwap, notifies Layer4Service
- Builder: `.with_l4_servers(servers, notify)`

**`dwaar-cli/src/main.rs`** — wiring:
- L4 ArcSwap + Notify created alongside service
- Passed through to ConfigWatcher via builder

### Pattern

Same proven `ArcSwap` + `Notify` pattern used by health pools, ACME domains, and SNI domain map. No new abstractions.

## Test plan

- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] 1,095 unit tests pass
- [x] Build clean, zero warnings