### PR TITLE
feat(grpc): scaffold DwaarControl gRPC service (Wheel #2 Week 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
@@ -45,6 +48,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: Swatinem/rust-cache@v2
       # proxy_integration.rs requires a live dwaar instance + hardcoded
       # port 8080 (ISSUE-010). Exclude dwaar-cli integration tests from
@@ -61,6 +67,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --workspace --release
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,17 +28,6 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -312,6 +301,53 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1362,7 +1398,7 @@ dependencies = [
 name = "dwaar-core"
 version = "0.1.0"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arc-swap",
  "async-trait",
  "base64",
@@ -1440,6 +1476,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dwaar-grpc"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "prost",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-test",
+ "tonic",
+ "tonic-build",
+ "tracing",
+]
+
+[[package]]
 name = "dwaar-ingress"
 version = "0.1.0"
 dependencies = [
@@ -1481,7 +1533,7 @@ dependencies = [
 name = "dwaar-plugins"
 version = "0.1.0"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "anyhow",
  "base64",
  "bcrypt",
@@ -1989,9 +2041,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2028,6 +2077,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "headers"
@@ -2162,6 +2216,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2237,7 +2292,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2707,7 +2762,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
 ]
@@ -2749,7 +2804,7 @@ version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a41af186a0fe80c71a13a13994abdc3ebff80859ca6a4b8a6079948328c135b"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "async-broadcast",
  "async-stream",
  "async-trait",
@@ -2878,6 +2933,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "maxminddb"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2957,6 +3018,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "munge"
@@ -3375,7 +3442,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59d8c4c939a3a193a3da0e061aa7acf7432431f92ee62a26f5a9e5167a0ade2"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "async-trait",
  "blake2",
  "bstr",
@@ -3412,7 +3479,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08973c4853cef4c682f7a592907e81a32dcad69476c4846e5de079f16448b177"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "async-trait",
  "brotli 3.5.0",
  "bstr",
@@ -3447,7 +3514,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "sfv",
- "socket2",
+ "socket2 0.6.3",
  "strum",
  "strum_macros",
  "tokio",
@@ -3506,7 +3573,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7568624fc0e2f11fa32d27053ac862048b40bad98140b07a11d82f1b4989700"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
 ]
 
 [[package]]
@@ -3538,7 +3605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91bb5030596a3d442c0866ac68afe29c14ba558e77c726dcdf7016b0dbb359d9"
 dependencies = [
  "arrayvec",
- "hashbrown 0.12.3",
+ "hashbrown 0.17.0",
  "parking_lot",
  "rand 0.8.5",
 ]
@@ -3795,6 +3862,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3863,7 +3982,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3903,7 +4022,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4163,7 +4282,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -4685,6 +4804,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -4708,7 +4837,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d971cc77a245ccf1756dbd1a87c3e7f709c0191464096510d43eec056d0f2c4f"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "bumpalo",
  "bytes",
  "cfg-if",
@@ -5020,7 +5149,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -5094,6 +5223,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5125,7 +5318,7 @@ dependencies = [
  "iri-string",
  "mime",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ dwaar-admin = { path = "crates/dwaar-admin" }
 dwaar-docker = { path = "crates/dwaar-docker" }
 dwaar-geo = { path = "crates/dwaar-geo" }
 dwaar-log = { path = "crates/dwaar-log" }
+dwaar-grpc = { path = "crates/dwaar-grpc" }
 
 # Pingora
 pingora = { version = "0.8.0", features = ["proxy", "lb", "openssl"] }

--- a/crates/dwaar-grpc/Cargo.toml
+++ b/crates/dwaar-grpc/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "dwaar-grpc"
+version = "0.1.0"
+description = "Bidirectional gRPC control fabric — DwaarControl service (Permanu ↔ Dwaar)"
+edition.workspace = true
+publish = false
+rust-version.workspace = true
+license-file = "../../LICENSE"
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+tonic = "0.12"
+prost = "0.13"
+tokio = { workspace = true, features = ["rt-multi-thread", "net", "macros", "sync", "time"] }
+tokio-stream = "0.1"
+futures-core = "0.3"
+async-trait = { workspace = true }
+tracing = { workspace = true }
+thiserror = { workspace = true }
+
+[build-dependencies]
+tonic-build = "0.12"
+
+[dev-dependencies]
+tokio-test = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/dwaar-grpc/build.rs
+++ b/crates/dwaar-grpc/build.rs
@@ -1,0 +1,8 @@
+// Copyright (C) 2026 Permanu
+// SPDX-License-Identifier: BSL-1.1
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::compile_protos("proto/dwaar.proto")?;
+    println!("cargo:rerun-if-changed=proto/dwaar.proto");
+    Ok(())
+}

--- a/crates/dwaar-grpc/build.rs
+++ b/crates/dwaar-grpc/build.rs
@@ -6,6 +6,11 @@
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::compile_protos("proto/dwaar.proto")?;
-    println!("cargo:rerun-if-changed=proto/dwaar.proto");
+    // `println!` emits cargo build-script directives; the workspace
+    // disallowed-macros lint targets library/runtime code, not build.rs.
+    #[allow(clippy::disallowed_macros)]
+    {
+        println!("cargo:rerun-if-changed=proto/dwaar.proto");
+    }
     Ok(())
 }

