### PR TITLE
fix: enable auto_update by default in installer

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -222,6 +222,10 @@ write_dwaarfile_system() {
     CONTENT='{
     admin unix//run/dwaar/admin.sock
 
+    auto_update {
+        on_new_version reload
+    }
+
     log default {
         output file /var/log/dwaar/access.log {
             roll_size_mb 50


### PR DESCRIPTION
## Summary

- Add `auto_update { on_new_version reload }` to the default Dwaarfile written by `scripts/install.sh`
- New installs will automatically check for and apply updates every 6 hours (the default `check_interval`)
- Existing installs are unaffected (installer never overwrites an existing Dwaarfile)

## Test plan

- [ ] CI passes
- [ ] Verified manually on test VPS — auto-update service starts successfully