### PR TITLE
chore: bump LICENSE version to 0.3.0 for release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.2.13
+Licensed Work:        Dwaar 0.3.0
                       The Licensed Work is
                       (c) 2026 Permanu
 
@@ -65,7 +65,7 @@ Additional Use Grant: You may use, copy, modify, create derivative works of,
                         of the Licensed Work as part of a commercial
                         infrastructure or platform product.
 
-Change Date:          2036-04-14
+Change Date:          2036-04-16
 
 Change License:       GNU Affero General Public License v3.0
 


### PR DESCRIPTION
## Summary
- Bump `Licensed Work` version in LICENSE from 0.2.13 to 0.3.0
- Update Change Date to 2036-04-16 (10-year BSL protection window)
- Update copyright year to 2026

Required for the v0.3.0 release workflow — tag validation checks LICENSE version matches the tag.