### PR TITLE
chore: bump version to 0.2.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-cli"
-version = "0.2.11"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.2.11
+Licensed Work:        Dwaar 0.2.13
                       The Licensed Work is
                       (c) 2026 Permanu
 
@@ -65,7 +65,7 @@ Additional Use Grant: You may use, copy, modify, create derivative works of,
                         of the Licensed Work as part of a commercial
                         infrastructure or platform product.
 
-Change Date:          2036-04-13
+Change Date:          2036-04-14
 
 Change License:       GNU Affero General Public License v3.0
 

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.2.11"
+version = "0.2.13"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false


### PR DESCRIPTION
## Summary

- Bump LICENSE and Cargo.toml version to 0.2.13 to match release tag
- Required by CI release workflow which validates version consistency

## Test plan

- [ ] CI passes