### PR TITLE
feat: L4 TLS termination with explicit cert/key for database proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.10] - 2026-04-13
+
+Layer 4 TLS termination with explicit cert/key — enables encrypted database
+and TCP proxy connections without an HTTP site block.
+
+### Added
+
+- **L4 TLS with explicit cert/key paths** — the `tls { cert ... key ... }`
+  config block in layer4 handlers now loads certs directly from disk instead
+  of requiring a shared HTTP `CertStore` entry. This enables TLS termination
+  for L4-only services like PostgreSQL, MySQL, and Redis proxies where no
+  corresponding HTTP site block exists.
+- Two-mode TLS resolution: explicit cert/key paths take priority; falls back
+  to `CertStore` SNI lookup for domains that share certs with HTTP sites.
+
+### Example
+
+```
+layer4 {
+    :5432 {
+        route {
+            tls {
+                cert /etc/dwaar/certs/db.crt
+                key  /etc/dwaar/certs/db.key
+            }
+            proxy 172.18.0.2:5432
+        }
+    }
+}
+```
+
+External clients connect with `sslmode=require` and Dwaar terminates TLS
+before forwarding plaintext to the container on the same host.
+
 ## [0.2.9] - 2026-04-13
 
 Hotfix: imported config files now work with hot-reload.

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.2.9
+Licensed Work:        Dwaar 0.2.10
                       The Licensed Work is
                       (c) 2026 Permanu
 

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.2.9"
+version = "0.2.10"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-cli/src/main.rs
+++ b/crates/dwaar-cli/src/main.rs
@@ -824,7 +824,7 @@ fn run_server(
         for server_cfg in &mut l4_servers {
             for route in &mut server_cfg.routes {
                 for handler in &mut route.handlers {
-                    if let dwaar_core::l4::CompiledL4Handler::Tls { cert_store: cs } = handler {
+                    if let dwaar_core::l4::CompiledL4Handler::Tls { cert_store: cs, .. } = handler {
                         *cs = Some(Arc::clone(&cert_store));
                     }
                 }

--- a/crates/dwaar-config/src/compile.rs
+++ b/crates/dwaar-config/src/compile.rs
@@ -455,7 +455,23 @@ fn compile_l4_handler(handler: &Layer4Handler) -> Option<CompiledL4Handler> {
                 connect_timeout,
             ))
         }
-        Layer4Handler::Tls(_) => Some(CompiledL4Handler::Tls { cert_store: None }),
+        Layer4Handler::Tls(tls) => {
+            let cert_path = tls
+                .options
+                .iter()
+                .find(|o| o.name == "cert")
+                .and_then(|o| o.args.first().cloned());
+            let key_path = tls
+                .options
+                .iter()
+                .find(|o| o.name == "key")
+                .and_then(|o| o.args.first().cloned());
+            Some(CompiledL4Handler::Tls {
+                cert_path,
+                key_path,
+                cert_store: None,
+            })
+        }
         Layer4Handler::Subroute(sub) => {
             let routes = compile_l4_routes(&sub.matchers, &sub.routes);
             let timeout = sub

--- a/crates/dwaar-core/src/l4.rs
+++ b/crates/dwaar-core/src/l4.rs
@@ -196,14 +196,19 @@ pub enum CompiledL4Handler {
     },
     /// TLS termination — decrypt then pass to the next handler in the chain.
     ///
-    /// Carries the cert store so the acceptor can look up the right cert for
-    /// the SNI hostname parsed from the `ClientHello` peek. We avoid baking in
-    /// an `SslAcceptor` because certs are hot-reloadable; the store handles
-    /// its own LRU cache.
+    /// Two modes:
+    /// 1. **Explicit cert/key** — loaded from paths in the `tls { cert ... key ... }`
+    ///    config block. Used for L4-only services (databases, TCP) that have no
+    ///    corresponding HTTP site block.
+    /// 2. **`CertStore` SNI lookup** — falls back to the shared HTTP cert store
+    ///    when no explicit paths are given.
     Tls {
+        /// Explicit cert file path from config (e.g. `/etc/dwaar/certs/db.crt`).
+        cert_path: Option<String>,
+        /// Explicit key file path from config (e.g. `/etc/dwaar/certs/db.key`).
+        key_path: Option<String>,
         /// Injected at runtime in main.rs after compilation. `None` during
-        /// the compile phase; the service refuses TLS if still `None` at
-        /// accept time.
+        /// the compile phase; used as fallback when no explicit cert/key paths.
         cert_store: Option<Arc<CertStore>>,
     },
     /// Nested routing after decryption.
@@ -234,7 +239,13 @@ impl Clone for CompiledL4Handler {
                 fail_duration: *fail_duration,
                 connect_timeout: *connect_timeout,
             },
-            Self::Tls { cert_store } => Self::Tls {
+            Self::Tls {
+                cert_path,
+                key_path,
+                cert_store,
+            } => Self::Tls {
+                cert_path: cert_path.clone(),
+                key_path: key_path.clone(),
                 cert_store: cert_store.clone(),
             },
             Self::Subroute {
@@ -667,19 +678,23 @@ async fn execute_handlers(
                 }
             }
         }
-        CompiledL4Handler::Tls { cert_store } => {
-            let Some(cert_store) = cert_store else {
-                warn!(peer = %peer, "L4 TLS handler: no cert store injected — dropping connection");
-                return Ok(());
-            };
-
-            // Build an acceptor using the cert for the SNI we already parsed
-            // from the peeked `ClientHello`. The acceptor is built per-connection
-            // because each connection may carry a different SNI. CertStore
-            // handles its own LRU caching of the parsed cert+key.
+        CompiledL4Handler::Tls {
+            cert_path,
+            key_path,
+            cert_store,
+        } => {
+            // Build an acceptor using explicit cert/key or CertStore fallback.
+            // The acceptor is built per-connection because each connection may
+            // carry a different SNI. CertStore handles its own LRU caching.
             let sni = parse_tls_client_hello(peeked).and_then(|h| h.sni);
 
-            let acceptor = build_ssl_acceptor(cert_store, sni.as_deref(), peer)?;
+            let acceptor = build_ssl_acceptor(
+                cert_path.as_deref(),
+                key_path.as_deref(),
+                cert_store.as_ref(),
+                sni.as_deref(),
+                peer,
+            )?;
 
             // Drive the TLS handshake asynchronously.
             // The `ClientHello` bytes are still in the kernel socket buffer
@@ -1256,8 +1271,15 @@ async fn execute_handlers_on_decrypted(
 /// anyway. The `CertStore` handles LRU caching of parsed cert+key, so the
 /// only cost here is `SslAcceptor` construction (~microseconds vs handshake
 /// latency at ~milliseconds).
+/// Build an `SslAcceptor` for L4 TLS termination.
+///
+/// Two modes:
+/// - **Explicit paths**: load cert/key directly from disk (L4-only services)
+/// - **`CertStore` fallback**: look up cert by SNI from the shared store (HTTP sites)
 fn build_ssl_acceptor(
-    cert_store: &Arc<CertStore>,
+    cert_path: Option<&str>,
+    key_path: Option<&str>,
+    cert_store: Option<&Arc<CertStore>>,
     sni: Option<&str>,
     peer: SocketAddr,
 ) -> Result<SslAcceptor, L4Error> {
@@ -1267,17 +1289,31 @@ fn build_ssl_acceptor(
     // No client cert verification at L4 — mTLS is the HTTP layer's concern.
     builder.set_verify(SslVerifyMode::NONE);
 
-    let cached = sni.and_then(|name| cert_store.get(name)).ok_or_else(|| {
-        warn!(peer = %peer, sni = ?sni, "L4 TLS: no cert for SNI — dropping");
-        L4Error::TlsNoCert(sni.map(str::to_owned))
-    })?;
+    if let (Some(cert), Some(key)) = (cert_path, key_path) {
+        // Explicit cert/key from config — load from disk.
+        builder
+            .set_certificate_chain_file(cert)
+            .map_err(|e| L4Error::TlsConfig(format!("failed to load cert {cert}: {e}")))?;
+        builder
+            .set_private_key_file(key, openssl::ssl::SslFiletype::PEM)
+            .map_err(|e| L4Error::TlsConfig(format!("failed to load key {key}: {e}")))?;
+    } else if let Some(cert_store) = cert_store {
+        // CertStore SNI lookup — shared with HTTP layer.
+        let cached = sni.and_then(|name| cert_store.get(name)).ok_or_else(|| {
+            warn!(peer = %peer, sni = ?sni, "L4 TLS: no cert for SNI — dropping");
+            L4Error::TlsNoCert(sni.map(str::to_owned))
+        })?;
+        builder
+            .set_certificate(&cached.cert)
+            .map_err(|e| L4Error::TlsConfig(e.to_string()))?;
+        builder
+            .set_private_key(&cached.key)
+            .map_err(|e| L4Error::TlsConfig(e.to_string()))?;
+    } else {
+        warn!(peer = %peer, "L4 TLS: no cert source configured — dropping");
+        return Err(L4Error::TlsNoCert(sni.map(str::to_owned)));
+    }
 
-    builder
-        .set_certificate(&cached.cert)
-        .map_err(|e| L4Error::TlsConfig(e.to_string()))?;
-    builder
-        .set_private_key(&cached.key)
-        .map_err(|e| L4Error::TlsConfig(e.to_string()))?;
     // Verify key matches cert — gives a clean error before the handshake
     // rather than a cryptic SSL alert mid-connection.
     builder


### PR DESCRIPTION
## Summary

Completes the L4 TLS termination pipeline. The parser already accepted `tls { cert ... key ... }` blocks but the compiler discarded all options — only `CertStore` SNI lookup worked, which requires an HTTP site block.

### The gap

```
layer4 {
    :5432 {
        route {
            tls {
                cert /etc/dwaar/certs/db.crt    ← parsed but DISCARDED
                key  /etc/dwaar/certs/db.key     ← parsed but DISCARDED
            }
            proxy 172.18.0.2:5432
        }
    }
}
```

External clients with `sslmode=require` got connection refused — no cert available.

### The fix

- **Compiler** extracts `cert` and `key` from `Layer4TlsHandler.options` into `CompiledL4Handler::Tls { cert_path, key_path, cert_store }`
- **Runtime** `build_ssl_acceptor()` now has two modes:
  1. Explicit paths → `set_certificate_chain_file()` + `set_private_key_file()` from disk
  2. `CertStore` fallback → SNI lookup (existing behavior for HTTP-shared certs)
- **main.rs** cert_store injection updated for the new struct fields

### Security chain complete

1. At rest in DB: AES-256-GCM encrypted
2. API response: HTTPS
3. UI: masked by default
4. Dwaarfile: only container IP + port, never passwords
5. **Database connection: TLS-terminated by Dwaar L4** (this PR)

## Test plan

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] 1,095 unit tests pass
- [x] Build clean, zero warnings