### PR TITLE
fix(tls): send intermediate chain cert in TLS handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.3.0"
+version = "0.3.1"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-tls/src/sni.rs
+++ b/crates/dwaar-tls/src/sni.rs
@@ -234,10 +234,10 @@ impl TlsAccept for SniResolver {
         // Send the intermediate certificate so clients can verify the full
         // chain. Without this, clients that don't have the intermediate
         // cached locally get "unable to get local issuer certificate".
-        if let Some(ref issuer) = cached.issuer {
-            if let Err(e) = ext::ssl_add_chain_cert(ssl, issuer) {
-                warn!(sni = %sni, error = %e, "failed to add intermediate chain cert");
-            }
+        if let Some(ref issuer) = cached.issuer
+            && let Err(e) = ext::ssl_add_chain_cert(ssl, issuer)
+        {
+            warn!(sni = %sni, error = %e, "failed to add intermediate chain cert");
         }
 
         // Staple OCSP response only if it was refreshed within MAX_OCSP_AGE

--- a/crates/dwaar-tls/src/sni.rs
+++ b/crates/dwaar-tls/src/sni.rs
@@ -231,6 +231,15 @@ impl TlsAccept for SniResolver {
             return;
         }
 
+        // Send the intermediate certificate so clients can verify the full
+        // chain. Without this, clients that don't have the intermediate
+        // cached locally get "unable to get local issuer certificate".
+        if let Some(ref issuer) = cached.issuer {
+            if let Err(e) = ext::ssl_add_chain_cert(ssl, issuer) {
+                warn!(sni = %sni, error = %e, "failed to add intermediate chain cert");
+            }
+        }
+
         // Staple OCSP response only if it was refreshed within MAX_OCSP_AGE
         // (M-11). A stale response — e.g. refresh has been failing for days —
         // is withheld so clients fall back to their own OCSP checks rather


### PR DESCRIPTION
## Summary
- Adds `ssl_add_chain_cert` call in the SNI callback to send the intermediate certificate during TLS handshake
- Without this, only the leaf cert was sent — clients without the intermediate cached locally got `unable to get local issuer certificate`
- Bumps version to v0.3.1

## Root Cause
`CachedCert` correctly parsed and stored the intermediate cert from the PEM chain file, but `certificate_callback` in `sni.rs` only called `ssl_use_certificate` (leaf) and `ssl_use_private_key` — never `ssl_add_chain_cert` for the intermediate.

## Test plan
- [ ] `openssl s_client -connect staging.permanu.com:443` shows `depth=1` with the intermediate cert
- [ ] `curl https://staging.permanu.com/health` works from a fresh server without `-k`
- [ ] Server install script (`curl | sh`) succeeds from Prod-Permanu VPS