--- a/crates/dwaar-grpc/build.rs
+++ b/crates/dwaar-grpc/build.rs
@@ -1,5 +1,8 @@
 // Copyright (C) 2026 Permanu
 // SPDX-License-Identifier: BSL-1.1
+//
+// This file is part of Dwaar — https://dwaar.dev
+// Licensed under the Business Source License 1.1
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::compile_protos("proto/dwaar.proto")?;

--- a/crates/dwaar-grpc/proto/dwaar.proto
+++ b/crates/dwaar-grpc/proto/dwaar.proto
@@ -1,0 +1,168 @@
+// Copyright (C) 2026 Permanu
+// SPDX-License-Identifier: BSL-1.1
+//
+// Dwaar control-plane protocol. Source of truth:
+// permanu/docs/substrate-contract.md (Wheel #2).
+// Any change to this file MUST be mirrored in the substrate contract.
+
+syntax = "proto3";
+package permanu.dwaar.v1;
+
+// DwaarControl is the bidirectional control channel between Permanu
+// (the orchestrator) and a Dwaar proxy instance.
+//
+// Upstream   (Permanu -> Dwaar): route mutations, traffic splits, mirrors.
+// Downstream (Dwaar   -> Permanu): lifecycle events, anomalies, live logs.
+service DwaarControl {
+  // Permanu opens a long-lived bidirectional stream.
+  rpc Channel(stream ClientMessage) returns (stream ServerMessage);
+}
+
+// -----------------------------------------------------------------------------
+// Envelope messages
+// -----------------------------------------------------------------------------
+
+message ClientMessage {
+  oneof kind {
+    Hello hello = 1;
+    Heartbeat heartbeat = 2;
+    AddRoute add_route = 10;
+    RemoveRoute remove_route = 11;
+    SplitTraffic split_traffic = 12;
+    MirrorRequest mirror_request = 13;
+    SetHeaderRule set_header_rule = 14;
+  }
+}
+
+message ServerMessage {
+  oneof kind {
+    HelloAck hello_ack = 1;
+    HeartbeatAck heartbeat_ack = 2;
+    CommandAck command_ack = 3;       // ack_id matches ClientMessage id
+    RouteEvent route_event = 10;
+    AnomalyEvent anomaly_event = 11;
+    TrafficSpikeEvent spike_event = 12;
+    LiveLogChunk log_chunk = 13;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Handshake & liveness
+// -----------------------------------------------------------------------------
+
+message Hello {
+  string permanu_instance_id = 1;
+  string permanu_version = 2;
+}
+
+message HelloAck {
+  string dwaar_instance_id = 1;
+  string dwaar_version = 2;
+}
+
+message Heartbeat {
+  uint64 sequence = 1;
+  int64 sent_at_unix_ms = 2;
+}
+
+message HeartbeatAck {
+  uint64 sequence = 1;
+  int64 received_at_unix_ms = 2;
+}
+
+// CommandAck is returned for any stateful ClientMessage (AddRoute, RemoveRoute,
+// SplitTraffic, MirrorRequest, SetHeaderRule). The ack_id correlates to a
+// caller-supplied identifier on the originating message.
+message CommandAck {
+  string ack_id = 1;
+  string status = 2;                 // "ok" | "error" | "not_implemented"
+  string error_message = 3;          // populated when status == "error"
+}
+
+// -----------------------------------------------------------------------------
+// Route primitives
+// -----------------------------------------------------------------------------
+
+message Route {
+  string deploy_id = 1;                // links to BuildManifest.id (Wheel #1)
+  string release_name = 2;             // Wheel #6
+  string domain = 3;
+  string upstream_addr = 4;            // "1.2.3.4:8080"
+  bool tls = 5;
+  map<string, string> header_match = 6; // feature-flag routing
+}
+
+message WeightedUpstream {
+  Route route = 1;
+  uint32 weight = 2;                   // 0-100
+}
+
+// -----------------------------------------------------------------------------
+// Client-initiated commands
+// -----------------------------------------------------------------------------
+
+message AddRoute {
+  string ack_id = 1;
+  Route route = 2;
+}
+
+message RemoveRoute {
+  string ack_id = 1;
+  string domain = 2;
+  string deploy_id = 3;                // optional — remove a specific revision
+}
+
+message SplitTraffic {
+  string ack_id = 1;
+  string domain = 2;
+  repeated WeightedUpstream upstreams = 3;  // weights sum to 100
+  string strategy = 4;                      // "canary" | "blue_green" | "shadow"
+}
+
+message MirrorRequest {
+  string ack_id = 1;
+  string source_domain = 2;
+  string mirror_to = 3;                // upstream address
+  uint32 sample_rate_bps = 4;          // basis points, 10000 = 100%
+}
+
+message SetHeaderRule {
+  string ack_id = 1;
+  string domain = 2;
+  string header_name = 3;
+  string header_value = 4;
+  string action = 5;                   // "set" | "append" | "remove"
+}
+
+// -----------------------------------------------------------------------------
+// Server-initiated events
+// -----------------------------------------------------------------------------
+
+message RouteEvent {
+  string domain = 1;
+  string deploy_id = 2;
+  string event_type = 3;               // "added" | "removed" | "updated" | "promoted"
+  int64 observed_at_unix_ms = 4;
+}
+
+message AnomalyEvent {
+  string domain = 1;
+  string anomaly_type = 2;             // "latency_spike" | "error_rate" | "upstream_down"
+  double severity = 3;                 // 0.0-1.0
+  string detail = 4;
+  int64 observed_at_unix_ms = 5;
+}
+
+message TrafficSpikeEvent {
+  string domain = 1;
+  double rps_current = 2;
+  double rps_baseline = 3;
+  int64 observed_at_unix_ms = 4;
+}
+
+message LiveLogChunk {
+  string domain = 1;
+  string deploy_id = 2;
+  bytes payload = 3;
+  int64 observed_at_unix_ms = 4;
+}

--- a/crates/dwaar-grpc/src/lib.rs
+++ b/crates/dwaar-grpc/src/lib.rs
@@ -1,0 +1,25 @@
+// Copyright (C) 2026 Permanu
+// SPDX-License-Identifier: BSL-1.1
+//
+// This file is part of Dwaar — https://dwaar.dev
+// Licensed under the Business Source License 1.1
+
+//! dwaar-grpc — bidirectional control fabric between Permanu and Dwaar.
+//!
+//! Wheel #2 of the substrate contract (see
+//! `permanu/docs/substrate-contract.md`). Week 1 ships the scaffold only:
+//! a tonic-generated `DwaarControl` service that acknowledges `Hello` and
+//! `Heartbeat` envelopes, and stubs every stateful command with a
+//! `CommandAck { status: "not_implemented" }`.
+//!
+//! Route / SplitTraffic / MirrorRequest handlers land in Week 3.
+
+pub mod pb {
+    //! Protobuf types generated from `proto/dwaar.proto`.
+    #![allow(clippy::all, clippy::pedantic, missing_debug_implementations)]
+    tonic::include_proto!("permanu.dwaar.v1");
+}
+
+pub mod service;
+
+pub use service::{DwaarControlService, Error, start_grpc_server};

--- a/crates/dwaar-grpc/src/lib.rs
+++ b/crates/dwaar-grpc/src/lib.rs
@@ -12,7 +12,7 @@
 //! `Heartbeat` envelopes, and stubs every stateful command with a
 //! `CommandAck { status: "not_implemented" }`.
 //!
-//! Route / SplitTraffic / MirrorRequest handlers land in Week 3.
+//! Route / `SplitTraffic` / `MirrorRequest` handlers land in Week 3.
 
 pub mod pb {
     //! Protobuf types generated from `proto/dwaar.proto`.

--- a/crates/dwaar-grpc/src/service.rs
+++ b/crates/dwaar-grpc/src/service.rs
@@ -1,0 +1,270 @@
+// Copyright (C) 2026 Permanu
+// SPDX-License-Identifier: BSL-1.1
+//
+// This file is part of Dwaar — https://dwaar.dev
+// Licensed under the Business Source License 1.1
+
+//! `DwaarControl` service scaffold.
+//!
+//! This module wires a tonic service that accepts the bidirectional
+//! `Channel` RPC and routes each inbound `ClientMessage` to a tiny
+//! handler. Only `Hello` and `Heartbeat` are fully implemented; every
+//! other variant is answered with a `CommandAck { status:
+//! "not_implemented" }` so Permanu's side of the stream can be
+//! exercised end-to-end before Week 3 lands the mutation handlers.
+
+use std::net::SocketAddr;
+use std::pin::Pin;
+
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio_stream::Stream;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::transport::Server;
+use tonic::{Request, Response, Status, Streaming};
+use tracing::{debug, info, warn};
+
+use crate::pb;
+use crate::pb::dwaar_control_server::{DwaarControl, DwaarControlServer};
+
+/// Channel depth for the per-stream outbound queue. Small on purpose:
+/// backpressure is preferable to unbounded memory if Permanu stalls.
+const OUTBOUND_CHANNEL_DEPTH: usize = 64;
+
+/// Dwaar version string surfaced in [`pb::HelloAck`].
+const DWAAR_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Errors surfaced by the gRPC scaffold.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("failed to bind gRPC listener on {addr}: {source}")]
+    Bind {
+        addr: SocketAddr,
+        #[source]
+        source: tonic::transport::Error,
+    },
+    #[error("gRPC server terminated: {0}")]
+    Serve(#[from] tonic::transport::Error),
+}
+
+/// Stubbed `DwaarControl` service. Holds the Dwaar instance identity
+/// that is echoed back in [`pb::HelloAck`].
+#[derive(Debug, Clone)]
+pub struct DwaarControlService {
+    dwaar_instance_id: String,
+}
+
+impl DwaarControlService {
+    #[must_use]
+    pub fn new(dwaar_instance_id: impl Into<String>) -> Self {
+        Self {
+            dwaar_instance_id: dwaar_instance_id.into(),
+        }
+    }
+}
+
+impl Default for DwaarControlService {
+    fn default() -> Self {
+        Self::new("dwaar-unidentified")
+    }
+}
+
+type ChannelStream = Pin<Box<dyn Stream<Item = Result<pb::ServerMessage, Status>> + Send>>;
+
+#[tonic::async_trait]
+impl DwaarControl for DwaarControlService {
+    type ChannelStream = ChannelStream;
+
+    async fn channel(
+        &self,
+        request: Request<Streaming<pb::ClientMessage>>,
+    ) -> Result<Response<Self::ChannelStream>, Status> {
+        let peer = request
+            .remote_addr()
+            .map_or_else(|| "unknown".to_string(), |a| a.to_string());
+        info!(peer, "dwaar-grpc: control channel opened");
+
+        let mut inbound = request.into_inner();
+        let (tx, rx) = mpsc::channel::<Result<pb::ServerMessage, Status>>(OUTBOUND_CHANNEL_DEPTH);
+        let svc = self.clone();
+
+        tokio::spawn(async move {
+            loop {
+                match inbound.message().await {
+                    Ok(Some(msg)) => {
+                        if let Some(reply) = svc.handle_client_message(msg) {
+                            if tx.send(Ok(reply)).await.is_err() {
+                                debug!("dwaar-grpc: downstream dropped, terminating channel");
+                                break;
+                            }
+                        }
+                    }
+                    Ok(None) => {
+                        info!(peer, "dwaar-grpc: control channel closed by peer");
+                        break;
+                    }
+                    Err(status) => {
+                        warn!(peer, %status, "dwaar-grpc: control channel errored");
+                        let _ = tx.send(Err(status)).await;
+                        break;
+                    }
+                }
+            }
+        });
+
+        let stream: ChannelStream = Box::pin(ReceiverStream::new(rx));
+        Ok(Response::new(stream))
+    }
+}
+
+impl DwaarControlService {
+    /// Translate a single `ClientMessage` into an optional `ServerMessage`.
+    /// Returns `None` when no reply is warranted (currently unreachable — every
+    /// known variant produces a reply — but kept as a hook for Week 3 streaming
+    /// responses).
+    fn handle_client_message(&self, msg: pb::ClientMessage) -> Option<pb::ServerMessage> {
+        use pb::client_message::Kind as In;
+        use pb::server_message::Kind as Out;
+
+        let kind = msg.kind?;
+        let out = match kind {
+            In::Hello(h) => {
+                info!(
+                    permanu_instance_id = %h.permanu_instance_id,
+                    permanu_version = %h.permanu_version,
+                    "dwaar-grpc: hello received"
+                );
+                Out::HelloAck(pb::HelloAck {
+                    dwaar_instance_id: self.dwaar_instance_id.clone(),
+                    dwaar_version: DWAAR_VERSION.to_string(),
+                })
+            }
+            In::Heartbeat(hb) => {
+                debug!(sequence = hb.sequence, "dwaar-grpc: heartbeat received");
+                Out::HeartbeatAck(pb::HeartbeatAck {
+                    sequence: hb.sequence,
+                    received_at_unix_ms: now_unix_ms(),
+                })
+            }
+            In::AddRoute(cmd) => not_implemented(cmd.ack_id, "add_route"),
+            In::RemoveRoute(cmd) => not_implemented(cmd.ack_id, "remove_route"),
+            In::SplitTraffic(cmd) => not_implemented(cmd.ack_id, "split_traffic"),
+            In::MirrorRequest(cmd) => not_implemented(cmd.ack_id, "mirror_request"),
+            In::SetHeaderRule(cmd) => not_implemented(cmd.ack_id, "set_header_rule"),
+        };
+
+        Some(pb::ServerMessage { kind: Some(out) })
+    }
+}
+
+fn not_implemented(ack_id: String, op: &'static str) -> pb::server_message::Kind {
+    warn!(op, %ack_id, "dwaar-grpc: command not implemented (Week 3)");
+    pb::server_message::Kind::CommandAck(pb::CommandAck {
+        ack_id,
+        status: "not_implemented".to_string(),
+        error_message: format!("{op} handler lands in Wheel #2 Week 3"),
+    })
+}
+
+fn now_unix_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
+        .unwrap_or(0)
+}
+
+/// Start the `DwaarControl` gRPC server on `addr`. Returns a `JoinHandle`
+/// that resolves once the server exits. The caller owns lifecycle.
+///
+/// This scaffold does **not** yet apply mTLS. Auth lands alongside the
+/// Week 3 mutation handlers (see substrate contract, Wheel #2).
+pub fn start_grpc_server(
+    addr: SocketAddr,
+    service: DwaarControlService,
+) -> JoinHandle<Result<(), Error>> {
+    tokio::spawn(async move {
+        info!(%addr, "dwaar-grpc: starting DwaarControl server");
+        Server::builder()
+            .add_service(DwaarControlServer::new(service))
+            .serve(addr)
+            .await
+            .map_err(Error::from)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn not_implemented_reply_carries_ack_id() {
+        let kind = not_implemented("abc-123".to_string(), "add_route");
+        let pb::server_message::Kind::CommandAck(ack) = kind else {
+            panic!("expected CommandAck");
+        };
+        assert_eq!(ack.ack_id, "abc-123");
+        assert_eq!(ack.status, "not_implemented");
+        assert!(ack.error_message.contains("add_route"));
+    }
+
+    #[test]
+    fn hello_produces_hello_ack() {
+        let svc = DwaarControlService::new("dwaar-test");
+        let reply = svc
+            .handle_client_message(pb::ClientMessage {
+                kind: Some(pb::client_message::Kind::Hello(pb::Hello {
+                    permanu_instance_id: "permanu-1".into(),
+                    permanu_version: "0.1.0".into(),
+                })),
+            })
+            .expect("hello must produce a reply");
+        let Some(pb::server_message::Kind::HelloAck(ack)) = reply.kind else {
+            panic!("expected HelloAck");
+        };
+        assert_eq!(ack.dwaar_instance_id, "dwaar-test");
+        assert_eq!(ack.dwaar_version, DWAAR_VERSION);
+    }
+
+    #[test]
+    fn heartbeat_echoes_sequence() {
+        let svc = DwaarControlService::new("dwaar-test");
+        let reply = svc
+            .handle_client_message(pb::ClientMessage {
+                kind: Some(pb::client_message::Kind::Heartbeat(pb::Heartbeat {
+                    sequence: 42,
+                    sent_at_unix_ms: 0,
+                })),
+            })
+            .expect("heartbeat must produce a reply");
+        let Some(pb::server_message::Kind::HeartbeatAck(ack)) = reply.kind else {
+            panic!("expected HeartbeatAck");
+        };
+        assert_eq!(ack.sequence, 42);
+    }
+
+    #[test]
+    fn add_route_returns_not_implemented() {
+        let svc = DwaarControlService::new("dwaar-test");
+        let reply = svc
+            .handle_client_message(pb::ClientMessage {
+                kind: Some(pb::client_message::Kind::AddRoute(pb::AddRoute {
+                    ack_id: "cmd-1".into(),
+                    route: Some(pb::Route {
+                        deploy_id: "d1".into(),
+                        release_name: "amber-otter-1".into(),
+                        domain: "example.test".into(),
+                        upstream_addr: "127.0.0.1:8080".into(),
+                        tls: false,
+                        header_match: Default::default(),
+                    }),
+                })),
+            })
+            .expect("add_route must produce a reply");
+        let Some(pb::server_message::Kind::CommandAck(ack)) = reply.kind else {
+            panic!("expected CommandAck");
+        };
+        assert_eq!(ack.ack_id, "cmd-1");
+        assert_eq!(ack.status, "not_implemented");
+    }
+}

--- a/crates/dwaar-grpc/src/service.rs
+++ b/crates/dwaar-grpc/src/service.rs
@@ -92,11 +92,11 @@ impl DwaarControl for DwaarControlService {
             loop {
                 match inbound.message().await {
                     Ok(Some(msg)) => {
-                        if let Some(reply) = svc.handle_client_message(msg) {
-                            if tx.send(Ok(reply)).await.is_err() {
-                                debug!("dwaar-grpc: downstream dropped, terminating channel");
-                                break;
-                            }
+                        if let Some(reply) = svc.handle_client_message(msg)
+                            && tx.send(Ok(reply)).await.is_err()
+                        {
+                            debug!("dwaar-grpc: downstream dropped, terminating channel");
+                            break;
                         }
                     }
                     Ok(None) => {
@@ -256,7 +256,7 @@ mod tests {
                         domain: "example.test".into(),
                         upstream_addr: "127.0.0.1:8080".into(),
                         tls: false,
-                        header_match: Default::default(),
+                        header_match: std::collections::HashMap::new(),
                     }),
                 })),
             })


### PR DESCRIPTION
## Summary
- New `dwaar-grpc` crate scaffolding `DwaarControl` bidi stream service per Permanu substrate contract (Wheel #2 Week 1).
- Handles `Hello`/`Heartbeat` fully; other command variants (AddRoute/RemoveRoute/SplitTraffic/MirrorRequest/SetHeaderRule) return `CommandAck{status:"not_implemented"}` with ack_id echo — implementations land Weeks 2-5.
- 4 passing unit tests. `cargo check --workspace` clean.

## Context
Part of the Permanu Apple-tier ecosystem plan. Substrate contract: permanu/docs/substrate-contract.md. This is pure additive scaffolding — no wiring into dwaar-admin startup yet (Week 2).

## Test plan
- [x] `cargo build -p dwaar-grpc`
- [x] `cargo test -p dwaar-grpc` — 4/4 green
- [x] `cargo check --workspace`
- [ ] Wiring into dwaar-admin startup — Week 2 follow-up PR
- [ ] mTLS auth — Week 2-3 follow-up PR