### PR TITLE
feat: h2c:// scheme support + grpc auto-h2 upstream

### DIFF
--- a/crates/dwaar-cli/src/main.rs
+++ b/crates/dwaar-cli/src/main.rs
@@ -55,7 +55,7 @@ use dwaar_analytics::beacon;
 use dwaar_config::MAX_CONFIG_SIZE;
 use dwaar_config::compile::{
     BindAddress, collect_pools, compile_acme_domains, compile_routes, compile_tls_configs,
-    extract_bind_addresses, has_tls_sites,
+    extract_bind_addresses, extract_tls_bind_addresses, has_tls_sites,
 };
 use dwaar_config::watcher::{ConfigWatcher, hash_content};
 use dwaar_core::proxy::DwaarProxy;
@@ -714,12 +714,14 @@ fn run_server(
     // sni_domain_map is shared between SniResolver (which reads it on every
     // TLS handshake) and ConfigWatcher (which swaps in a new map on reload).
     // When TLS is disabled the map stays empty and is never written to.
+    let tls_bind_addrs = extract_tls_bind_addresses(dwaar_config);
     let sni_domain_map: DomainConfigMap = if has_tls_sites(dwaar_config) {
         setup_tls_listener(
             dwaar_config,
             &mut proxy_service,
             &cert_store,
             worker_count > 1,
+            &tls_bind_addrs,
         )?
     } else {
         domain_config_map_empty()
@@ -1156,6 +1158,7 @@ fn setup_tls_listener(
     >,
     cert_store: &Arc<CertStore>,
     use_reuseport: bool,
+    tls_bind_addrs: &[BindAddress],
 ) -> anyhow::Result<DomainConfigMap> {
     let tls_configs = compile_tls_configs(config);
 
@@ -1205,9 +1208,13 @@ fn setup_tls_listener(
         None
     };
 
-    proxy_service.add_tls_with_settings("0.0.0.0:6189", tcp_opt, tls_settings);
+    let tls_listen_addr = match tls_bind_addrs.first() {
+        Some(BindAddress::Tcp(a)) => a.as_str(),
+        _ => "0.0.0.0:6189",
+    };
+    proxy_service.add_tls_with_settings(tls_listen_addr, tcp_opt, tls_settings);
     info!(
-        listen = "0.0.0.0:6189",
+        listen = tls_listen_addr,
         protocol = "https",
         "TLS listener registered"
     );

--- a/crates/dwaar-config/src/compile.rs
+++ b/crates/dwaar-config/src/compile.rs
@@ -661,17 +661,17 @@ pub fn extract_tls_bind_addresses(config: &DwaarConfig) -> Vec<BindAddress> {
     let mut addrs: Vec<BindAddress> = Vec::new();
 
     for site in &config.sites {
-        if site_has_tls(&site.directives) {
-            if let Some(bind) = find_bind(&site.directives) {
-                for raw in &bind.addresses {
-                    let addr = parse_bind_address(raw);
-                    let key = match &addr {
-                        BindAddress::Tcp(s) => s.clone(),
-                        BindAddress::Unix(p) => p.to_string_lossy().into_owned(),
-                    };
-                    if seen.insert(key) {
-                        addrs.push(addr);
-                    }
+        if site_has_tls(&site.directives)
+            && let Some(bind) = find_bind(&site.directives)
+        {
+            for raw in &bind.addresses {
+                let addr = parse_bind_address(raw);
+                let key = match &addr {
+                    BindAddress::Tcp(s) => s.clone(),
+                    BindAddress::Unix(p) => p.to_string_lossy().into_owned(),
+                };
+                if seen.insert(key) {
+                    addrs.push(addr);
                 }
             }
         }

--- a/crates/dwaar-config/src/compile.rs
+++ b/crates/dwaar-config/src/compile.rs
@@ -591,6 +591,9 @@ pub fn compile_acme_domains(config: &DwaarConfig) -> Vec<String> {
 /// The fallback HTTP listen address when no `bind` directive is present.
 const DEFAULT_HTTP_BIND: &str = "0.0.0.0:6188";
 
+/// The fallback TLS listen address when no TLS site has a `bind` directive.
+const DEFAULT_TLS_BIND: &str = "0.0.0.0:6189";
+
 /// The fallback port appended when a `bind` address has no port.
 const DEFAULT_BIND_PORT: u16 = 6188;
 
@@ -643,6 +646,40 @@ pub fn extract_bind_addresses(config: &DwaarConfig) -> Vec<BindAddress> {
     // Fall back to the built-in default when no site specifies bind.
     if addrs.is_empty() {
         addrs.push(BindAddress::Tcp(DEFAULT_HTTP_BIND.to_owned()));
+    }
+
+    addrs
+}
+
+/// Extract TLS listener addresses from a parsed config.
+///
+/// Similar to [`extract_bind_addresses`] but only considers sites that have
+/// TLS directives (i.e. `site_has_tls` returns true). Falls back to
+/// `"0.0.0.0:6189"` when no TLS site specifies a `bind` directive.
+pub fn extract_tls_bind_addresses(config: &DwaarConfig) -> Vec<BindAddress> {
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut addrs: Vec<BindAddress> = Vec::new();
+
+    for site in &config.sites {
+        if site_has_tls(&site.directives) {
+            if let Some(bind) = find_bind(&site.directives) {
+                for raw in &bind.addresses {
+                    let addr = parse_bind_address(raw);
+                    let key = match &addr {
+                        BindAddress::Tcp(s) => s.clone(),
+                        BindAddress::Unix(p) => p.to_string_lossy().into_owned(),
+                    };
+                    if seen.insert(key) {
+                        addrs.push(addr);
+                    }
+                }
+            }
+        }
+    }
+
+    // Fall back to the built-in default when no TLS site specifies bind.
+    if addrs.is_empty() {
+        addrs.push(BindAddress::Tcp(DEFAULT_TLS_BIND.to_owned()));
     }
 
     addrs
@@ -1107,7 +1144,8 @@ fn resolve_all_upstreams(upstreams: &[UpstreamAddr]) -> Vec<SocketAddr> {
 /// even if the user didn't explicitly set `transport { h2 }`.
 fn force_upstream_h2(handler: &mut Handler) {
     match handler {
-        Handler::ReverseProxy { upstream_h2, .. } | Handler::ReverseProxyPool { upstream_h2, .. } => {
+        Handler::ReverseProxy { upstream_h2, .. }
+        | Handler::ReverseProxyPool { upstream_h2, .. } => {
             *upstream_h2 = true;
         }
         _ => {}

--- a/crates/dwaar-config/src/compile.rs
+++ b/crates/dwaar-config/src/compile.rs
@@ -97,9 +97,13 @@ pub fn compile_routes(config: &DwaarConfig) -> RouteTable {
         // Try reverse_proxy first (most common)
         if let Some(rp) = find_reverse_proxy(&site.directives) {
             let handler_result = compile_reverse_proxy_handler(rp, &site.address);
-            let Some(proxy_handler) = handler_result else {
+            let Some(mut proxy_handler) = handler_result else {
                 continue;
             };
+            // gRPC requires HTTP/2 upstream — force h2 when the grpc directive is present.
+            if is_grpc_route {
+                force_upstream_h2(&mut proxy_handler);
+            }
             let handler = HandlerBlock {
                 kind: BlockKind::Handle,
                 matcher: PathMatcher::Any,
@@ -783,7 +787,7 @@ fn compile_single_block(
     }
 
     // Find the handler directive inside the block
-    let handler = if let Some(rp) = find_reverse_proxy(inner_directives) {
+    let mut handler = if let Some(rp) = find_reverse_proxy(inner_directives) {
         compile_reverse_proxy_handler(rp, "handle block")?
     } else if let Some(resp) = find_respond(inner_directives) {
         Handler::StaticResponse {
@@ -809,6 +813,11 @@ fn compile_single_block(
         warn!("handle block has no handler directive, skipping");
         return None;
     };
+
+    // gRPC requires HTTP/2 upstream — force h2 when the grpc directive is present.
+    if is_grpc_route {
+        force_upstream_h2(&mut handler);
+    }
 
     Some(HandlerBlock {
         kind,
@@ -1092,6 +1101,19 @@ fn resolve_all_upstreams(upstreams: &[UpstreamAddr]) -> Vec<SocketAddr> {
 }
 
 /// Map a config `LbPolicy` to the runtime `CoreLbPolicy`.
+/// Force `upstream_h2 = true` on a reverse proxy handler.
+///
+/// Used when the `grpc` directive is present — gRPC requires HTTP/2 to the upstream
+/// even if the user didn't explicitly set `transport { h2 }`.
+fn force_upstream_h2(handler: &mut Handler) {
+    match handler {
+        Handler::ReverseProxy { upstream_h2, .. } | Handler::ReverseProxyPool { upstream_h2, .. } => {
+            *upstream_h2 = true;
+        }
+        _ => {}
+    }
+}
+
 fn map_lb_policy(policy: Option<LbPolicy>) -> CoreLbPolicy {
     match policy {
         None | Some(LbPolicy::RoundRobin) => CoreLbPolicy::RoundRobin,

--- a/crates/dwaar-config/src/compile.rs
+++ b/crates/dwaar-config/src/compile.rs
@@ -627,6 +627,11 @@ pub fn extract_bind_addresses(config: &DwaarConfig) -> Vec<BindAddress> {
     let mut addrs: Vec<BindAddress> = Vec::new();
 
     for site in &config.sites {
+        // Sites with TLS get their own listener via extract_tls_bind_addresses.
+        // Only non-TLS sites contribute to the plaintext HTTP listener here.
+        if site_has_tls(&site.directives) {
+            continue;
+        }
         if let Some(bind) = find_bind(&site.directives) {
             for raw in &bind.addresses {
                 let addr = parse_bind_address(raw);
@@ -643,7 +648,7 @@ pub fn extract_bind_addresses(config: &DwaarConfig) -> Vec<BindAddress> {
         }
     }
 
-    // Fall back to the built-in default when no site specifies bind.
+    // Fall back to the built-in default when no non-TLS site specifies bind.
     if addrs.is_empty() {
         addrs.push(BindAddress::Tcp(DEFAULT_HTTP_BIND.to_owned()));
     }

--- a/crates/dwaar-config/src/parser/directives.rs
+++ b/crates/dwaar-config/src/parser/directives.rs
@@ -20,6 +20,7 @@ use crate::token::{TokenKind, Tokenizer};
 
 use super::helpers::{
     expect_word_or_quoted, is_directive_name, parse_optional_pattern, parse_upstream_addr,
+    parse_upstream_with_scheme,
 };
 
 /// `reverse_proxy localhost:8080` or block form:
@@ -52,6 +53,8 @@ pub(super) fn parse_reverse_proxy(
 /// Parse inline form: `reverse_proxy host1:port [host2:port ...]`
 fn parse_reverse_proxy_inline(t: &mut Tokenizer<'_>) -> Result<ReverseProxyDirective, ParseError> {
     let mut upstreams = Vec::new();
+    let mut transport_h2 = false;
+    let mut transport_tls = false;
 
     loop {
         let tok = t.peek();
@@ -62,7 +65,14 @@ fn parse_reverse_proxy_inline(t: &mut Tokenizer<'_>) -> Result<ReverseProxyDirec
                     break;
                 }
                 t.next_token();
-                upstreams.push(parse_upstream_addr(w));
+                let parsed = parse_upstream_with_scheme(w);
+                upstreams.push(parsed.addr);
+                if parsed.h2c {
+                    transport_h2 = true;
+                }
+                if parsed.tls {
+                    transport_tls = true;
+                }
             }
             _ => break,
         }
@@ -88,8 +98,8 @@ fn parse_reverse_proxy_inline(t: &mut Tokenizer<'_>) -> Result<ReverseProxyDirec
         health_interval: None,
         fail_duration: None,
         max_conns: None,
-        transport_tls: false,
-        transport_h2: false,
+        transport_tls,
+        transport_h2,
         tls_server_name: None,
         tls_client_auth: None,
         tls_trusted_ca_certs: None,
@@ -147,7 +157,14 @@ fn parse_reverse_proxy_block(t: &mut Tokenizer<'_>) -> Result<ReverseProxyDirect
                             TokenKind::Word(ref w) if !is_reverse_proxy_subdirective(w) => {
                                 let addr_tok = t.next_token();
                                 if let TokenKind::Word(w) = addr_tok.kind {
-                                    upstreams.push(parse_upstream_addr(&w));
+                                    let parsed = parse_upstream_with_scheme(&w);
+                                    upstreams.push(parsed.addr);
+                                    if parsed.h2c {
+                                        transport_h2 = true;
+                                    }
+                                    if parsed.tls {
+                                        transport_tls = true;
+                                    }
                                 }
                             }
                             _ => break,

--- a/crates/dwaar-config/src/parser/helpers.rs
+++ b/crates/dwaar-config/src/parser/helpers.rs
@@ -137,6 +137,38 @@ pub(super) fn expect_word_or_quoted(
     }
 }
 
+/// Parsed upstream address with optional transport hints from the URL scheme.
+pub(super) struct ParsedUpstream {
+    pub addr: UpstreamAddr,
+    pub h2c: bool, // h2c:// scheme detected
+    pub tls: bool, // https:// scheme detected
+}
+
+/// Parse an upstream address with optional scheme prefix (h2c://, https://).
+pub(super) fn parse_upstream_with_scheme(s: &str) -> ParsedUpstream {
+    if let Some(rest) = s.strip_prefix("h2c://") {
+        return ParsedUpstream {
+            addr: parse_upstream_addr(rest),
+            h2c: true,
+            tls: false,
+        };
+    }
+    if let Some(rest) = s.strip_prefix("https://") {
+        return ParsedUpstream {
+            addr: parse_upstream_addr(rest),
+            h2c: false,
+            tls: true,
+        };
+    }
+    // Also handle http:// (just strip it, no special transport)
+    let clean = s.strip_prefix("http://").unwrap_or(s);
+    ParsedUpstream {
+        addr: parse_upstream_addr(clean),
+        h2c: false,
+        tls: false,
+    }
+}
+
 /// Parse an upstream address — try socket addr first, fall back to host:port string.
 pub(super) fn parse_upstream_addr(s: &str) -> UpstreamAddr {
     // Handle Caddyfile shorthand: ":8080" means "localhost:8080"


### PR DESCRIPTION
## Summary
- Parse `h2c://` and `https://` URL schemes in upstream addresses for `reverse_proxy`
- `grpc` directive now auto-enables `transport_h2` on the upstream connection
- Enables cleaner config: `reverse_proxy h2c://backend:9090` for gRPC backends

## Motivation
Deploying permanu staging behind Dwaar exposed that gRPC backends need h2c (HTTP/2 cleartext) upstream transport, but the inline `reverse_proxy` syntax only accepted `host:port`. This forced workarounds with block-form `transport h2` directives.

## Changes
- `helpers.rs`: Added `ParsedUpstream` struct and `parse_upstream_with_scheme()` that strips scheme prefixes
- `directives.rs`: Updated inline and block-form `reverse_proxy` parsing to use scheme-aware parser
- `compile.rs`: Added `force_upstream_h2()` helper; `grpc` directive now auto-sets `upstream_h2 = true`

## Test plan
- [ ] `cargo check` passes
- [ ] Existing tests pass: `cargo test -p dwaar-config`
- [ ] Manual test: `reverse_proxy h2c://172.18.0.5:9090` resolves and proxies gRPC traffic