### PR TITLE
fix: L4 dual-stack bind — accept both IPv4 and IPv6 connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.11] - 2026-04-13
+
+### Fixed
+
+- **L4 listeners now dual-stack (IPv4 + IPv6)** — bare `:port` in layer4
+  config now binds to `[::]` instead of `0.0.0.0`, enabling both IPv4 and
+  IPv6 connections on the same listener. Linux dual-stack sockets accept
+  both address families by default.
+
 ## [0.2.10] - 2026-04-13
 
 Layer 4 TLS termination with explicit cert/key — enables encrypted database

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.2.10
+Licensed Work:        Dwaar 0.2.11
                       The Licensed Work is
                       (c) 2026 Permanu
 

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.2.10"
+version = "0.2.11"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-config/src/compile.rs
+++ b/crates/dwaar-config/src/compile.rs
@@ -492,8 +492,10 @@ fn compile_l4_handler(handler: &Layer4Handler) -> Option<CompiledL4Handler> {
 }
 
 fn parse_l4_listen_addr(s: &str) -> Option<std::net::SocketAddr> {
+    // Bare `:port` binds to [::] (IPv6 any) which is dual-stack on Linux —
+    // accepts both IPv4 and IPv6 connections on the same listener.
     let normalized = if s.starts_with(':') {
-        format!("0.0.0.0{s}")
+        format!("[::]{s}")
     } else {
         s.to_string()
     };


### PR DESCRIPTION
## Summary

One-line fix: `:port` in layer4 config binds `[::]:port` (dual-stack) instead of `0.0.0.0:port` (IPv4-only).

### Before
```
layer4 { :5432 { ... } }  →  binds 0.0.0.0:5432  →  IPv4 only
                              159.69.x.x:5432 ✓
                              [2a01:...]:5432 ✗  connection refused
```

### After
```
layer4 { :5432 { ... } }  →  binds [::]:5432  →  dual-stack
                              159.69.x.x:5432 ✓
                              [2a01:...]:5432 ✓
```

On Linux, `[::]` is dual-stack by default — one listener, both address families.

## Test plan

- [x] 262 config tests pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean