### PR TITLE
fix: imported config files now trigger L4 hot-reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-04-13
+
+Hotfix: imported config files now work with hot-reload.
+
+### Fixed
+
+- **Import resolution used CWD instead of config directory** — `parser::parse()`
+  resolved `import` paths relative to the working directory, not the Dwaarfile's
+  parent. On servers where CWD is `/`, imported files were never found.
+- **Imported file changes didn't trigger reload** — the content hash was computed
+  from the raw Dwaarfile only. Now hashes the expanded content (after import
+  expansion) so changes to any imported file trigger a reload.
+- **Config watcher now watches recursively** — `RecursiveMode::Recursive` ensures
+  changes to imported files in subdirectories (e.g. `apps/*.dwaar`) are detected.
+- Added `parse_expanded()` entry point for pre-expanded config text, avoiding
+  double import expansion in the watcher.
+
 ## [0.2.8] - 2026-04-13
 
 Layer 4 hot-reload — the last major gap for zero-touch deploy automation.

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.2.8
+Licensed Work:        Dwaar 0.2.9
                       The Licensed Work is
                       (c) 2026 Permanu
 

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.2.8"
+version = "0.2.9"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-config/src/parser/mod.rs
+++ b/crates/dwaar-config/src/parser/mod.rs
@@ -62,7 +62,15 @@ pub fn parse_with_base_dir(
     base_dir: &std::path::Path,
 ) -> Result<DwaarConfig, ParseError> {
     let expanded = crate::import::expand_imports(input, base_dir)?;
-    let mut tokenizer = Tokenizer::new(&expanded);
+    parse_expanded(&expanded)
+}
+
+/// Parse pre-expanded config text (imports already resolved).
+///
+/// Used by [`ConfigWatcher`] which expands imports separately to hash the
+/// expanded content before parsing.
+pub fn parse_expanded(input: &str) -> Result<DwaarConfig, ParseError> {
+    let mut tokenizer = Tokenizer::new(input);
     parse_config(&mut tokenizer)
 }
 

--- a/crates/dwaar-config/src/watcher.rs
+++ b/crates/dwaar-config/src/watcher.rs
@@ -283,8 +283,23 @@ impl ConfigWatcher {
             }
         };
 
-        // Content hash comparison
-        let new_hash = match openssl::hash::hash(MessageDigest::sha256(), content.as_bytes()) {
+        // Expand imports first so the hash covers imported file contents too.
+        // When an agent writes to an imported file (e.g. tcp.dwaar), the main
+        // Dwaarfile doesn't change — but the expanded text does.
+        let base_dir = self
+            .config_path
+            .parent()
+            .unwrap_or(std::path::Path::new("."));
+        let expanded = match crate::import::expand_imports(&content, base_dir) {
+            Ok(e) => e,
+            Err(e) => {
+                error!(error = %e, "import expansion failed — keeping current config");
+                return;
+            }
+        };
+
+        // Hash the expanded content (includes all imported files)
+        let new_hash = match openssl::hash::hash(MessageDigest::sha256(), expanded.as_bytes()) {
             Ok(h) => {
                 let mut arr = [0u8; 32];
                 arr.copy_from_slice(&h);
@@ -304,8 +319,8 @@ impl ConfigWatcher {
             }
         }
 
-        // Parse
-        let config = match parser::parse(&content) {
+        // Parse the already-expanded content (no double-expansion).
+        let config = match parser::parse_expanded(&expanded) {
             Ok(c) => c,
             Err(e) => {
                 error!(error = %e, "config parse failed — keeping current config");
@@ -480,9 +495,10 @@ fn setup_watcher(
         notify::Config::default(),
     )?;
 
-    // Watch the parent directory (handles atomic rename patterns)
+    // Watch the parent directory recursively so changes to imported files
+    // (e.g. apps/*.dwaar) also trigger a reload check.
     let parent = config_path.parent().unwrap_or(std::path::Path::new("."));
-    watcher.watch(parent, RecursiveMode::NonRecursive)?;
+    watcher.watch(parent, RecursiveMode::Recursive)?;
 
     Ok(watcher)
 }


### PR DESCRIPTION
## Summary

Deploy agents write L4 config to imported files (e.g. `tcp.dwaar`), but Dwaar's reload path never picked up those changes. Three root causes:

1. **Wrong base dir** — `parser::parse()` resolved imports relative to CWD (`/` on servers), not the Dwaarfile's directory (`/etc/dwaar/`)
2. **Hash only covered main file** — changes to imported files didn't change the hash → reload skipped
3. **Non-recursive watch** — subdirectory imports (`apps/*.dwaar`) weren't detected by the file watcher

### Changes

- **`watcher.rs`** — expand imports before hashing; hash the expanded content; use `parse_expanded()` to avoid double expansion; watch recursively
- **`parser/mod.rs`** — add `parse_expanded()` for pre-expanded config text
- Bump to v0.2.9

## Test plan

- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] 1,095 unit tests pass
- [x] Existing `imported_layer4_block_parsed` test confirms import+parse works