### PR TITLE
feat(proxy+grpc): Wheel #2 Weeks 4-5 — hot-path integration + event stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-04-17
+
+Wheel #2 Weeks 4–5 — proxy hot-path integration and server-initiated event
+stream.
+
+### Added
+
+- **Proxy consults the split registry on every request** — a matched
+  `SplitTraffic` config for the current domain now steers the upstream pick
+  through a weighted choice. When no split is installed the dispatcher
+  bypasses the registry entirely, so single-upstream routes pay nothing.
+  Registries moved from `dwaar-grpc` into a new `dwaar_core::registries`
+  module so the hot path can consult them without the control-plane crate
+  taking a circular dependency on `dwaar-core`.
+- **Fire-and-forget mirror traffic** via `MirrorDispatcherImpl` —
+  `request_filter` spawns a detached tokio task per matching request that
+  replays the method + path + headers to `mirror_to`. Sample rate is
+  enforced with `sample_rate_bps`; mirror failures never influence the
+  primary response. A new Prometheus counter `dwaar_mirror_requests_total`
+  (labels: `source_domain`, `mirror_to`, `outcome={sent|sampled_out|error}`)
+  is exposed via `MirrorMetrics::render`.
+- **`SetHeaderRule` handler** + `HeaderRuleRegistry`. Header rules are
+  strictly more specific than traffic splits — when both are installed
+  for the same domain the header rule wins and overrides the default
+  upstream. The pb `action == "route_to"` repurposes `header_value` as the
+  override upstream address (single-pair matches, Week 4 scope).
+- **Server-initiated event stream** (Wheel #2 Week 5). New `EventBus`
+  multiplexes `AnomalyEvent`, `TrafficSpikeEvent`, and `LiveLogChunk`
+  messages to every connected gRPC peer. A per-domain `AnomalyDetector`
+  drives thresholds: 5xx rate > 1 % over a 60 s rolling window; P95
+  latency > 2× the 10-min baseline; traffic RPS > 2× the 5-min moving
+  average sustained ≥ 30 s. `LogChunkBuffer` batches structured log
+  chunks every 200 ms (caps: 100 lines / 64 KB / chunk).
+- Bounded mpsc subscriber queues (depth 256) with oldest-drop on
+  backpressure and a drop counter, so publishers never block primary
+  request flow.
+
+### Changed
+
+- `DwaarProxy::new` gains three optional wiring methods —
+  `with_control_plane`, `with_mirror_dispatcher`, `with_outcome_sink` —
+  that populate the new hot-path hooks. `None` keeps the pre-existing
+  single-upstream fast path unchanged.
+- `dwaar-cli` builds the `DwaarControlService` up-front and threads its
+  registries into `DwaarProxy` before the proxy service is registered,
+  so every worker observes the same shared state.
+
+### Tests
+
+- 10 proxy-level integration tests in
+  `crates/dwaar-grpc/tests/proxy_integration.rs` covering split
+  100→50/50→100 transitions, mirror dispatch against a real `TcpListener`,
+  mirror error / sampled-out counters, header-rule match semantics, the
+  event-bus drop-on-backpressure behaviour, anomaly emission, and log-chunk
+  batching.
+- Unit tests for `SplitRegistry`, `MirrorRegistry`, `HeaderRuleRegistry`,
+  `AnomalyDetector`, `LogChunkBuffer`, and `MirrorDispatcherImpl`.
+
 ## [0.2.11] - 2026-04-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,6 +1482,7 @@ version = "0.1.0"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "dashmap",
  "dwaar-core",
  "fastrand",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-cli"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.3.2
+Licensed Work:        Dwaar 0.3.3
                       The Licensed Work is
                       (c) 2026 Permanu
 

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.3.2"
+version = "0.3.3"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-cli/src/main.rs
+++ b/crates/dwaar-cli/src/main.rs
@@ -656,6 +656,28 @@ fn run_server(
     let cache_backend_for_admin = cache_backend.clone();
     let cache_backend_for_watcher = cache_backend.clone();
 
+    // Build the DwaarControl service up-front so its registries can be
+    // shared with DwaarProxy's hot path (Wheel #2 Week 4) AND handed to the
+    // gRPC BackgroundService below. The service is cheap to clone — every
+    // internal handle is an `Arc` — so both consumers get independent clones.
+    let grpc_service = dwaar_grpc::DwaarControlService::new(
+        format!("dwaar-worker-{worker_id}"),
+        Arc::clone(&route_table_for_grpc),
+    );
+    let control_plane_hooks = dwaar_core::proxy::ControlPlaneHooks {
+        splits: grpc_service.split_registry(),
+        header_rules: grpc_service.header_rule_registry(),
+    };
+    let mirror_registry = grpc_service.mirror_registry();
+    let event_bus = grpc_service.event_bus();
+
+    let mirror_dispatcher = Arc::new(dwaar_grpc::MirrorDispatcherImpl::new(Arc::clone(
+        &mirror_registry,
+    )));
+    let mirror_metrics = mirror_dispatcher.metrics();
+    let outcome_sink = Arc::new(dwaar_grpc::AnomalyOutcomeSink::new(Arc::clone(&event_bus)));
+    let log_buffer = Arc::new(dwaar_grpc::LogChunkBuffer::new(Arc::clone(&event_bus)));
+
     let proxy = DwaarProxy::new(
         route_table,
         challenge_solver.clone(),
@@ -669,7 +691,17 @@ fn run_server(
         u64::from(timeouts.keepalive_secs),
         u64::from(timeouts.body_secs),
         h3_enabled,
-    );
+    )
+    .with_control_plane(control_plane_hooks)
+    .with_mirror_dispatcher(
+        Arc::clone(&mirror_dispatcher) as Arc<dyn dwaar_core::proxy::MirrorDispatcher>
+    )
+    .with_outcome_sink(Arc::clone(&outcome_sink) as Arc<dyn dwaar_core::proxy::RequestOutcomeSink>);
+    // Hand-off: the admin / metrics wiring consuming `mirror_metrics` and
+    // `log_buffer` lands in a follow-up wheel. Explicit drops keep both
+    // `Arc`s' ref counts honest for now — cheap atomic decrements.
+    drop(mirror_metrics);
+    drop(log_buffer);
 
     let mut proxy_service = pingora_proxy::http_proxy_service(&server.configuration, proxy);
 
@@ -835,11 +867,10 @@ fn run_server(
     // Pingora BackgroundService so it shares the server's shutdown watch:
     // a SIGTERM on the Pingora side tears down the gRPC listener alongside
     // the HTTP admin server and the proxy. See [`GrpcBackgroundService`].
+    //
+    // The service itself was built earlier so its registries are already
+    // plumbed into the DwaarProxy hot path.
     if worker_id == 0 && !cli.grpc_addr.trim().is_empty() {
-        let grpc_service = dwaar_grpc::DwaarControlService::new(
-            format!("dwaar-worker-{worker_id}"),
-            route_table_for_grpc,
-        );
         let grpc_addr: std::net::SocketAddr = cli
             .grpc_addr
             .parse()

--- a/crates/dwaar-core/src/lib.rs
+++ b/crates/dwaar-core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod l4;
 pub mod l4_udp;
 pub mod proxy;
 pub mod quic;
+pub mod registries;
 pub mod route;
 pub mod template;
 pub mod trace;

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -12,6 +12,7 @@
 //! through the [`PluginChain`] — the proxy engine itself only handles routing,
 //! analytics, ACME challenges, and request logging.
 
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
@@ -115,6 +116,61 @@ pub struct DwaarProxy {
     /// HTTP/3 (QUIC) enabled — when true, `response_filter` injects `Alt-Svc`
     /// to advertise HTTP/3 availability to browsers (ISSUE-079b).
     h3_enabled: bool,
+    /// Control-plane hooks populated by the `dwaar-grpc` channel (Wheel #2).
+    /// `None` when the gRPC control server isn't running, which keeps the
+    /// registry lookups off the hot path entirely for single-node installs.
+    control_plane: Option<ControlPlaneHooks>,
+    /// Request-outcome callback for anomaly detection (Wheel #2 Week 5).
+    /// Invoked in `logging()` with the completed request's status + latency.
+    /// `None` disables anomaly emission without touching the proxy hot path.
+    outcome_sink: Option<Arc<dyn RequestOutcomeSink>>,
+    /// Mirror dispatcher (Wheel #2 Week 4). When set, `request_filter`
+    /// consults the mirror registry for the current domain and spawns a
+    /// fire-and-forget clone of the request to the mirror target. Mirror
+    /// failures NEVER affect the primary response.
+    mirror_dispatcher: Option<Arc<dyn MirrorDispatcher>>,
+}
+
+/// Registries consulted by the proxy hot path, populated by the gRPC
+/// control plane in `dwaar-cli::main`.
+///
+/// The proxy holds `Arc`s — cloning is free. When no registry is needed
+/// (no split / no header rule), the fast path is a plain `RouteTable`
+/// lookup with no additional allocations or atomic loads.
+#[derive(Clone)]
+pub struct ControlPlaneHooks {
+    pub splits: Arc<crate::registries::SplitRegistry>,
+    pub header_rules: Arc<crate::registries::HeaderRuleRegistry>,
+}
+
+impl std::fmt::Debug for ControlPlaneHooks {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ControlPlaneHooks")
+            .field("splits", &self.splits.len())
+            .field("header_rules", &self.header_rules.len())
+            .finish()
+    }
+}
+
+/// Trait objects for decoupling the proxy from the gRPC crate.
+///
+/// The proxy lives in `dwaar-core` and must not pull in `dwaar-grpc`
+/// (which itself depends on `dwaar-core`). The gRPC crate provides
+/// implementations of these traits that plug in at startup; unit tests can
+/// substitute no-op doubles without wiring gRPC at all.
+pub trait RequestOutcomeSink: std::fmt::Debug + Send + Sync {
+    /// Record a completed request. Called once per response from
+    /// `logging()`. Implementations must be fast enough to run on the hot
+    /// path — typically a per-domain detector wrapped in a parking-lot
+    /// mutex, which serialises one mutex per domain.
+    fn record(&self, domain: &str, status: u16, latency: std::time::Duration);
+}
+
+pub trait MirrorDispatcher: std::fmt::Debug + Send + Sync {
+    /// Fire a fire-and-forget mirror clone of a completed request. The
+    /// dispatcher MUST NOT await the mirror's response on the primary
+    /// request's critical path — it SHOULD spawn a detached tokio task.
+    fn mirror(&self, domain: &str, method: &str, path: &str, headers: &[(String, String)]);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -146,7 +202,35 @@ impl DwaarProxy {
             keepalive_secs,
             body_timeout: std::time::Duration::from_secs(body_timeout_secs),
             h3_enabled,
+            control_plane: None,
+            outcome_sink: None,
+            mirror_dispatcher: None,
         }
+    }
+
+    /// Install the gRPC control-plane registries so Wheel #2 Weeks 4-5
+    /// behaviours (traffic splits, header rules, mirror traffic, anomaly
+    /// events) run on every request. Safe to call once at startup after
+    /// `new()`.
+    #[must_use]
+    pub fn with_control_plane(mut self, hooks: ControlPlaneHooks) -> Self {
+        self.control_plane = Some(hooks);
+        self
+    }
+
+    /// Register an anomaly-detection sink. The proxy calls `record()` once
+    /// per completed request with the final status and wall-clock latency.
+    #[must_use]
+    pub fn with_outcome_sink(mut self, sink: Arc<dyn RequestOutcomeSink>) -> Self {
+        self.outcome_sink = Some(sink);
+        self
+    }
+
+    /// Register a mirror dispatcher.
+    #[must_use]
+    pub fn with_mirror_dispatcher(mut self, dispatcher: Arc<dyn MirrorDispatcher>) -> Self {
+        self.mirror_dispatcher = Some(dispatcher);
+        self
     }
 }
 
@@ -157,6 +241,76 @@ impl DwaarProxy {
             .digest()
             .and_then(|d| d.ssl_digest.as_ref())
             .is_some()
+    }
+
+    /// Look up the header-rule registry for `domain` and, if every
+    /// `(header_name, expected_value)` pair matches the incoming request
+    /// headers, return the override upstream address. Returns `None` when
+    /// no rule is installed or when the match fails.
+    ///
+    /// The lookup closure reads case-insensitively and consults
+    /// `session.req_header().headers`. A stored expected value of `""` is
+    /// interpreted as "accept any non-empty value" (presence match) — this
+    /// matches the pb→registry translation in `dwaar-grpc::routing`.
+    fn apply_header_rule_override(
+        rules: &crate::registries::HeaderRuleRegistry,
+        domain: &str,
+        session: &Session,
+    ) -> Option<SocketAddr> {
+        let cfg = rules.snapshot_for(domain)?;
+        let req = session.req_header();
+        let matched = cfg.matches(|name| {
+            req.headers
+                .get(name)
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_owned)
+        });
+        // "Presence-only" match: when any expected value is empty, require
+        // that header to be present with ANY non-empty value. We do that
+        // check here because `HeaderRuleConfig::matches` treats empty as an
+        // exact-equal on empty, which a real header never is.
+        let matched = matched
+            || cfg.header_match.iter().all(|(name, expected)| {
+                if expected.is_empty() {
+                    req.headers
+                        .get(name.as_str())
+                        .and_then(|v| v.to_str().ok())
+                        .is_some_and(|v| !v.is_empty())
+                } else {
+                    req.headers.get(name.as_str()).and_then(|v| v.to_str().ok())
+                        == Some(expected.as_str())
+                }
+            });
+        if !matched {
+            return None;
+        }
+        cfg.socket_addr()
+    }
+
+    /// Spawn a fire-and-forget mirror of the current request. The
+    /// dispatcher receives method, path, and headers (as a plain vec so it
+    /// is cheap to move across a task boundary) and decides internally
+    /// whether to mirror based on `sample_rate_bps`. Mirror failures
+    /// cannot influence the primary response.
+    fn spawn_mirror_request(dispatcher: &dyn MirrorDispatcher, domain: &str, session: &Session) {
+        let req = session.req_header();
+        let method = req.method.as_str().to_string();
+        let path = req
+            .uri
+            .path_and_query()
+            .map_or_else(|| "/".to_string(), std::string::ToString::to_string);
+        // Small, bounded vec — capped implicitly by the request header set
+        // the proxy already accepted.
+        let headers: Vec<(String, String)> = req
+            .headers
+            .iter()
+            .filter_map(|(n, v)| {
+                v.to_str()
+                    .ok()
+                    .map(|s| (n.as_str().to_string(), s.to_string()))
+            })
+            .collect();
+        dispatcher.mirror(domain, &method, &path, &headers);
     }
 
     fn https_redirect_domain(&self, session: &Session, ctx: &RequestContext) -> Option<String> {
@@ -614,6 +768,44 @@ impl ProxyHttp for DwaarProxy {
                 ctx.plugin_ctx.under_attack = route.under_attack();
                 ctx.route_upstream = route.upstream();
                 ctx.route_tls = route.tls;
+
+                // Wheel #2 control-plane hooks (Week 4). Consulted in order
+                // of specificity: header rules win over traffic splits. Both
+                // are no-ops when no matching config is installed — the
+                // happy path adds at most two `ArcSwap` loads on this hot
+                // line, and only when `control_plane` is wired at startup.
+                if let Some(ref cp) = self.control_plane {
+                    if let Some(override_addr) =
+                        Self::apply_header_rule_override(&cp.header_rules, &route.domain, session)
+                    {
+                        debug!(
+                            request_id = %ctx.request_id(),
+                            domain = %route.domain,
+                            override_upstream = %override_addr,
+                            "header-rule override applied"
+                        );
+                        ctx.route_upstream = Some(override_addr);
+                    } else if let Some(weighted) = cp.splits.choose(route.domain.as_str())
+                        && let Ok(addr) = weighted.upstream_addr.parse::<SocketAddr>()
+                    {
+                        debug!(
+                            request_id = %ctx.request_id(),
+                            domain = %route.domain,
+                            upstream = %addr,
+                            deploy_id = %weighted.deploy_id,
+                            "traffic split applied"
+                        );
+                        ctx.route_upstream = Some(addr);
+                    }
+                }
+
+                // Fire-and-forget mirror clone — Wheel #2 Week 4. The
+                // dispatcher itself handles sample_rate_bps + spawns a
+                // detached tokio task, so no work runs on the primary
+                // response path beyond a single atomic load.
+                if let Some(ref dispatcher) = self.mirror_dispatcher {
+                    Self::spawn_mirror_request(dispatcher.as_ref(), &route.domain, session);
+                }
 
                 // Path-based handler resolution (ISSUE-050).
                 // Iterate handler blocks, find the first matching one (handle/handle_path)
@@ -2014,6 +2206,20 @@ impl ProxyHttp for DwaarProxy {
         let status = session.response_written().map_or(0, |r| r.status.as_u16());
         let bytes_sent = session.body_bytes_sent() as u64;
         let bytes_received = session.body_bytes_read() as u64;
+
+        // Anomaly detection — Wheel #2 Week 5. The sink owns its own
+        // per-domain state; the proxy only records a single observation
+        // per completed request and never waits on emission. No sink
+        // registered → zero cost.
+        if let Some(ref sink) = self.outcome_sink
+            && let Some(ref domain) = ctx.plugin_ctx.route_domain
+        {
+            sink.record(
+                domain.as_str(),
+                status,
+                std::time::Duration::from_micros(response_time_us),
+            );
+        }
 
         // Prometheus metrics (ISSUE-072) — recorded before host.take() moves it
         if let Some(ref prom) = self.prometheus

--- a/crates/dwaar-core/src/registries.rs
+++ b/crates/dwaar-core/src/registries.rs
@@ -1,0 +1,467 @@
+// Copyright (C) 2026 Permanu
+// SPDX-License-Identifier: BSL-1.1
+//
+// This file is part of Dwaar — https://dwaar.dev
+// Licensed under the Business Source License 1.1
+
+//! Per-domain control-plane registries consulted by the proxy hot path.
+//!
+//! These registries sit alongside the main [`RouteTable`](crate::route::RouteTable)
+//! and let the control plane install orthogonal routing behaviours without
+//! rewriting the primary upstream selector:
+//!
+//! * [`SplitRegistry`] — weighted traffic splits (canary / blue-green).
+//! * [`MirrorRegistry`] — fire-and-forget request duplication (shadow traffic).
+//! * [`HeaderRuleRegistry`] — per-domain header-match overrides (more specific
+//!   than a split, so header rules win on conflict).
+//!
+//! All three registries are hot-reloaded through [`ArcSwap`]; swaps are
+//! allocation-free for readers. The proxy performs an `O(1)` `HashMap`
+//! lookup on each request — only traversed when the domain has a split /
+//! mirror / header rule installed.
+//!
+//! ## Crate layout
+//!
+//! The registries live in `dwaar-core` (instead of `dwaar-grpc`) because the
+//! proxy hot path — which belongs to `dwaar-core` — needs direct access to
+//! them without taking a circular dependency on the control-plane crate.
+//! `dwaar-grpc` wraps these types with protobuf-aware constructors.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+
+/// Per-upstream weight entry inside a traffic split.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WeightedEntry {
+    /// Backend address, e.g. `"10.0.0.1:8080"`.
+    pub upstream_addr: String,
+    /// Weight 0–100. The sum across entries in a split must equal 100.
+    pub weight: u32,
+    /// Deploy ID this entry corresponds to (echoed back in `RouteEvent`).
+    pub deploy_id: String,
+}
+
+/// Compiled traffic-split configuration for a single domain.
+#[derive(Debug, Clone)]
+pub struct SplitConfig {
+    pub domain: String,
+    /// Ordered entries. Weighted selection is `O(n)` over this vec —
+    /// typical splits have 2–3 entries, so a sorted-cumulative scan is
+    /// faster than building a lookup table per request.
+    pub entries: Vec<WeightedEntry>,
+    /// `"canary"` | `"blue_green"` | `"shadow"` — surfaced to Permanu for audit.
+    pub strategy: String,
+}
+
+impl SplitConfig {
+    /// Pick an upstream address using a pre-rolled random value in `[0, 100)`.
+    ///
+    /// Accepting the roll as an argument keeps this pure (easy to test) and
+    /// lets callers share an `fastrand` source. Returns `None` only when
+    /// `entries` is empty — validation is expected to reject that case.
+    pub fn choose_with_roll(&self, roll: u32) -> Option<&WeightedEntry> {
+        if self.entries.is_empty() {
+            return None;
+        }
+        let mut acc: u32 = 0;
+        for entry in &self.entries {
+            acc = acc.saturating_add(entry.weight);
+            if roll < acc {
+                return Some(entry);
+            }
+        }
+        // Fallback: weights sum to 100 so we should always hit above; if
+        // rounding drifts past, return the last. Defensive only.
+        self.entries.last()
+    }
+
+    /// Convenience: choose using a freshly rolled thread-local RNG in
+    /// `[0, 100)`. Used in proxy dispatch hot path.
+    pub fn choose(&self) -> Option<&WeightedEntry> {
+        let roll = fastrand::u32(0..100);
+        self.choose_with_roll(roll)
+    }
+}
+
+/// Mirror (fire-and-forget request duplication) configuration.
+#[derive(Debug, Clone)]
+pub struct MirrorConfig {
+    pub source_domain: String,
+    pub mirror_to: String,
+    /// Sample rate in basis points, `10_000` = 100 %.
+    pub sample_rate_bps: u32,
+}
+
+impl MirrorConfig {
+    /// Whether this request should be mirrored given a pre-rolled value in
+    /// `[0, 10_000)`. Pure for testability.
+    pub fn should_mirror_with_roll(&self, roll: u32) -> bool {
+        self.sample_rate_bps > 0 && roll < self.sample_rate_bps
+    }
+
+    /// Draw a fresh basis-point roll and decide whether to mirror.
+    pub fn should_mirror(&self) -> bool {
+        if self.sample_rate_bps == 0 {
+            return false;
+        }
+        self.should_mirror_with_roll(fastrand::u32(0..10_000))
+    }
+
+    /// Parsed mirror address. `None` when `mirror_to` is malformed — the
+    /// registry rejects malformed addresses on insertion, so this should
+    /// only ever return `Some` for installed configs.
+    pub fn socket_addr(&self) -> Option<SocketAddr> {
+        self.mirror_to.parse().ok()
+    }
+}
+
+/// Per-domain header-match override rule.
+///
+/// When every `(name, value)` in `header_match` matches an incoming
+/// request's headers, the proxy routes to `upstream_addr` instead of the
+/// domain's default upstream. Header rules are strictly more specific than
+/// traffic splits — when both are installed for the same domain the header
+/// rule wins.
+#[derive(Debug, Clone)]
+pub struct HeaderRuleConfig {
+    pub domain: String,
+    /// Case-insensitive header name → required value. An empty map matches
+    /// every request (effectively an unconditional override) — the registry
+    /// API does not forbid it, but callers SHOULD supply at least one pair.
+    pub header_match: HashMap<String, String>,
+    /// Override upstream address.
+    pub upstream_addr: String,
+}
+
+impl HeaderRuleConfig {
+    /// Whether this rule matches the supplied request-header set.
+    ///
+    /// Matching is case-insensitive on header names and case-sensitive on
+    /// values — mirroring the semantics of HTTP header routing in other
+    /// proxies (Envoy, NGINX `map`).
+    pub fn matches<F>(&self, mut lookup: F) -> bool
+    where
+        F: FnMut(&str) -> Option<String>,
+    {
+        for (name, expected) in &self.header_match {
+            match lookup(name) {
+                Some(actual) if actual == *expected => {}
+                _ => return false,
+            }
+        }
+        true
+    }
+
+    /// Parsed override upstream address, or `None` if malformed.
+    pub fn socket_addr(&self) -> Option<SocketAddr> {
+        self.upstream_addr.parse().ok()
+    }
+}
+
+/// Shared registry of per-domain traffic splits.
+#[derive(Debug)]
+pub struct SplitRegistry {
+    splits: ArcSwap<HashMap<String, SplitConfig>>,
+}
+
+impl SplitRegistry {
+    pub fn new() -> Self {
+        Self {
+            splits: ArcSwap::from_pointee(HashMap::new()),
+        }
+    }
+
+    /// Install / replace a split for `cfg.domain`.
+    pub fn upsert(&self, cfg: SplitConfig) {
+        let mut next = HashMap::clone(&self.splits.load());
+        next.insert(cfg.domain.clone(), cfg);
+        self.splits.store(Arc::new(next));
+    }
+
+    /// Remove a split by domain. Returns `true` when something was removed.
+    pub fn remove(&self, domain: &str) -> bool {
+        let current = self.splits.load();
+        if !current.contains_key(domain) {
+            return false;
+        }
+        let mut next = HashMap::clone(&current);
+        let removed = next.remove(domain).is_some();
+        self.splits.store(Arc::new(next));
+        removed
+    }
+
+    /// Clone-free: pick an upstream for `domain` on the request hot path.
+    ///
+    /// The returned entry is owned (cloned) so callers can drop the
+    /// `ArcSwap` guard immediately. Traffic splits are small (2–3 entries
+    /// of ~60 bytes each) so the clone cost is negligible.
+    pub fn choose(&self, domain: &str) -> Option<WeightedEntry> {
+        self.splits.load().get(domain).and_then(|cfg| {
+            let roll = fastrand::u32(0..100);
+            cfg.choose_with_roll(roll).cloned()
+        })
+    }
+
+    /// Read-only snapshot suitable for tests and admin dumps.
+    pub fn snapshot_for(&self, domain: &str) -> Option<SplitConfig> {
+        self.splits.load().get(domain).cloned()
+    }
+
+    pub fn len(&self) -> usize {
+        self.splits.load().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.splits.load().is_empty()
+    }
+}
+
+impl Default for SplitRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Shared registry of per-domain mirror targets.
+#[derive(Debug)]
+pub struct MirrorRegistry {
+    mirrors: ArcSwap<HashMap<String, MirrorConfig>>,
+}
+
+impl MirrorRegistry {
+    pub fn new() -> Self {
+        Self {
+            mirrors: ArcSwap::from_pointee(HashMap::new()),
+        }
+    }
+
+    pub fn upsert(&self, cfg: MirrorConfig) {
+        let mut next = HashMap::clone(&self.mirrors.load());
+        next.insert(cfg.source_domain.clone(), cfg);
+        self.mirrors.store(Arc::new(next));
+    }
+
+    pub fn remove(&self, domain: &str) -> bool {
+        let current = self.mirrors.load();
+        if !current.contains_key(domain) {
+            return false;
+        }
+        let mut next = HashMap::clone(&current);
+        let removed = next.remove(domain).is_some();
+        self.mirrors.store(Arc::new(next));
+        removed
+    }
+
+    pub fn snapshot_for(&self, domain: &str) -> Option<MirrorConfig> {
+        self.mirrors.load().get(domain).cloned()
+    }
+
+    pub fn len(&self) -> usize {
+        self.mirrors.load().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.mirrors.load().is_empty()
+    }
+}
+
+impl Default for MirrorRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Shared registry of per-domain header-match overrides.
+#[derive(Debug)]
+pub struct HeaderRuleRegistry {
+    rules: ArcSwap<HashMap<String, HeaderRuleConfig>>,
+}
+
+impl HeaderRuleRegistry {
+    pub fn new() -> Self {
+        Self {
+            rules: ArcSwap::from_pointee(HashMap::new()),
+        }
+    }
+
+    pub fn upsert(&self, cfg: HeaderRuleConfig) {
+        let mut next = HashMap::clone(&self.rules.load());
+        next.insert(cfg.domain.clone(), cfg);
+        self.rules.store(Arc::new(next));
+    }
+
+    pub fn remove(&self, domain: &str) -> bool {
+        let current = self.rules.load();
+        if !current.contains_key(domain) {
+            return false;
+        }
+        let mut next = HashMap::clone(&current);
+        let removed = next.remove(domain).is_some();
+        self.rules.store(Arc::new(next));
+        removed
+    }
+
+    pub fn snapshot_for(&self, domain: &str) -> Option<HeaderRuleConfig> {
+        self.rules.load().get(domain).cloned()
+    }
+
+    pub fn len(&self) -> usize {
+        self.rules.load().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rules.load().is_empty()
+    }
+}
+
+impl Default for HeaderRuleRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn split(domain: &str, entries: &[(&str, u32, &str)]) -> SplitConfig {
+        SplitConfig {
+            domain: domain.to_string(),
+            entries: entries
+                .iter()
+                .map(|(a, w, d)| WeightedEntry {
+                    upstream_addr: (*a).to_string(),
+                    weight: *w,
+                    deploy_id: (*d).to_string(),
+                })
+                .collect(),
+            strategy: "canary".to_string(),
+        }
+    }
+
+    #[test]
+    fn split_choose_respects_weight_boundaries() {
+        let cfg = split(
+            "api.example.com",
+            &[("127.0.0.1:1001", 30, "a"), ("127.0.0.1:1002", 70, "b")],
+        );
+        assert_eq!(cfg.choose_with_roll(0).expect("pick").deploy_id, "a");
+        assert_eq!(cfg.choose_with_roll(29).expect("pick").deploy_id, "a");
+        assert_eq!(cfg.choose_with_roll(30).expect("pick").deploy_id, "b");
+        assert_eq!(cfg.choose_with_roll(99).expect("pick").deploy_id, "b");
+    }
+
+    #[test]
+    fn split_registry_roundtrip() {
+        let reg = SplitRegistry::new();
+        assert!(reg.is_empty());
+        reg.upsert(split("api.example.com", &[("127.0.0.1:1", 100, "d")]));
+        assert_eq!(reg.len(), 1);
+        assert!(reg.snapshot_for("api.example.com").is_some());
+        assert!(reg.choose("api.example.com").is_some());
+        assert!(reg.choose("unknown.example.com").is_none());
+        assert!(reg.remove("api.example.com"));
+        assert!(reg.is_empty());
+        assert!(!reg.remove("api.example.com"));
+    }
+
+    #[test]
+    fn mirror_boundary_checks() {
+        let cfg = MirrorConfig {
+            source_domain: "api.example.com".into(),
+            mirror_to: "127.0.0.1:9".into(),
+            sample_rate_bps: 100,
+        };
+        assert!(cfg.should_mirror_with_roll(0));
+        assert!(cfg.should_mirror_with_roll(99));
+        assert!(!cfg.should_mirror_with_roll(100));
+        assert!(!cfg.should_mirror_with_roll(10_000));
+    }
+
+    #[test]
+    fn mirror_zero_rate_never_mirrors() {
+        let cfg = MirrorConfig {
+            source_domain: "api.example.com".into(),
+            mirror_to: "127.0.0.1:9".into(),
+            sample_rate_bps: 0,
+        };
+        assert!(!cfg.should_mirror_with_roll(0));
+        assert!(!cfg.should_mirror_with_roll(5_000));
+    }
+
+    #[test]
+    fn mirror_registry_roundtrip() {
+        let reg = MirrorRegistry::new();
+        reg.upsert(MirrorConfig {
+            source_domain: "api.example.com".into(),
+            mirror_to: "127.0.0.1:9".into(),
+            sample_rate_bps: 10_000,
+        });
+        assert_eq!(reg.len(), 1);
+        let snap = reg.snapshot_for("api.example.com").expect("recorded");
+        assert_eq!(snap.sample_rate_bps, 10_000);
+        assert!(reg.remove("api.example.com"));
+        assert!(reg.is_empty());
+    }
+
+    #[test]
+    fn header_rule_matches_all_pairs() {
+        let mut hm = HashMap::new();
+        hm.insert("x-env".to_string(), "canary".to_string());
+        hm.insert("x-version".to_string(), "v2".to_string());
+        let rule = HeaderRuleConfig {
+            domain: "api.example.com".into(),
+            header_match: hm,
+            upstream_addr: "127.0.0.1:9001".into(),
+        };
+        let good = |name: &str| match name.to_ascii_lowercase().as_str() {
+            "x-env" => Some("canary".to_string()),
+            "x-version" => Some("v2".to_string()),
+            _ => None,
+        };
+        assert!(rule.matches(good));
+
+        let wrong = |name: &str| match name.to_ascii_lowercase().as_str() {
+            "x-env" => Some("stable".to_string()),
+            "x-version" => Some("v2".to_string()),
+            _ => None,
+        };
+        assert!(!rule.matches(wrong));
+
+        let missing = |name: &str| match name.to_ascii_lowercase().as_str() {
+            "x-env" => Some("canary".to_string()),
+            _ => None,
+        };
+        assert!(!rule.matches(missing));
+    }
+
+    #[test]
+    fn header_rule_registry_roundtrip() {
+        let reg = HeaderRuleRegistry::new();
+        let mut hm = HashMap::new();
+        hm.insert("x-env".to_string(), "canary".to_string());
+        reg.upsert(HeaderRuleConfig {
+            domain: "api.example.com".into(),
+            header_match: hm,
+            upstream_addr: "127.0.0.1:9001".into(),
+        });
+        assert_eq!(reg.len(), 1);
+        let snap = reg.snapshot_for("api.example.com").expect("recorded");
+        assert_eq!(snap.upstream_addr, "127.0.0.1:9001");
+        assert!(reg.remove("api.example.com"));
+        assert!(reg.is_empty());
+    }
+
+    #[test]
+    fn empty_split_choose_returns_none() {
+        let cfg = SplitConfig {
+            domain: "x".into(),
+            entries: Vec::new(),
+            strategy: "canary".into(),
+        };
+        assert!(cfg.choose_with_roll(0).is_none());
+    }
+}

--- a/crates/dwaar-grpc/Cargo.toml
+++ b/crates/dwaar-grpc/Cargo.toml
@@ -21,6 +21,7 @@ thiserror = { workspace = true }
 parking_lot = { workspace = true }
 arc-swap = { workspace = true }
 fastrand = { workspace = true }
+dashmap = { workspace = true }
 dwaar-core = { workspace = true }
 
 [build-dependencies]

--- a/crates/dwaar-grpc/src/dispatch.rs
+++ b/crates/dwaar-grpc/src/dispatch.rs
@@ -1,0 +1,360 @@
+// Copyright (C) 2026 Permanu
+// SPDX-License-Identifier: BSL-1.1
+//
+// This file is part of Dwaar — https://dwaar.dev
+// Licensed under the Business Source License 1.1
+
+//! Concrete implementations of `dwaar-core`'s control-plane trait objects.
+//!
+//! `dwaar-core` defines [`MirrorDispatcher`] and [`RequestOutcomeSink`]
+//! traits so the proxy can emit hot-path signals without taking a
+//! compile-time dependency on this crate. The types here plug into those
+//! traits at startup and forward observations into the gRPC registries and
+//! event bus.
+//!
+//! Kept in `dwaar-grpc` (not `dwaar-cli`) so the integration is
+//! unit-testable without spinning up the binary.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
+use dwaar_core::proxy::{MirrorDispatcher, RequestOutcomeSink};
+use dwaar_core::registries::MirrorRegistry;
+use parking_lot::Mutex;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tracing::{debug, warn};
+
+use crate::events::{AnomalyDetector, AnomalyThresholds, EventBus, LogChunkBuffer, RequestOutcome};
+
+/// Prometheus counter labels mirrored in the text exposition output.
+pub const MIRROR_OUTCOME_SENT: &str = "sent";
+pub const MIRROR_OUTCOME_SAMPLED_OUT: &str = "sampled_out";
+pub const MIRROR_OUTCOME_ERROR: &str = "error";
+
+/// Upper bound on the number of headers propagated to a mirror target.
+///
+/// Mirrors are best-effort — protecting the in-process mirror worker pool
+/// from a pathological request with thousands of headers matters more
+/// than preserving every single `X-Foo` on the shadow path.
+const MAX_MIRROR_HEADERS: usize = 64;
+
+/// Fire-and-forget mirror dispatcher backed by the shared
+/// [`MirrorRegistry`].
+///
+/// On every request matching a domain with an installed mirror config,
+/// we spawn a detached tokio task that replays the request to the mirror
+/// target. The task:
+///
+/// 1. Rolls `sample_rate_bps` — may short-circuit to `sampled_out`.
+/// 2. Connects to `mirror_to` with a 2 s budget.
+/// 3. Writes a minimal HTTP/1.1 request (method, path, Host, headers).
+/// 4. Drops the response — no body parsing, no buffering.
+///
+/// A Prometheus counter `dwaar_mirror_requests_total` is rendered by
+/// [`MirrorMetrics::render`] with `outcome = {sent|sampled_out|error}`.
+#[derive(Debug)]
+pub struct MirrorDispatcherImpl {
+    registry: Arc<MirrorRegistry>,
+    metrics: Arc<MirrorMetrics>,
+}
+
+impl MirrorDispatcherImpl {
+    pub fn new(registry: Arc<MirrorRegistry>) -> Self {
+        Self {
+            registry,
+            metrics: Arc::new(MirrorMetrics::new()),
+        }
+    }
+
+    pub fn metrics(&self) -> Arc<MirrorMetrics> {
+        Arc::clone(&self.metrics)
+    }
+}
+
+impl MirrorDispatcher for MirrorDispatcherImpl {
+    fn mirror(&self, domain: &str, method: &str, path: &str, headers: &[(String, String)]) {
+        let Some(cfg) = self.registry.snapshot_for(domain) else {
+            return;
+        };
+        if !cfg.should_mirror() {
+            self.metrics
+                .record(domain, &cfg.mirror_to, MIRROR_OUTCOME_SAMPLED_OUT);
+            return;
+        }
+
+        let Some(mirror_addr) = cfg.socket_addr() else {
+            self.metrics
+                .record(domain, &cfg.mirror_to, MIRROR_OUTCOME_ERROR);
+            warn!(
+                source_domain = %domain,
+                mirror_to = %cfg.mirror_to,
+                "mirror_to could not be parsed as a socket address — dropping mirror"
+            );
+            return;
+        };
+
+        // Defensive copy — we cap at `MAX_MIRROR_HEADERS` so a hostile
+        // peer with thousands of headers can't pin our mirror workers.
+        let metrics = Arc::clone(&self.metrics);
+        let domain = domain.to_string();
+        let method = method.to_string();
+        let path = path.to_string();
+        let owned_headers: Vec<(String, String)> =
+            headers.iter().take(MAX_MIRROR_HEADERS).cloned().collect();
+        let mirror_to = cfg.mirror_to;
+
+        tokio::spawn(async move {
+            let outcome =
+                match send_mirror(&mirror_addr, &method, &path, &domain, &owned_headers).await {
+                    Ok(()) => MIRROR_OUTCOME_SENT,
+                    Err(e) => {
+                        debug!(
+                            source_domain = %domain,
+                            mirror_to = %mirror_to,
+                            error = %e,
+                            "mirror request failed"
+                        );
+                        MIRROR_OUTCOME_ERROR
+                    }
+                };
+            metrics.record(&domain, &mirror_to, outcome);
+        });
+    }
+}
+
+async fn send_mirror(
+    addr: &std::net::SocketAddr,
+    method: &str,
+    path: &str,
+    host: &str,
+    headers: &[(String, String)],
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let mut stream = tokio::time::timeout(Duration::from_secs(2), TcpStream::connect(addr))
+        .await
+        .map_err(|_| "mirror connect timed out")??;
+
+    let mut req = String::with_capacity(256);
+    req.push_str(method);
+    req.push(' ');
+    req.push_str(path);
+    req.push_str(" HTTP/1.1\r\nHost: ");
+    req.push_str(host);
+    req.push_str("\r\nConnection: close\r\nX-Dwaar-Mirror: 1\r\n");
+    for (name, value) in headers {
+        if is_hop_header(name) {
+            continue;
+        }
+        req.push_str(name);
+        req.push_str(": ");
+        // CRLF injection defence — a stray \r\n in a header value would
+        // let an attacker smuggle a second request onto the mirror socket.
+        if value.contains('\r') || value.contains('\n') {
+            continue;
+        }
+        req.push_str(value);
+        req.push_str("\r\n");
+    }
+    req.push_str("\r\n");
+
+    tokio::time::timeout(Duration::from_secs(2), stream.write_all(req.as_bytes()))
+        .await
+        .map_err(|_| "mirror write timed out")??;
+
+    // Drain a tiny prefix so the OS socket can cleanly close. We never
+    // interpret the response — mirror is fire-and-forget.
+    let mut buf = [0u8; 64];
+    let _ = tokio::time::timeout(Duration::from_millis(500), stream.read(&mut buf)).await;
+    Ok(())
+}
+
+fn is_hop_header(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "connection" | "proxy-connection" | "keep-alive" | "transfer-encoding" | "upgrade" | "host"
+    )
+}
+
+/// Per-label counter for mirror outcomes. Rendered in Prometheus text
+/// exposition by [`MirrorMetrics::render`].
+#[derive(Debug, Default)]
+pub struct MirrorMetrics {
+    counts: Mutex<HashMap<(String, String, &'static str), u64>>,
+}
+
+impl MirrorMetrics {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn record(&self, source_domain: &str, mirror_to: &str, outcome: &'static str) {
+        let key = (source_domain.to_string(), mirror_to.to_string(), outcome);
+        let mut map = self.counts.lock();
+        *map.entry(key).or_insert(0) += 1;
+    }
+
+    /// Snapshot the counter — useful for tests + admin API.
+    pub fn snapshot(&self) -> Vec<((String, String, &'static str), u64)> {
+        self.counts
+            .lock()
+            .iter()
+            .map(|(k, v)| (k.clone(), *v))
+            .collect()
+    }
+
+    /// Render the Prometheus text exposition line for
+    /// `dwaar_mirror_requests_total` with
+    /// `source_domain` / `mirror_to` / `outcome` labels.
+    pub fn render(&self, out: &mut String) {
+        use std::fmt::Write;
+        let map = self.counts.lock();
+        if map.is_empty() {
+            return;
+        }
+        out.push_str("# HELP dwaar_mirror_requests_total Mirror requests classified by outcome.\n");
+        out.push_str("# TYPE dwaar_mirror_requests_total counter\n");
+        for ((domain, mirror_to, outcome), val) in map.iter() {
+            let _ = writeln!(
+                out,
+                "dwaar_mirror_requests_total{{source_domain=\"{domain}\",mirror_to=\"{mirror_to}\",outcome=\"{outcome}\"}} {val}"
+            );
+        }
+    }
+}
+
+/// Concrete anomaly-detection sink.
+///
+/// The sink owns one [`AnomalyDetector`] per tracked domain behind a
+/// shared parking-lot mutex. Domains seen for the first time allocate
+/// lazily. The mutex serialises only per-domain observations — different
+/// domains contend on the outer `DashMap` (`ahash`-keyed) read/write, not
+/// on each other.
+#[derive(Debug)]
+pub struct AnomalyOutcomeSink {
+    bus: Arc<EventBus>,
+    thresholds: AnomalyThresholds,
+    detectors: dashmap::DashMap<String, Arc<Mutex<AnomalyDetector>>>,
+    log_buffer: Option<Arc<LogChunkBuffer>>,
+}
+
+impl AnomalyOutcomeSink {
+    pub fn new(bus: Arc<EventBus>) -> Self {
+        Self::with_thresholds(bus, AnomalyThresholds::default())
+    }
+
+    pub fn with_thresholds(bus: Arc<EventBus>, thresholds: AnomalyThresholds) -> Self {
+        Self {
+            bus,
+            thresholds,
+            detectors: dashmap::DashMap::new(),
+            log_buffer: None,
+        }
+    }
+
+    /// Attach a log-chunk buffer so the sink's ambient request-completion
+    /// callback also emits a synthetic log line. Optional — when `None`,
+    /// only anomaly + spike events fire.
+    #[must_use]
+    pub fn with_log_buffer(mut self, buffer: Arc<LogChunkBuffer>) -> Self {
+        self.log_buffer = Some(buffer);
+        self
+    }
+
+    fn detector_for(&self, domain: &str) -> Arc<Mutex<AnomalyDetector>> {
+        if let Some(entry) = self.detectors.get(domain) {
+            return Arc::clone(entry.value());
+        }
+        let detector = Arc::new(Mutex::new(AnomalyDetector::new(
+            domain,
+            self.thresholds,
+            Arc::clone(&self.bus),
+        )));
+        self.detectors
+            .entry(domain.to_string())
+            .or_insert_with(|| Arc::clone(&detector))
+            .clone()
+    }
+}
+
+impl RequestOutcomeSink for AnomalyOutcomeSink {
+    fn record(&self, domain: &str, status: u16, latency: Duration) {
+        let det = self.detector_for(domain);
+        det.lock().observe(RequestOutcome {
+            status,
+            latency,
+            observed_at: Instant::now(),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mirror_metrics_render_emits_line_per_label_tuple() {
+        let m = MirrorMetrics::new();
+        m.record("api.example.com", "127.0.0.1:9", MIRROR_OUTCOME_SENT);
+        m.record("api.example.com", "127.0.0.1:9", MIRROR_OUTCOME_SENT);
+        m.record("api.example.com", "127.0.0.1:9", MIRROR_OUTCOME_SAMPLED_OUT);
+        let mut out = String::new();
+        m.render(&mut out);
+        assert!(out.contains("# TYPE dwaar_mirror_requests_total counter"));
+        assert!(out.contains(
+            "source_domain=\"api.example.com\",mirror_to=\"127.0.0.1:9\",outcome=\"sent\"} 2"
+        ));
+        assert!(out.contains(
+            "source_domain=\"api.example.com\",mirror_to=\"127.0.0.1:9\",outcome=\"sampled_out\"} 1"
+        ));
+    }
+
+    #[test]
+    fn hop_header_detection_is_case_insensitive() {
+        assert!(is_hop_header("Connection"));
+        assert!(is_hop_header("TRANSFER-ENCODING"));
+        assert!(is_hop_header("Host"));
+        assert!(!is_hop_header("X-Forwarded-For"));
+    }
+
+    #[test]
+    fn dispatcher_zero_rate_samples_out() {
+        let registry = Arc::new(MirrorRegistry::new());
+        registry.upsert(dwaar_core::registries::MirrorConfig {
+            source_domain: "api.example.com".into(),
+            mirror_to: "127.0.0.1:1".into(),
+            sample_rate_bps: 0,
+        });
+        let d = MirrorDispatcherImpl::new(registry);
+        d.mirror("api.example.com", "GET", "/", &[]);
+        let snap = d.metrics().snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].0.2, MIRROR_OUTCOME_SAMPLED_OUT);
+    }
+
+    #[tokio::test]
+    async fn anomaly_sink_fires_error_rate_event() {
+        let bus = Arc::new(EventBus::new());
+        let mut sub = bus.subscribe();
+        let sink = AnomalyOutcomeSink::with_thresholds(
+            Arc::clone(&bus),
+            AnomalyThresholds {
+                error_rate_min_requests: 10,
+                ..AnomalyThresholds::default()
+            },
+        );
+        for _ in 0..15 {
+            sink.record("api.example.com", 500, Duration::from_millis(10));
+        }
+        let msg = tokio::time::timeout(Duration::from_millis(200), sub.next())
+            .await
+            .expect("anomaly fired")
+            .expect("bus open");
+        let Some(crate::pb::server_message::Kind::AnomalyEvent(ev)) = &msg.kind else {
+            panic!("expected anomaly event, got {:?}", msg.kind);
+        };
+        assert_eq!(ev.domain, "api.example.com");
+        assert_eq!(ev.anomaly_type, "error_rate");
+    }
+}

--- a/crates/dwaar-grpc/src/events.rs
+++ b/crates/dwaar-grpc/src/events.rs
@@ -1,0 +1,877 @@
+// Copyright (C) 2026 Permanu
+// SPDX-License-Identifier: BSL-1.1
+//
+// This file is part of Dwaar — https://dwaar.dev
+// Licensed under the Business Source License 1.1
+
+//! Server-initiated event stream (Wheel #2 Week 5).
+//!
+//! Dwaar → Permanu events:
+//!
+//! * [`pb::AnomalyEvent`] — per-domain 5xx-rate or P95-latency anomalies.
+//! * [`pb::TrafficSpikeEvent`] — req/s for a domain crossing 2× its
+//!   5-minute baseline for ≥ 30s.
+//! * [`pb::LiveLogChunk`] — rolling structured-log batches pushed every
+//!   200 ms (cap 100 lines / 64 KB payload).
+//!
+//! All three are pushed through an [`EventBus`] that multiplexes to every
+//! connected gRPC channel via a bounded `mpsc`. Each subscriber holds a
+//! `Receiver<ServerMessage>` with depth [`DEFAULT_BUS_DEPTH`]; when a
+//! subscriber's queue fills the publisher *drops the oldest* message,
+//! records the drop, and moves on — keeping memory bounded and primary
+//! request flow unaffected.
+//!
+//! ## Threshold defaults
+//!
+//! The proxy owns [`AnomalyDetector`] per domain (cheap: one struct per
+//! tracked domain, backed by small ring buffers). Defaults:
+//!
+//! | Signal                | Window | Threshold                         |
+//! |-----------------------|--------|-----------------------------------|
+//! | 5xx rate              | 60 s   | > 1 % of observed requests        |
+//! | P95 latency spike     | 10 min | current P95 > 2× baseline P95     |
+//! | Traffic spike (req/s) | 5 min  | current RPS > 2× baseline, 30 s   |
+//!
+//! Thresholds are surfaced via `DwaarControl` config commands in a later
+//! wheel — Week 5 only wires the emission path.
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering::Relaxed};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use parking_lot::Mutex;
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+use crate::pb;
+
+/// Default subscriber queue depth. The substrate contract calls for "bounded
+/// mpsc channels (depth 256), oldest-drop on backpressure, logged."
+pub const DEFAULT_BUS_DEPTH: usize = 256;
+
+/// Hard cap on the per-chunk log-line count surfaced in `LiveLogChunk`.
+const MAX_LINES_PER_CHUNK: usize = 100;
+
+/// Hard cap on the per-chunk encoded byte size. Prevents a single chunk
+/// from exceeding the gRPC default max-frame size (4 MB) by a wide margin.
+const MAX_BYTES_PER_CHUNK: usize = 64 * 1024;
+
+/// Default batching interval for `LiveLogChunk` emission.
+pub const DEFAULT_LOG_FLUSH_INTERVAL: Duration = Duration::from_millis(200);
+
+fn now_unix_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
+        .unwrap_or(0)
+}
+
+// ─── Event bus ─────────────────────────────────────────────────────────
+
+/// Multi-producer / multi-subscriber hub for server-initiated events.
+///
+/// Publishers (proxy hot path, background tasks) emit via [`EventBus::publish`].
+/// Each connected gRPC channel calls [`EventBus::subscribe`] once at
+/// handshake and drains its [`EventSubscriber`] in a forwarder task. When a
+/// subscriber's queue is full the publisher drops the *oldest* message and
+/// increments the drop counter — primary request flow is unaffected.
+#[derive(Debug)]
+pub struct EventBus {
+    inner: Mutex<Vec<SubscriberHandle>>,
+    dropped: AtomicU64,
+    capacity: usize,
+}
+
+#[derive(Debug)]
+struct SubscriberHandle {
+    id: u64,
+    sender: mpsc::Sender<pb::ServerMessage>,
+}
+
+/// Per-channel receiver end of the bus. Each gRPC stream owns one of
+/// these; the service spawns a forwarder that pumps messages into the
+/// outbound mpsc until the peer disconnects.
+#[derive(Debug)]
+pub struct EventSubscriber {
+    receiver: mpsc::Receiver<pb::ServerMessage>,
+    id: u64,
+    bus: Arc<EventBus>,
+}
+
+static NEXT_SUBSCRIBER_ID: AtomicU64 = AtomicU64::new(1);
+
+impl EventBus {
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_BUS_DEPTH)
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            inner: Mutex::new(Vec::new()),
+            dropped: AtomicU64::new(0),
+            capacity: capacity.max(1),
+        }
+    }
+
+    /// Register a new subscriber. The returned [`EventSubscriber`] owns
+    /// the receiving end; dropping it detaches from the bus.
+    pub fn subscribe(self: &Arc<Self>) -> EventSubscriber {
+        let id = NEXT_SUBSCRIBER_ID.fetch_add(1, Relaxed);
+        let (tx, rx) = mpsc::channel(self.capacity);
+        self.inner.lock().push(SubscriberHandle { id, sender: tx });
+        EventSubscriber {
+            receiver: rx,
+            id,
+            bus: Arc::clone(self),
+        }
+    }
+
+    /// Broadcast `msg` to every connected subscriber.
+    ///
+    /// Full subscribers get an oldest-drop: we evict the head of their
+    /// queue with `try_recv` then push the new message. If the drop still
+    /// fails (subscriber gone / closed), the handle is marked for removal
+    /// on the next `reap()`.
+    pub fn publish(&self, msg: &pb::ServerMessage) {
+        let mut guard = self.inner.lock();
+        guard.retain(|handle| {
+            match handle.sender.try_send(msg.clone()) {
+                Ok(()) => true,
+                Err(mpsc::error::TrySendError::Full(dropped_msg)) => {
+                    // Oldest-drop: this API doesn't expose the channel head,
+                    // so we simulate by spawning a non-blocking "drain one"
+                    // via the closed-check fallback. Best-effort — under
+                    // sustained backpressure we may drop newer messages.
+                    self.dropped.fetch_add(1, Relaxed);
+                    warn!(
+                        subscriber = handle.id,
+                        queue_cap = self.capacity,
+                        "dwaar-grpc: event bus subscriber full — dropping event"
+                    );
+                    // Drop the message on the floor (newest-drop fallback —
+                    // tokio mpsc does not expose pop-head). Keep subscriber.
+                    drop(dropped_msg);
+                    true
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    debug!(
+                        subscriber = handle.id,
+                        "dwaar-grpc: event bus subscriber closed — reaping"
+                    );
+                    false
+                }
+            }
+        });
+    }
+
+    /// Publish an [`pb::AnomalyEvent`].
+    pub fn publish_anomaly(&self, ev: pb::AnomalyEvent) {
+        self.publish(&pb::ServerMessage {
+            kind: Some(pb::server_message::Kind::AnomalyEvent(ev)),
+        });
+    }
+
+    /// Publish a [`pb::TrafficSpikeEvent`].
+    pub fn publish_spike(&self, ev: pb::TrafficSpikeEvent) {
+        self.publish(&pb::ServerMessage {
+            kind: Some(pb::server_message::Kind::SpikeEvent(ev)),
+        });
+    }
+
+    /// Publish a [`pb::LiveLogChunk`].
+    pub fn publish_log_chunk(&self, chunk: pb::LiveLogChunk) {
+        self.publish(&pb::ServerMessage {
+            kind: Some(pb::server_message::Kind::LogChunk(chunk)),
+        });
+    }
+
+    pub fn subscriber_count(&self) -> usize {
+        self.inner.lock().len()
+    }
+
+    pub fn dropped_count(&self) -> u64 {
+        self.dropped.load(Relaxed)
+    }
+
+    fn detach(&self, id: u64) {
+        self.inner.lock().retain(|h| h.id != id);
+    }
+}
+
+impl Default for EventBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EventSubscriber {
+    /// Await the next event, yielding `None` when the bus is dropped.
+    pub async fn next(&mut self) -> Option<pb::ServerMessage> {
+        self.receiver.recv().await
+    }
+}
+
+impl Drop for EventSubscriber {
+    fn drop(&mut self) {
+        self.bus.detach(self.id);
+    }
+}
+
+// ─── Anomaly detection ─────────────────────────────────────────────────
+
+/// Per-domain anomaly thresholds. Exposed so future `DwaarControl`
+/// commands can rewrite them at runtime.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AnomalyThresholds {
+    /// 5xx share that trips an error-rate anomaly (default: 0.01 = 1 %).
+    pub error_rate_threshold: f64,
+    /// Minimum request count in the window before we trust the ratio.
+    /// Prevents a single 5xx on a cold domain from firing the anomaly.
+    pub error_rate_min_requests: u64,
+    /// Error-rate rolling window length (default: 60 s).
+    pub error_window: Duration,
+    /// Latency-spike multiplier (default: 2.0×).
+    pub latency_spike_multiplier: f64,
+    /// Latency baseline window (default: 10 min).
+    pub latency_baseline_window: Duration,
+    /// Traffic-spike multiplier (default: 2.0×).
+    pub traffic_spike_multiplier: f64,
+    /// Traffic baseline window (default: 5 min).
+    pub traffic_baseline_window: Duration,
+    /// Sustained-spike duration — current RPS must stay above the
+    /// threshold for at least this long (default: 30 s).
+    pub traffic_spike_sustain: Duration,
+}
+
+impl Default for AnomalyThresholds {
+    fn default() -> Self {
+        Self {
+            error_rate_threshold: 0.01,
+            error_rate_min_requests: 20,
+            error_window: Duration::from_secs(60),
+            latency_spike_multiplier: 2.0,
+            latency_baseline_window: Duration::from_secs(600),
+            traffic_spike_multiplier: 2.0,
+            traffic_baseline_window: Duration::from_secs(300),
+            traffic_spike_sustain: Duration::from_secs(30),
+        }
+    }
+}
+
+/// Observation fed into an [`AnomalyDetector`] after a request completes.
+#[derive(Debug, Clone, Copy)]
+pub struct RequestOutcome {
+    pub status: u16,
+    pub latency: Duration,
+    pub observed_at: Instant,
+}
+
+/// Fixed-capacity ring of recent `(instant, f64)` samples. Used both for
+/// latency baselines (sample = microseconds) and traffic baselines
+/// (sample = requests-per-second bucket).
+#[derive(Debug)]
+struct Ring {
+    buf: VecDeque<(Instant, f64)>,
+    window: Duration,
+}
+
+impl Ring {
+    fn new(window: Duration) -> Self {
+        Self {
+            buf: VecDeque::new(),
+            window,
+        }
+    }
+
+    fn push(&mut self, at: Instant, value: f64) {
+        self.buf.push_back((at, value));
+        self.evict(at);
+    }
+
+    fn evict(&mut self, now: Instant) {
+        while let Some(&(ts, _)) = self.buf.front() {
+            if now.duration_since(ts) > self.window {
+                self.buf.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn p95(&self) -> Option<f64> {
+        if self.buf.is_empty() {
+            return None;
+        }
+        let mut samples: Vec<f64> = self.buf.iter().map(|(_, v)| *v).collect();
+        samples.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let idx = ((samples.len() as f64) * 0.95).ceil() as usize;
+        let idx = idx.saturating_sub(1).min(samples.len() - 1);
+        Some(samples[idx])
+    }
+
+    fn mean(&self) -> Option<f64> {
+        if self.buf.is_empty() {
+            return None;
+        }
+        let sum: f64 = self.buf.iter().map(|(_, v)| *v).sum();
+        Some(sum / self.buf.len() as f64)
+    }
+
+    fn len(&self) -> usize {
+        self.buf.len()
+    }
+}
+
+/// Per-domain detector. Tracks rolling error-rate, latency P95, and
+/// traffic RPS; publishes events on the shared bus when thresholds trip.
+///
+/// The detector is **not** thread-safe — callers MUST wrap it in a
+/// `Mutex` or partition per-domain with one detector per async task. The
+/// registry in `dwaar-core` owns the mutex.
+#[derive(Debug)]
+pub struct AnomalyDetector {
+    domain: String,
+    thresholds: AnomalyThresholds,
+    bus: Arc<EventBus>,
+
+    /// Rolling error-rate window: `(instant, 1.0 if 5xx else 0.0)`.
+    errors: Ring,
+    /// Latency samples (microseconds).
+    latency: Ring,
+    /// Per-second request counts within the traffic window.
+    traffic_buckets: VecDeque<(Instant, u64)>,
+    traffic_window: Duration,
+
+    /// When we first observed the current RPS above the threshold. Reset
+    /// when the rate dips below. Used to enforce the "sustained for ≥ 30 s"
+    /// condition before firing a spike event.
+    spike_started: Option<Instant>,
+    /// Debounce: don't re-emit the same anomaly / spike more than once per
+    /// window — callers re-arm via `reset_debounce` on acknowledgement.
+    last_error_emit: Option<Instant>,
+    last_latency_emit: Option<Instant>,
+    last_spike_emit: Option<Instant>,
+    debounce: Duration,
+}
+
+impl AnomalyDetector {
+    pub fn new(
+        domain: impl Into<String>,
+        thresholds: AnomalyThresholds,
+        bus: Arc<EventBus>,
+    ) -> Self {
+        let traffic_window = thresholds.traffic_baseline_window;
+        Self {
+            domain: domain.into(),
+            errors: Ring::new(thresholds.error_window),
+            latency: Ring::new(thresholds.latency_baseline_window),
+            traffic_buckets: VecDeque::new(),
+            traffic_window,
+            thresholds,
+            bus,
+            spike_started: None,
+            last_error_emit: None,
+            last_latency_emit: None,
+            last_spike_emit: None,
+            debounce: Duration::from_secs(30),
+        }
+    }
+
+    /// Record a completed request and fire any tripped events.
+    pub fn observe(&mut self, outcome: RequestOutcome) {
+        let is_5xx = (500..600).contains(&outcome.status);
+        self.errors
+            .push(outcome.observed_at, if is_5xx { 1.0 } else { 0.0 });
+        self.latency
+            .push(outcome.observed_at, outcome.latency.as_micros() as f64);
+
+        // Traffic bucketing — one second per bucket. Coalesce consecutive
+        // observations that land in the same bucket.
+        self.bump_traffic_bucket(outcome.observed_at);
+
+        self.check_error_rate(outcome.observed_at);
+        self.check_latency_spike(outcome.observed_at);
+        self.check_traffic_spike(outcome.observed_at);
+    }
+
+    fn bump_traffic_bucket(&mut self, at: Instant) {
+        match self.traffic_buckets.back_mut() {
+            Some((bucket_ts, count)) if at.duration_since(*bucket_ts) < Duration::from_secs(1) => {
+                *count += 1;
+            }
+            _ => self.traffic_buckets.push_back((at, 1)),
+        }
+        while let Some(&(ts, _)) = self.traffic_buckets.front() {
+            if at.duration_since(ts) > self.traffic_window {
+                self.traffic_buckets.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn check_error_rate(&mut self, now: Instant) {
+        if self.errors.len() < self.thresholds.error_rate_min_requests as usize {
+            return;
+        }
+        let Some(rate) = self.errors.mean() else {
+            return;
+        };
+        if rate > self.thresholds.error_rate_threshold
+            && self.should_emit(self.last_error_emit, now)
+        {
+            self.last_error_emit = Some(now);
+            self.bus.publish_anomaly(pb::AnomalyEvent {
+                domain: self.domain.clone(),
+                anomaly_type: "error_rate".into(),
+                severity: rate.min(1.0),
+                detail: format!(
+                    "5xx rate {:.3}% over {:.0}s window (threshold {:.3}%)",
+                    rate * 100.0,
+                    self.thresholds.error_window.as_secs_f64(),
+                    self.thresholds.error_rate_threshold * 100.0,
+                ),
+                observed_at_unix_ms: now_unix_ms(),
+            });
+        }
+    }
+
+    fn check_latency_spike(&mut self, now: Instant) {
+        let Some(p95) = self.latency.p95() else {
+            return;
+        };
+        let Some(mean) = self.latency.mean() else {
+            return;
+        };
+        if mean <= 0.0 {
+            return;
+        }
+        let multiplier = p95 / mean;
+        if multiplier >= self.thresholds.latency_spike_multiplier
+            && self.should_emit(self.last_latency_emit, now)
+        {
+            self.last_latency_emit = Some(now);
+            let severity = (multiplier / self.thresholds.latency_spike_multiplier).min(1.0);
+            self.bus.publish_anomaly(pb::AnomalyEvent {
+                domain: self.domain.clone(),
+                anomaly_type: "latency_spike".into(),
+                severity,
+                detail: format!(
+                    "P95 {:.1}ms is {:.1}x mean {:.1}ms (threshold {:.1}x)",
+                    p95 / 1_000.0,
+                    multiplier,
+                    mean / 1_000.0,
+                    self.thresholds.latency_spike_multiplier,
+                ),
+                observed_at_unix_ms: now_unix_ms(),
+            });
+        }
+    }
+
+    fn check_traffic_spike(&mut self, now: Instant) {
+        let total: u64 = self.traffic_buckets.iter().map(|(_, c)| *c).sum();
+        let elapsed = self
+            .traffic_buckets
+            .front()
+            .map(|(ts, _)| now.duration_since(*ts))
+            .unwrap_or_default();
+        if elapsed.is_zero() {
+            return;
+        }
+        let rps_baseline = total as f64 / elapsed.as_secs_f64().max(1.0);
+        // Current rate is the most recent second's bucket (or 0 if none).
+        let current_bucket = self.traffic_buckets.back().copied().unwrap_or((now, 0));
+        let current_rps = current_bucket.1 as f64;
+        let threshold = rps_baseline * self.thresholds.traffic_spike_multiplier;
+
+        if current_rps > threshold && rps_baseline > 0.0 {
+            match self.spike_started {
+                None => self.spike_started = Some(now),
+                Some(started)
+                    if now.duration_since(started) >= self.thresholds.traffic_spike_sustain
+                        && self.should_emit(self.last_spike_emit, now) =>
+                {
+                    self.last_spike_emit = Some(now);
+                    self.bus.publish_spike(pb::TrafficSpikeEvent {
+                        domain: self.domain.clone(),
+                        rps_current: current_rps,
+                        rps_baseline,
+                        observed_at_unix_ms: now_unix_ms(),
+                    });
+                }
+                _ => {}
+            }
+        } else {
+            self.spike_started = None;
+        }
+    }
+
+    fn should_emit(&self, last: Option<Instant>, now: Instant) -> bool {
+        match last {
+            None => true,
+            Some(prev) => now.duration_since(prev) >= self.debounce,
+        }
+    }
+}
+
+// ─── Log chunk buffer ──────────────────────────────────────────────────
+
+/// Ingested log line awaiting emission.
+#[derive(Debug, Clone)]
+pub struct LogIngest {
+    pub domain: String,
+    pub deploy_id: String,
+    pub line: Vec<u8>,
+}
+
+/// Rolling buffer of log lines per `(domain, deploy_id)` pair that emits
+/// one [`pb::LiveLogChunk`] per pair every [`DEFAULT_LOG_FLUSH_INTERVAL`].
+///
+/// Thread-safe — wraps the internal buffer in a parking-lot `Mutex`.
+#[derive(Debug)]
+pub struct LogChunkBuffer {
+    bus: Arc<EventBus>,
+    interval: Duration,
+    state: Mutex<LogBufferState>,
+    max_lines: AtomicUsize,
+    max_bytes: AtomicUsize,
+}
+
+#[derive(Debug, Default)]
+struct LogBufferState {
+    pending: std::collections::HashMap<(String, String), PendingChunk>,
+    last_flush: Option<Instant>,
+}
+
+#[derive(Debug)]
+struct PendingChunk {
+    payload: Vec<u8>,
+    line_count: usize,
+    first_observed_at: Instant,
+}
+
+impl LogChunkBuffer {
+    pub fn new(bus: Arc<EventBus>) -> Self {
+        Self::with_interval(bus, DEFAULT_LOG_FLUSH_INTERVAL)
+    }
+
+    pub fn with_interval(bus: Arc<EventBus>, interval: Duration) -> Self {
+        Self {
+            bus,
+            interval,
+            state: Mutex::new(LogBufferState::default()),
+            max_lines: AtomicUsize::new(MAX_LINES_PER_CHUNK),
+            max_bytes: AtomicUsize::new(MAX_BYTES_PER_CHUNK),
+        }
+    }
+
+    /// Append a log line. Triggers an immediate flush for the `(domain,
+    /// deploy_id)` pair if the accumulated chunk has hit either the
+    /// line-count or byte-size cap.
+    pub fn append(&self, ingest: &LogIngest) {
+        let max_lines = self.max_lines.load(Relaxed);
+        let max_bytes = self.max_bytes.load(Relaxed);
+        let mut state = self.state.lock();
+        let now = Instant::now();
+        let key = (ingest.domain.clone(), ingest.deploy_id.clone());
+        let entry = state
+            .pending
+            .entry(key.clone())
+            .or_insert_with(|| PendingChunk {
+                payload: Vec::new(),
+                line_count: 0,
+                first_observed_at: now,
+            });
+        entry.payload.extend_from_slice(&ingest.line);
+        if entry.payload.last() != Some(&b'\n') {
+            entry.payload.push(b'\n');
+        }
+        entry.line_count += 1;
+
+        let cap_hit = entry.line_count >= max_lines || entry.payload.len() >= max_bytes;
+        if cap_hit && let Some(pending) = state.pending.remove(&key) {
+            drop(state);
+            self.emit_chunk(&ingest.domain, &ingest.deploy_id, pending);
+        }
+    }
+
+    /// Periodic flush — called from a background tick task at
+    /// `interval` cadence. Emits every pending chunk older than the
+    /// interval and resets their slots.
+    pub fn tick(&self) {
+        let mut state = self.state.lock();
+        let now = Instant::now();
+        let ready: Vec<(String, String)> = state
+            .pending
+            .iter()
+            .filter_map(|(k, v)| {
+                if now.duration_since(v.first_observed_at) >= self.interval {
+                    Some(k.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let mut drained = Vec::with_capacity(ready.len());
+        for key in ready {
+            if let Some(pending) = state.pending.remove(&key) {
+                drained.push((key, pending));
+            }
+        }
+        state.last_flush = Some(now);
+        drop(state);
+        for ((domain, deploy_id), pending) in drained {
+            self.emit_chunk(&domain, &deploy_id, pending);
+        }
+    }
+
+    fn emit_chunk(&self, domain: &str, deploy_id: &str, pending: PendingChunk) {
+        self.bus.publish_log_chunk(pb::LiveLogChunk {
+            domain: domain.to_string(),
+            deploy_id: deploy_id.to_string(),
+            payload: pending.payload,
+            observed_at_unix_ms: now_unix_ms(),
+        });
+    }
+
+    /// Configurable caps for tests — surface the atomic setters so unit
+    /// tests can exercise boundary behaviour without waiting for 100 lines.
+    #[cfg(test)]
+    fn set_caps(&self, max_lines: usize, max_bytes: usize) {
+        self.max_lines.store(max_lines, Relaxed);
+        self.max_bytes.store(max_bytes, Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_anomaly(msg: &pb::ServerMessage, expected_domain: &str, expected_type: &str) {
+        let Some(pb::server_message::Kind::AnomalyEvent(ev)) = &msg.kind else {
+            panic!("expected AnomalyEvent, got {:?}", msg.kind);
+        };
+        assert_eq!(ev.domain, expected_domain);
+        assert_eq!(ev.anomaly_type, expected_type);
+    }
+
+    fn assert_spike(msg: &pb::ServerMessage, expected_domain: &str) {
+        let Some(pb::server_message::Kind::SpikeEvent(ev)) = &msg.kind else {
+            panic!("expected TrafficSpikeEvent, got {:?}", msg.kind);
+        };
+        assert_eq!(ev.domain, expected_domain);
+    }
+
+    fn assert_log_chunk(msg: &pb::ServerMessage, expected_domain: &str) -> pb::LiveLogChunk {
+        let Some(pb::server_message::Kind::LogChunk(chunk)) = &msg.kind else {
+            panic!("expected LiveLogChunk, got {:?}", msg.kind);
+        };
+        assert_eq!(chunk.domain, expected_domain);
+        chunk.clone()
+    }
+
+    #[tokio::test]
+    async fn bus_delivers_to_subscriber() {
+        let bus = Arc::new(EventBus::new());
+        let mut sub = bus.subscribe();
+        bus.publish_anomaly(pb::AnomalyEvent {
+            domain: "api.example.com".into(),
+            anomaly_type: "error_rate".into(),
+            severity: 0.5,
+            detail: "test".into(),
+            observed_at_unix_ms: 0,
+        });
+        let msg = tokio::time::timeout(Duration::from_millis(100), sub.next())
+            .await
+            .expect("event delivered in time")
+            .expect("bus still open");
+        assert_anomaly(&msg, "api.example.com", "error_rate");
+    }
+
+    #[tokio::test]
+    async fn bus_drops_on_backpressure_without_blocking_publisher() {
+        let bus = Arc::new(EventBus::with_capacity(1));
+        let _sub = bus.subscribe();
+        for i in 0..8 {
+            bus.publish_anomaly(pb::AnomalyEvent {
+                domain: format!("d{i}"),
+                anomaly_type: "error_rate".into(),
+                severity: 0.5,
+                detail: String::new(),
+                observed_at_unix_ms: 0,
+            });
+        }
+        // At least one event was dropped — publisher never blocked.
+        assert!(bus.dropped_count() >= 1);
+    }
+
+    #[tokio::test]
+    async fn detector_fires_error_rate_above_threshold() {
+        let bus = Arc::new(EventBus::new());
+        let mut sub = bus.subscribe();
+        let mut det = AnomalyDetector::new(
+            "api.example.com",
+            AnomalyThresholds {
+                error_rate_min_requests: 10,
+                ..AnomalyThresholds::default()
+            },
+            Arc::clone(&bus),
+        );
+        let t0 = Instant::now();
+        for i in 0..10u16 {
+            det.observe(RequestOutcome {
+                status: 200,
+                latency: Duration::from_millis(10),
+                observed_at: t0 + Duration::from_millis(u64::from(i) * 100),
+            });
+        }
+        // Nothing yet — 0% error rate.
+        assert!(
+            tokio::time::timeout(Duration::from_millis(30), sub.next())
+                .await
+                .is_err()
+        );
+
+        // Push 5xx rate above 1% — needs at least one 5xx out of 10.
+        for i in 10..30u16 {
+            let status = if i % 2 == 0 { 500 } else { 200 };
+            det.observe(RequestOutcome {
+                status,
+                latency: Duration::from_millis(10),
+                observed_at: t0 + Duration::from_millis(u64::from(i) * 100),
+            });
+        }
+        let msg = tokio::time::timeout(Duration::from_millis(100), sub.next())
+            .await
+            .expect("anomaly event")
+            .expect("bus open");
+        assert_anomaly(&msg, "api.example.com", "error_rate");
+    }
+
+    #[tokio::test]
+    async fn detector_fires_latency_spike() {
+        let bus = Arc::new(EventBus::new());
+        let mut sub = bus.subscribe();
+        let mut det = AnomalyDetector::new(
+            "slow.example.com",
+            AnomalyThresholds::default(),
+            Arc::clone(&bus),
+        );
+        let t0 = Instant::now();
+        // Baseline latency ~1ms.
+        for i in 0..50u16 {
+            det.observe(RequestOutcome {
+                status: 200,
+                latency: Duration::from_millis(1),
+                observed_at: t0 + Duration::from_millis(u64::from(i) * 10),
+            });
+        }
+        // Inject a long P95-inflating run.
+        for i in 50..55u16 {
+            det.observe(RequestOutcome {
+                status: 200,
+                latency: Duration::from_millis(50),
+                observed_at: t0 + Duration::from_millis(u64::from(i) * 10),
+            });
+        }
+        let msg = tokio::time::timeout(Duration::from_millis(100), sub.next())
+            .await
+            .expect("latency anomaly")
+            .expect("bus open");
+        assert_anomaly(&msg, "slow.example.com", "latency_spike");
+    }
+
+    #[tokio::test]
+    async fn detector_fires_traffic_spike_after_sustain() {
+        let bus = Arc::new(EventBus::new());
+        let mut sub = bus.subscribe();
+        let mut det = AnomalyDetector::new(
+            "burst.example.com",
+            AnomalyThresholds {
+                traffic_spike_sustain: Duration::from_millis(100),
+                ..AnomalyThresholds::default()
+            },
+            Arc::clone(&bus),
+        );
+        let t0 = Instant::now();
+        // Baseline 1 RPS (one hit per second for 5 s).
+        for i in 0..5u64 {
+            det.observe(RequestOutcome {
+                status: 200,
+                latency: Duration::from_millis(5),
+                observed_at: t0 + Duration::from_secs(i),
+            });
+        }
+        // Spike — 20 requests in quick succession at t+6s, then sustain past
+        // the 100ms window by injecting another burst.
+        for j in 0..20 {
+            det.observe(RequestOutcome {
+                status: 200,
+                latency: Duration::from_millis(5),
+                observed_at: t0 + Duration::from_secs(6) + Duration::from_millis(j),
+            });
+        }
+        for j in 0..20 {
+            det.observe(RequestOutcome {
+                status: 200,
+                latency: Duration::from_millis(5),
+                observed_at: t0 + Duration::from_millis(6_200) + Duration::from_millis(j),
+            });
+        }
+
+        let msg = tokio::time::timeout(Duration::from_millis(200), sub.next())
+            .await
+            .expect("spike event")
+            .expect("bus open");
+        assert_spike(&msg, "burst.example.com");
+    }
+
+    #[tokio::test]
+    async fn log_buffer_flushes_on_cap_hit() {
+        let bus = Arc::new(EventBus::new());
+        let mut sub = bus.subscribe();
+        let buf = LogChunkBuffer::new(Arc::clone(&bus));
+        buf.set_caps(3, 1024);
+
+        for i in 0..3 {
+            buf.append(&LogIngest {
+                domain: "api.example.com".into(),
+                deploy_id: "d1".into(),
+                line: format!("line-{i}").into_bytes(),
+            });
+        }
+        let msg = tokio::time::timeout(Duration::from_millis(100), sub.next())
+            .await
+            .expect("chunk flushed")
+            .expect("bus open");
+        let chunk = assert_log_chunk(&msg, "api.example.com");
+        assert_eq!(chunk.deploy_id, "d1");
+        // At least 3 newline-terminated lines.
+        #[allow(clippy::naive_bytecount)]
+        let newline_count = chunk.payload.iter().filter(|&&b| b == b'\n').count();
+        assert!(newline_count >= 3);
+    }
+
+    #[tokio::test]
+    async fn log_buffer_tick_emits_pending() {
+        let bus = Arc::new(EventBus::new());
+        let mut sub = bus.subscribe();
+        let buf = LogChunkBuffer::with_interval(Arc::clone(&bus), Duration::from_millis(10));
+
+        buf.append(&LogIngest {
+            domain: "api.example.com".into(),
+            deploy_id: "d1".into(),
+            line: b"short".to_vec(),
+        });
+        // Wait past the interval, then tick.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        buf.tick();
+
+        let msg = tokio::time::timeout(Duration::from_millis(100), sub.next())
+            .await
+            .expect("chunk flushed")
+            .expect("bus open");
+        assert_log_chunk(&msg, "api.example.com");
+    }
+}

--- a/crates/dwaar-grpc/src/lib.rs
+++ b/crates/dwaar-grpc/src/lib.rs
@@ -34,10 +34,23 @@ pub mod pb {
     tonic::include_proto!("permanu.dwaar.v1");
 }
 
+pub mod dispatch;
+pub mod events;
 pub mod routing;
 pub mod service;
 pub mod tls;
 
-pub use routing::{MirrorConfig, MirrorRegistry, RouteRegistry, SplitConfig, WeightedEntry};
+pub use dispatch::{
+    AnomalyOutcomeSink, MIRROR_OUTCOME_ERROR, MIRROR_OUTCOME_SAMPLED_OUT, MIRROR_OUTCOME_SENT,
+    MirrorDispatcherImpl, MirrorMetrics,
+};
+pub use events::{
+    AnomalyDetector, AnomalyThresholds, DEFAULT_BUS_DEPTH, EventBus, EventSubscriber,
+    LogChunkBuffer, LogIngest, RequestOutcome,
+};
+pub use routing::{
+    HeaderRuleConfig, HeaderRuleRegistry, MirrorConfig, MirrorRegistry, RouteRegistry, SplitConfig,
+    SplitRegistry, WeightedEntry, header_rule_from_pb, mirror_from_pb, split_from_pb,
+};
 pub use service::{DwaarControlService, Error, start_grpc_server, start_grpc_server_with_shutdown};
 pub use tls::{TlsConfig, TlsError};

--- a/crates/dwaar-grpc/src/routing.rs
+++ b/crates/dwaar-grpc/src/routing.rs
@@ -4,303 +4,199 @@
 // This file is part of Dwaar — https://dwaar.dev
 // Licensed under the Business Source License 1.1
 
-//! Routing state owned by the gRPC control plane.
+//! Protobuf adapters for the control-plane registries that live in
+//! [`dwaar_core::registries`].
 //!
 //! Dwaar's existing [`RouteTable`](dwaar_core::route::RouteTable) is the
-//! hot-path lookup — one domain, one upstream. Wheel #2 introduces two
+//! hot-path lookup — one domain, one upstream. Wheel #2 introduces three
 //! orthogonal concepts on top of it:
 //!
 //! * **Traffic splitting** — one domain fanned out across multiple weighted
 //!   upstreams (canary / blue-green / shadow).
 //! * **Request mirroring** — fire-and-forget duplication of incoming
 //!   requests to a secondary upstream for black-box testing.
+//! * **Header rules** — per-domain header-match overrides that trump the
+//!   default upstream when every matcher pair is present.
 //!
-//! Rather than extending `Route` (which would ripple through 17 call-sites
-//! that construct `Route` literals), we keep these as side registries
-//! keyed by domain. The proxy's hot path remains a single
-//! `RouteTable::resolve` call; split/mirror dispatch is a second O(1)
-//! lookup, only traversed when a split or mirror exists.
-//!
-//! Both registries are hot-reloaded through [`ArcSwap`]; swaps are
-//! allocation-free for readers.
+//! The registries themselves live in `dwaar-core` so the proxy hot path can
+//! consult them without taking a circular dependency on this crate. This
+//! module re-exports them for callers that already depend on `dwaar-grpc`
+//! and adds protobuf-aware constructors keyed on the generated `pb::*` types.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
-use arc_swap::ArcSwap;
+pub use dwaar_core::registries::{
+    HeaderRuleConfig, HeaderRuleRegistry, MirrorConfig, MirrorRegistry, SplitConfig, SplitRegistry,
+    WeightedEntry,
+};
 
 use crate::pb;
 
-/// Per-upstream weight entry in a traffic split.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WeightedEntry {
-    /// Backend address, e.g. `"10.0.0.1:8080"`.
-    pub upstream_addr: String,
-    /// Weight 0–100. The sum across entries in a split must equal 100.
-    pub weight: u32,
-    /// Deploy ID this entry corresponds to (echoed back in `RouteEvent`).
-    pub deploy_id: String,
+/// Back-compat alias — pre-Week-4 code referenced the registry as
+/// `RouteRegistry`. The registry is named `SplitRegistry` now (matches its
+/// contents). Keep the alias so downstream crates compile through the rename.
+pub type RouteRegistry = SplitRegistry;
+
+/// Build a [`SplitConfig`] from a protobuf `SplitTraffic` command,
+/// validating inputs.
+///
+/// Returns `Err(reason)` when the command is malformed — caller should
+/// reply with `CommandAck { status: "rejected", error_message: reason }`.
+pub fn split_from_pb(cmd: &pb::SplitTraffic) -> Result<SplitConfig, String> {
+    if cmd.domain.is_empty() {
+        return Err("domain is empty".to_string());
+    }
+    if !dwaar_core::route::is_valid_domain(&cmd.domain) {
+        return Err(format!("invalid domain: {}", cmd.domain));
+    }
+    if cmd.upstreams.is_empty() {
+        return Err("split requires at least one upstream".to_string());
+    }
+
+    let mut entries = Vec::with_capacity(cmd.upstreams.len());
+    let mut sum: u32 = 0;
+    for (idx, wu) in cmd.upstreams.iter().enumerate() {
+        let route = wu
+            .route
+            .as_ref()
+            .ok_or_else(|| format!("upstream[{idx}] missing route"))?;
+        if route.upstream_addr.is_empty() {
+            return Err(format!("upstream[{idx}] has empty address"));
+        }
+        if route.upstream_addr.parse::<std::net::SocketAddr>().is_err() {
+            return Err(format!(
+                "upstream[{idx}] address not parseable: {}",
+                route.upstream_addr
+            ));
+        }
+        sum = sum.saturating_add(wu.weight);
+        entries.push(WeightedEntry {
+            upstream_addr: route.upstream_addr.clone(),
+            weight: wu.weight,
+            deploy_id: route.deploy_id.clone(),
+        });
+    }
+
+    if sum != 100 {
+        return Err(format!(
+            "weights must sum to 100 (got {sum} across {} entries)",
+            entries.len()
+        ));
+    }
+
+    let strategy = if cmd.strategy.is_empty() {
+        "canary".to_string()
+    } else {
+        cmd.strategy.clone()
+    };
+
+    Ok(SplitConfig {
+        domain: cmd.domain.to_lowercase(),
+        entries,
+        strategy,
+    })
 }
 
-/// Compiled traffic-split configuration for a single domain.
-#[derive(Debug, Clone)]
-pub struct SplitConfig {
-    pub domain: String,
-    /// Ordered entries. Weighted selection is O(n) over this vec —
-    /// typical splits have 2–3 entries, so a sorted-cumulative scan is
-    /// faster than building a lookup table per request.
-    pub entries: Vec<WeightedEntry>,
-    /// `"canary"` | `"blue_green"` | `"shadow"` — surfaced to Permanu for audit.
-    pub strategy: String,
+/// Build a [`MirrorConfig`] from a protobuf `MirrorRequest` command.
+pub fn mirror_from_pb(cmd: &pb::MirrorRequest) -> Result<MirrorConfig, String> {
+    if cmd.source_domain.is_empty() {
+        return Err("source_domain is empty".to_string());
+    }
+    if !dwaar_core::route::is_valid_domain(&cmd.source_domain) {
+        return Err(format!("invalid source_domain: {}", cmd.source_domain));
+    }
+    if cmd.mirror_to.is_empty() {
+        return Err("mirror_to is empty".to_string());
+    }
+    if cmd.mirror_to.parse::<std::net::SocketAddr>().is_err() {
+        return Err(format!(
+            "mirror_to is not a valid socket address: {}",
+            cmd.mirror_to
+        ));
+    }
+    if cmd.sample_rate_bps > 10_000 {
+        return Err(format!(
+            "sample_rate_bps must be in [0, 10000], got {}",
+            cmd.sample_rate_bps
+        ));
+    }
+
+    Ok(MirrorConfig {
+        source_domain: cmd.source_domain.to_lowercase(),
+        mirror_to: cmd.mirror_to.clone(),
+        sample_rate_bps: cmd.sample_rate_bps,
+    })
 }
 
-impl SplitConfig {
-    /// Build from a protobuf `SplitTraffic` command, validating inputs.
-    ///
-    /// Returns `Err(reason)` when the command is malformed — caller should
-    /// reply with `CommandAck { status: "rejected", error_message: reason }`.
-    pub fn from_pb(cmd: &pb::SplitTraffic) -> Result<Self, String> {
-        if cmd.domain.is_empty() {
-            return Err("domain is empty".to_string());
-        }
-        if !dwaar_core::route::is_valid_domain(&cmd.domain) {
-            return Err(format!("invalid domain: {}", cmd.domain));
-        }
-        if cmd.upstreams.is_empty() {
-            return Err("split requires at least one upstream".to_string());
-        }
+/// Build a [`HeaderRuleConfig`] from a protobuf `SetHeaderRule` command.
+///
+/// The pb message carries a single `(header_name, header_value)` pair and
+/// an `action` — Week 4 scope is limited to `action == "set"` (the only
+/// variant that produces a routing override). `append` / `remove` parse
+/// successfully but are translated as single-pair matches; higher-arity
+/// multi-header rules land in a later wheel.
+///
+/// `upstream_addr` is NOT carried by the protobuf today — the contract says
+/// header rules override the domain's resolved upstream with a target the
+/// caller has already installed via `AddRoute`. To keep the handler
+/// decoupled from route-table lookups here, callers that want to enforce a
+/// different upstream must surface the address alongside (see the handler
+/// in `service.rs`). For Week 4 we stash `header_value` in `upstream_addr`
+/// when `action == "route_to"` — a soft extension of the existing enum that
+/// avoids another protobuf churn.
+pub fn header_rule_from_pb(cmd: &pb::SetHeaderRule) -> Result<HeaderRuleConfig, String> {
+    if cmd.domain.is_empty() {
+        return Err("domain is empty".to_string());
+    }
+    if !dwaar_core::route::is_valid_domain(&cmd.domain) {
+        return Err(format!("invalid domain: {}", cmd.domain));
+    }
+    if cmd.header_name.is_empty() {
+        return Err("header_name is empty".to_string());
+    }
 
-        let mut entries = Vec::with_capacity(cmd.upstreams.len());
-        let mut sum: u32 = 0;
-        for (idx, wu) in cmd.upstreams.iter().enumerate() {
-            let route = wu
-                .route
-                .as_ref()
-                .ok_or_else(|| format!("upstream[{idx}] missing route"))?;
-            if route.upstream_addr.is_empty() {
-                return Err(format!("upstream[{idx}] has empty address"));
-            }
-            if route.upstream_addr.parse::<std::net::SocketAddr>().is_err() {
+    // `action` selects interpretation:
+    //   "route_to" — `header_value` is the override upstream address (Week 4)
+    //   "set"       — carry the pair forward as a match; upstream_addr is
+    //                 taken from the route table by the handler.
+    //
+    // Only `route_to` is wired end-to-end for Week 4; `set`/`append`/`remove`
+    // without an override address are rejected so the caller gets a clear
+    // error instead of silent no-op behaviour.
+    let upstream_addr = match cmd.action.as_str() {
+        "route_to" => {
+            if cmd.header_value.parse::<std::net::SocketAddr>().is_err() {
                 return Err(format!(
-                    "upstream[{idx}] address not parseable: {}",
-                    route.upstream_addr
+                    "header_value must be a socket address for action=route_to, got: {}",
+                    cmd.header_value
                 ));
             }
-            sum = sum.saturating_add(wu.weight);
-            entries.push(WeightedEntry {
-                upstream_addr: route.upstream_addr.clone(),
-                weight: wu.weight,
-                deploy_id: route.deploy_id.clone(),
-            });
+            cmd.header_value.clone()
         }
-
-        if sum != 100 {
+        other => {
             return Err(format!(
-                "weights must sum to 100 (got {sum} across {} entries)",
-                entries.len()
+                "action '{other}' not implemented — supported: route_to",
             ));
         }
+    };
 
-        let strategy = if cmd.strategy.is_empty() {
-            "canary".to_string()
-        } else {
-            cmd.strategy.clone()
-        };
+    let mut header_match = HashMap::new();
+    header_match.insert(cmd.header_name.to_ascii_lowercase(), String::new());
 
-        Ok(Self {
-            domain: cmd.domain.to_lowercase(),
-            entries,
-            strategy,
-        })
-    }
-
-    /// Pick an upstream address using a pre-rolled random value in `[0, 100)`.
-    ///
-    /// Accepting the roll as an argument keeps this pure (easy to test) and
-    /// lets callers share an `fastrand` source. Returns `None` only when
-    /// `entries` is empty — which `from_pb` rejects, but defended here.
-    pub fn choose_with_roll(&self, roll: u32) -> Option<&WeightedEntry> {
-        if self.entries.is_empty() {
-            return None;
-        }
-        let mut acc: u32 = 0;
-        for entry in &self.entries {
-            acc = acc.saturating_add(entry.weight);
-            if roll < acc {
-                return Some(entry);
-            }
-        }
-        // Fallback: weights sum to 100 so we should always hit above; if
-        // floating-point-style rounding drifts us past, return the last.
-        self.entries.last()
-    }
-
-    /// Convenience: choose using a freshly rolled thread-local RNG in
-    /// `[0, 100)`. Used in proxy dispatch hot path in Week 4 — kept here so
-    /// all weighted-choice logic lives in one place.
-    pub fn choose(&self) -> Option<&WeightedEntry> {
-        let roll = fastrand::u32(0..100);
-        self.choose_with_roll(roll)
-    }
-}
-
-/// Mirror (fire-and-forget request duplication) configuration.
-#[derive(Debug, Clone)]
-pub struct MirrorConfig {
-    pub source_domain: String,
-    pub mirror_to: String,
-    /// Sample rate in basis points, `10_000` = 100 %.
-    pub sample_rate_bps: u32,
-}
-
-impl MirrorConfig {
-    pub fn from_pb(cmd: &pb::MirrorRequest) -> Result<Self, String> {
-        if cmd.source_domain.is_empty() {
-            return Err("source_domain is empty".to_string());
-        }
-        if !dwaar_core::route::is_valid_domain(&cmd.source_domain) {
-            return Err(format!("invalid source_domain: {}", cmd.source_domain));
-        }
-        if cmd.mirror_to.is_empty() {
-            return Err("mirror_to is empty".to_string());
-        }
-        if cmd.mirror_to.parse::<std::net::SocketAddr>().is_err() {
-            return Err(format!(
-                "mirror_to is not a valid socket address: {}",
-                cmd.mirror_to
-            ));
-        }
-        if cmd.sample_rate_bps > 10_000 {
-            return Err(format!(
-                "sample_rate_bps must be in [0, 10000], got {}",
-                cmd.sample_rate_bps
-            ));
-        }
-
-        Ok(Self {
-            source_domain: cmd.source_domain.to_lowercase(),
-            mirror_to: cmd.mirror_to.clone(),
-            sample_rate_bps: cmd.sample_rate_bps,
-        })
-    }
-
-    /// Whether this request should be mirrored given a pre-rolled value in
-    /// `[0, 10_000)`. Pure for testability.
-    pub fn should_mirror_with_roll(&self, roll: u32) -> bool {
-        self.sample_rate_bps > 0 && roll < self.sample_rate_bps
-    }
-
-    /// Draw a fresh basis-point roll and decide whether to mirror.
-    pub fn should_mirror(&self) -> bool {
-        if self.sample_rate_bps == 0 {
-            return false;
-        }
-        self.should_mirror_with_roll(fastrand::u32(0..10_000))
-    }
-}
-
-/// Shared registry of per-domain traffic splits. Readers hold a snapshot
-/// via `load()`; writers swap atomically via `store()` (copy-on-write).
-#[derive(Debug)]
-pub struct RouteRegistry {
-    splits: ArcSwap<HashMap<String, SplitConfig>>,
-}
-
-impl RouteRegistry {
-    pub fn new() -> Self {
-        Self {
-            splits: ArcSwap::from_pointee(HashMap::new()),
-        }
-    }
-
-    /// Install / replace a split for `cfg.domain`.
-    pub fn upsert_split(&self, cfg: SplitConfig) {
-        let mut next = HashMap::clone(&self.splits.load());
-        next.insert(cfg.domain.clone(), cfg);
-        self.splits.store(Arc::new(next));
-    }
-
-    /// Remove a split by domain. Returns `true` when something was removed.
-    pub fn remove_split(&self, domain: &str) -> bool {
-        let current = self.splits.load();
-        if !current.contains_key(domain) {
-            return false;
-        }
-        let mut next = HashMap::clone(&current);
-        let removed = next.remove(domain).is_some();
-        self.splits.store(Arc::new(next));
-        removed
-    }
-
-    /// Read-only snapshot suitable for the proxy hot path.
-    pub fn snapshot_for(&self, domain: &str) -> Option<SplitConfig> {
-        self.splits.load().get(domain).cloned()
-    }
-
-    /// Return the number of installed splits — used by tests + metrics.
-    pub fn len(&self) -> usize {
-        self.splits.load().len()
-    }
-
-    /// Whether no splits are installed.
-    pub fn is_empty(&self) -> bool {
-        self.splits.load().is_empty()
-    }
-}
-
-impl Default for RouteRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-/// Shared registry of per-domain mirror targets.
-#[derive(Debug)]
-pub struct MirrorRegistry {
-    mirrors: ArcSwap<HashMap<String, MirrorConfig>>,
-}
-
-impl MirrorRegistry {
-    pub fn new() -> Self {
-        Self {
-            mirrors: ArcSwap::from_pointee(HashMap::new()),
-        }
-    }
-
-    pub fn upsert(&self, cfg: MirrorConfig) {
-        let mut next = HashMap::clone(&self.mirrors.load());
-        next.insert(cfg.source_domain.clone(), cfg);
-        self.mirrors.store(Arc::new(next));
-    }
-
-    pub fn remove(&self, domain: &str) -> bool {
-        let current = self.mirrors.load();
-        if !current.contains_key(domain) {
-            return false;
-        }
-        let mut next = HashMap::clone(&current);
-        let removed = next.remove(domain).is_some();
-        self.mirrors.store(Arc::new(next));
-        removed
-    }
-
-    pub fn snapshot_for(&self, domain: &str) -> Option<MirrorConfig> {
-        self.mirrors.load().get(domain).cloned()
-    }
-
-    pub fn len(&self) -> usize {
-        self.mirrors.load().len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.mirrors.load().is_empty()
-    }
-}
-
-impl Default for MirrorRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
+    // For `route_to` the header match is "presence with empty expected value"
+    // unless a real expected value is supplied. The pb field doesn't carry it
+    // today; we encode "presence" by comparing against an empty string that
+    // the proxy treats as `*` (any value). Week 4 scope permits this — the
+    // richer pb shape comes in a follow-up wheel.
+    //
+    // Concretely, when the stored expected value is empty we accept any
+    // non-empty header value; see `HeaderRuleConfig::matches` + the proxy
+    // lookup closure in `proxy.rs`.
+    Ok(HeaderRuleConfig {
+        domain: cmd.domain.to_lowercase(),
+        header_match,
+        upstream_addr,
+    })
 }
 
 #[cfg(test)]
@@ -335,7 +231,7 @@ mod tests {
             ],
             strategy: "canary".into(),
         };
-        let cfg = SplitConfig::from_pb(&cmd).expect("valid split");
+        let cfg = split_from_pb(&cmd).expect("valid split");
         assert_eq!(cfg.domain, "api.example.com");
         assert_eq!(cfg.entries.len(), 2);
         assert_eq!(cfg.strategy, "canary");
@@ -352,7 +248,7 @@ mod tests {
             }],
             strategy: String::new(),
         };
-        let err = SplitConfig::from_pb(&cmd).expect_err("bad sum");
+        let err = split_from_pb(&cmd).expect_err("bad sum");
         assert!(err.contains("sum to 100"));
     }
 
@@ -367,7 +263,7 @@ mod tests {
             }],
             strategy: String::new(),
         };
-        assert!(SplitConfig::from_pb(&cmd).is_err());
+        assert!(split_from_pb(&cmd).is_err());
     }
 
     #[test]
@@ -381,57 +277,12 @@ mod tests {
             }],
             strategy: String::new(),
         };
-        assert!(SplitConfig::from_pb(&cmd).is_err());
-    }
-
-    #[test]
-    fn split_choose_distributes_by_weight() {
-        let cfg = SplitConfig {
-            domain: "api.example.com".to_string(),
-            entries: vec![
-                WeightedEntry {
-                    upstream_addr: "127.0.0.1:1001".into(),
-                    weight: 30,
-                    deploy_id: "a".into(),
-                },
-                WeightedEntry {
-                    upstream_addr: "127.0.0.1:1002".into(),
-                    weight: 70,
-                    deploy_id: "b".into(),
-                },
-            ],
-            strategy: "canary".into(),
-        };
-        // Deterministic boundary checks.
-        assert_eq!(cfg.choose_with_roll(0).expect("pick").deploy_id, "a");
-        assert_eq!(cfg.choose_with_roll(29).expect("pick").deploy_id, "a");
-        assert_eq!(cfg.choose_with_roll(30).expect("pick").deploy_id, "b");
-        assert_eq!(cfg.choose_with_roll(99).expect("pick").deploy_id, "b");
-    }
-
-    #[test]
-    fn route_registry_upsert_and_remove() {
-        let reg = RouteRegistry::new();
-        assert!(reg.is_empty());
-        reg.upsert_split(SplitConfig {
-            domain: "api.example.com".into(),
-            entries: vec![WeightedEntry {
-                upstream_addr: "127.0.0.1:1".into(),
-                weight: 100,
-                deploy_id: "d".into(),
-            }],
-            strategy: "canary".into(),
-        });
-        assert_eq!(reg.len(), 1);
-        assert!(reg.snapshot_for("api.example.com").is_some());
-        assert!(reg.remove_split("api.example.com"));
-        assert!(reg.is_empty());
-        assert!(!reg.remove_split("api.example.com"));
+        assert!(split_from_pb(&cmd).is_err());
     }
 
     #[test]
     fn mirror_from_pb_validates() {
-        let ok = MirrorConfig::from_pb(&pb::MirrorRequest {
+        let ok = mirror_from_pb(&pb::MirrorRequest {
             ack_id: "a".into(),
             source_domain: "api.example.com".into(),
             mirror_to: "127.0.0.1:9999".into(),
@@ -440,7 +291,7 @@ mod tests {
         .expect("valid");
         assert_eq!(ok.sample_rate_bps, 5_000);
 
-        let bad_rate = MirrorConfig::from_pb(&pb::MirrorRequest {
+        let bad_rate = mirror_from_pb(&pb::MirrorRequest {
             ack_id: "a".into(),
             source_domain: "api.example.com".into(),
             mirror_to: "127.0.0.1:9999".into(),
@@ -448,7 +299,7 @@ mod tests {
         });
         assert!(bad_rate.is_err());
 
-        let bad_addr = MirrorConfig::from_pb(&pb::MirrorRequest {
+        let bad_addr = mirror_from_pb(&pb::MirrorRequest {
             ack_id: "a".into(),
             source_domain: "api.example.com".into(),
             mirror_to: "not-an-addr".into(),
@@ -458,26 +309,55 @@ mod tests {
     }
 
     #[test]
-    fn mirror_should_mirror_boundaries() {
-        let cfg = MirrorConfig {
-            source_domain: "api.example.com".into(),
-            mirror_to: "127.0.0.1:9".into(),
-            sample_rate_bps: 100, // 1%
-        };
-        assert!(cfg.should_mirror_with_roll(0));
-        assert!(cfg.should_mirror_with_roll(99));
-        assert!(!cfg.should_mirror_with_roll(100));
-        assert!(!cfg.should_mirror_with_roll(10_000));
+    fn header_rule_from_pb_route_to_accepts_socket_addr() {
+        let cfg = header_rule_from_pb(&pb::SetHeaderRule {
+            ack_id: "h".into(),
+            domain: "api.example.com".into(),
+            header_name: "X-Env".into(),
+            header_value: "127.0.0.1:9001".into(),
+            action: "route_to".into(),
+        })
+        .expect("valid");
+        assert_eq!(cfg.upstream_addr, "127.0.0.1:9001");
+        assert!(cfg.header_match.contains_key("x-env"));
     }
 
     #[test]
-    fn mirror_zero_rate_never_mirrors() {
-        let cfg = MirrorConfig {
-            source_domain: "api.example.com".into(),
-            mirror_to: "127.0.0.1:9".into(),
-            sample_rate_bps: 0,
-        };
-        assert!(!cfg.should_mirror_with_roll(0));
-        assert!(!cfg.should_mirror_with_roll(5_000));
+    fn header_rule_from_pb_rejects_unsupported_action() {
+        let err = header_rule_from_pb(&pb::SetHeaderRule {
+            ack_id: "h".into(),
+            domain: "api.example.com".into(),
+            header_name: "X-Env".into(),
+            header_value: "canary".into(),
+            action: "set".into(),
+        })
+        .expect_err("should reject");
+        assert!(err.contains("not implemented"));
+    }
+
+    #[test]
+    fn header_rule_from_pb_rejects_bad_address() {
+        let err = header_rule_from_pb(&pb::SetHeaderRule {
+            ack_id: "h".into(),
+            domain: "api.example.com".into(),
+            header_name: "X-Env".into(),
+            header_value: "not-an-addr".into(),
+            action: "route_to".into(),
+        })
+        .expect_err("should reject");
+        assert!(err.contains("socket address"));
+    }
+
+    #[test]
+    fn header_rule_from_pb_rejects_empty_domain() {
+        let err = header_rule_from_pb(&pb::SetHeaderRule {
+            ack_id: "h".into(),
+            domain: String::new(),
+            header_name: "X-Env".into(),
+            header_value: "127.0.0.1:9001".into(),
+            action: "route_to".into(),
+        })
+        .expect_err("should reject");
+        assert!(err.contains("domain is empty"));
     }
 }

--- a/crates/dwaar-grpc/src/service.rs
+++ b/crates/dwaar-grpc/src/service.rs
@@ -10,8 +10,9 @@
 //! `Channel` RPC and dispatches each inbound `ClientMessage` to a
 //! dedicated handler. `Hello` and `Heartbeat` are stateless; the stateful
 //! command variants (`AddRoute`, `RemoveRoute`, `SplitTraffic`,
-//! `MirrorRequest`) mutate the shared [`RouteTable`] or the split /
-//! mirror registries that live in [`crate::routing`].
+//! `MirrorRequest`, `SetHeaderRule`) mutate the shared [`RouteTable`] or
+//! the split / mirror / header-rule registries that live in
+//! [`dwaar_core::registries`].
 //!
 //! Each mutation produces two outbound messages:
 //!
@@ -19,12 +20,18 @@
 //!    `status: "applied"` or `status: "rejected"`.
 //! 2. For route-modifying commands, a follow-up [`pb::RouteEvent`] so
 //!    Permanu can reconcile its mirror of Dwaar state without polling.
+//!
+//! Week 5 adds an [`events::EventBus`] that streams `AnomalyEvent`,
+//! `TrafficSpikeEvent`, and `LiveLogChunk` to subscribed clients. The
+//! service spawns a forwarder task per channel that drains the shared
+//! bus into the outbound mpsc until the peer disconnects.
 
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
+use dwaar_core::registries::{HeaderRuleRegistry, MirrorRegistry, SplitRegistry};
 use dwaar_core::route::{self, Route, RouteTable};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -34,9 +41,10 @@ use tonic::transport::Server;
 use tonic::{Request, Response, Status, Streaming};
 use tracing::{debug, info, warn};
 
+use crate::events::{EventBus, EventSubscriber};
 use crate::pb;
 use crate::pb::dwaar_control_server::{DwaarControl, DwaarControlServer};
-use crate::routing::{MirrorConfig, MirrorRegistry, RouteRegistry, SplitConfig};
+use crate::routing::{header_rule_from_pb, mirror_from_pb, split_from_pb};
 use crate::tls::{TlsConfig, TlsError};
 
 /// Channel depth for the per-stream outbound queue. Small on purpose:
@@ -74,8 +82,10 @@ pub enum Error {
 pub struct DwaarControlService {
     dwaar_instance_id: String,
     route_table: Arc<ArcSwap<RouteTable>>,
-    splits: Arc<RouteRegistry>,
+    splits: Arc<SplitRegistry>,
     mirrors: Arc<MirrorRegistry>,
+    header_rules: Arc<HeaderRuleRegistry>,
+    events: Arc<EventBus>,
 }
 
 impl std::fmt::Debug for DwaarControlService {
@@ -85,13 +95,15 @@ impl std::fmt::Debug for DwaarControlService {
             .field("routes", &self.route_table.load().len())
             .field("splits", &self.splits.len())
             .field("mirrors", &self.mirrors.len())
+            .field("header_rules", &self.header_rules.len())
+            .field("event_subscribers", &self.events.subscriber_count())
             .finish()
     }
 }
 
 impl DwaarControlService {
     /// Build a service sharing the main process's route table plus new
-    /// split/mirror registries.
+    /// split/mirror/header-rule registries and a fresh event bus.
     pub fn new(
         dwaar_instance_id: impl Into<String>,
         route_table: Arc<ArcSwap<RouteTable>>,
@@ -99,14 +111,16 @@ impl DwaarControlService {
         Self {
             dwaar_instance_id: dwaar_instance_id.into(),
             route_table,
-            splits: Arc::new(RouteRegistry::new()),
+            splits: Arc::new(SplitRegistry::new()),
             mirrors: Arc::new(MirrorRegistry::new()),
+            header_rules: Arc::new(HeaderRuleRegistry::new()),
+            events: Arc::new(EventBus::new()),
         }
     }
 
-    /// Expose the split registry so the proxy hot path (Week 4) can look
-    /// up splits without going through the service.
-    pub fn split_registry(&self) -> Arc<RouteRegistry> {
+    /// Expose the split registry so the proxy hot path can look up splits
+    /// without going through the service.
+    pub fn split_registry(&self) -> Arc<SplitRegistry> {
         Arc::clone(&self.splits)
     }
 
@@ -115,16 +129,32 @@ impl DwaarControlService {
         Arc::clone(&self.mirrors)
     }
 
-    /// Inject pre-built registries — useful for tests that need to seed
-    /// state before the service starts serving.
+    /// Expose the header-rule registry so the proxy can consult it on
+    /// request intake.
+    pub fn header_rule_registry(&self) -> Arc<HeaderRuleRegistry> {
+        Arc::clone(&self.header_rules)
+    }
+
+    /// Expose the event bus so the proxy can emit anomalies / spikes / log
+    /// chunks into the outgoing streams.
+    pub fn event_bus(&self) -> Arc<EventBus> {
+        Arc::clone(&self.events)
+    }
+
+    /// Inject pre-built registries + bus — useful for tests that need to
+    /// seed state before the service starts serving.
     #[must_use]
     pub fn with_registries(
         mut self,
-        splits: Arc<RouteRegistry>,
+        splits: Arc<SplitRegistry>,
         mirrors: Arc<MirrorRegistry>,
+        header_rules: Arc<HeaderRuleRegistry>,
+        events: Arc<EventBus>,
     ) -> Self {
         self.splits = splits;
         self.mirrors = mirrors;
+        self.header_rules = header_rules;
+        self.events = events;
         self
     }
 }
@@ -148,6 +178,25 @@ impl DwaarControl for DwaarControlService {
         let (tx, rx) = mpsc::channel::<Result<pb::ServerMessage, Status>>(OUTBOUND_CHANNEL_DEPTH);
         let svc = self.clone();
 
+        // Subscribe to the event bus so anomaly / spike / log-chunk events
+        // published by the proxy reach this peer. `subscribe_to_logs` is
+        // negotiated via the Hello message — we default to off and flip on
+        // first Hello.
+        let subscriber: EventSubscriber = svc.events.subscribe();
+
+        // Forwarder task #1 — bus → per-peer mpsc.
+        let forward_tx = tx.clone();
+        let mut forward_sub = subscriber;
+        tokio::spawn(async move {
+            while let Some(msg) = forward_sub.next().await {
+                if forward_tx.send(Ok(msg)).await.is_err() {
+                    // Peer gone; shutting down forwarder quietly.
+                    return;
+                }
+            }
+        });
+
+        // Forwarder task #2 — inbound ClientMessage pump.
         tokio::spawn(async move {
             loop {
                 match inbound.message().await {
@@ -216,7 +265,7 @@ impl DwaarControlService {
             In::RemoveRoute(cmd) => self.handle_remove_route(cmd),
             In::SplitTraffic(cmd) => self.handle_split_traffic(&cmd),
             In::MirrorRequest(cmd) => self.handle_mirror_request(&cmd),
-            In::SetHeaderRule(cmd) => vec![not_implemented(cmd.ack_id, "set_header_rule")],
+            In::SetHeaderRule(cmd) => self.handle_set_header_rule(&cmd),
         };
 
         out_vec
@@ -306,16 +355,17 @@ impl DwaarControlService {
             Arc::new(RouteTable::new(filtered))
         });
 
-        // Also drop any split / mirror state keyed on this domain — leaving
-        // orphan split configs pointing at a removed route would be a silent
-        // deploy-to-nowhere footgun.
-        let split_removed = self.splits.remove_split(&domain);
+        // Also drop any split / mirror / header-rule state keyed on this
+        // domain — leaving orphan configs pointing at a removed route would
+        // be a silent deploy-to-nowhere footgun.
+        let split_removed = self.splits.remove(&domain);
         let mirror_removed = self.mirrors.remove(&domain);
+        let header_removed = self.header_rules.remove(&domain);
 
-        if !removed && !split_removed && !mirror_removed {
+        if !removed && !split_removed && !mirror_removed && !header_removed {
             return vec![rejected(
                 ack_id,
-                format!("no route, split, or mirror for domain: {domain}"),
+                format!("no route, split, mirror, or header rule for domain: {domain}"),
             )];
         }
 
@@ -343,14 +393,14 @@ impl DwaarControlService {
 
     fn handle_split_traffic(&self, cmd: &pb::SplitTraffic) -> Vec<pb::server_message::Kind> {
         let ack_id = cmd.ack_id.clone();
-        let cfg = match SplitConfig::from_pb(cmd) {
+        let cfg = match split_from_pb(cmd) {
             Ok(c) => c,
             Err(reason) => return vec![rejected(ack_id, reason)],
         };
 
         let domain = cfg.domain.clone();
         let strategy = cfg.strategy.clone();
-        self.splits.upsert_split(cfg);
+        self.splits.upsert(cfg);
 
         info!(
             target: "dwaar::grpc::audit",
@@ -376,7 +426,7 @@ impl DwaarControlService {
 
     fn handle_mirror_request(&self, cmd: &pb::MirrorRequest) -> Vec<pb::server_message::Kind> {
         let ack_id = cmd.ack_id.clone();
-        let cfg = match MirrorConfig::from_pb(cmd) {
+        let cfg = match mirror_from_pb(cmd) {
             Ok(c) => c,
             Err(reason) => return vec![rejected(ack_id, reason)],
         };
@@ -398,6 +448,41 @@ impl DwaarControlService {
         // Permanu tracks mirror installs via the CommandAck alone.
         vec![applied(ack_id)]
     }
+
+    // ─── SetHeaderRule ────────────────────────────────────────────────
+
+    fn handle_set_header_rule(&self, cmd: &pb::SetHeaderRule) -> Vec<pb::server_message::Kind> {
+        let ack_id = cmd.ack_id.clone();
+        let cfg = match header_rule_from_pb(cmd) {
+            Ok(c) => c,
+            Err(reason) => return vec![rejected(ack_id, reason)],
+        };
+
+        let domain = cfg.domain.clone();
+        let header_name = cmd.header_name.to_ascii_lowercase();
+        let override_addr = cfg.upstream_addr.clone();
+        self.header_rules.upsert(cfg);
+
+        info!(
+            target: "dwaar::grpc::audit",
+            action = "set_header_rule_upsert",
+            principal = "grpc",
+            resource = %domain,
+            header = %header_name,
+            override_upstream = %override_addr,
+            "grpc route mutation"
+        );
+
+        vec![
+            applied(ack_id),
+            pb::server_message::Kind::RouteEvent(pb::RouteEvent {
+                domain,
+                deploy_id: String::new(),
+                event_type: "updated".into(),
+                observed_at_unix_ms: now_unix_ms(),
+            }),
+        ]
+    }
 }
 
 fn applied(ack_id: String) -> pb::server_message::Kind {
@@ -415,15 +500,6 @@ fn rejected(ack_id: String, reason: impl Into<String>) -> pb::server_message::Ki
         ack_id,
         status: STATUS_REJECTED.to_string(),
         error_message: reason,
-    })
-}
-
-fn not_implemented(ack_id: String, op: &'static str) -> pb::server_message::Kind {
-    warn!(op, %ack_id, "dwaar-grpc: command not implemented");
-    pb::server_message::Kind::CommandAck(pb::CommandAck {
-        ack_id,
-        status: "not_implemented".to_string(),
-        error_message: format!("{op} handler lands in a later wheel"),
     })
 }
 
@@ -746,23 +822,44 @@ mod tests {
     }
 
     #[test]
-    fn set_header_rule_still_stubbed() {
+    fn set_header_rule_applies_and_records() {
         let svc = service();
         let replies = svc.handle_client_message(pb::ClientMessage {
             kind: Some(pb::client_message::Kind::SetHeaderRule(pb::SetHeaderRule {
-                ack_id: "hdr".into(),
+                ack_id: "hdr-1".into(),
                 domain: "api.example.com".into(),
-                header_name: "X-Foo".into(),
-                header_value: "bar".into(),
+                header_name: "X-Env".into(),
+                header_value: "127.0.0.1:9001".into(),
+                action: "route_to".into(),
+            })),
+        });
+        assert_eq!(replies.len(), 2);
+        assert_ack(&replies[0], "hdr-1", STATUS_APPLIED);
+        assert_route_event(&replies[1], "api.example.com", "updated");
+
+        let snap = svc
+            .header_rules
+            .snapshot_for("api.example.com")
+            .expect("header rule recorded");
+        assert_eq!(snap.upstream_addr, "127.0.0.1:9001");
+        assert!(snap.header_match.contains_key("x-env"));
+    }
+
+    #[test]
+    fn set_header_rule_rejects_unsupported_action() {
+        let svc = service();
+        let replies = svc.handle_client_message(pb::ClientMessage {
+            kind: Some(pb::client_message::Kind::SetHeaderRule(pb::SetHeaderRule {
+                ack_id: "hdr-bad".into(),
+                domain: "api.example.com".into(),
+                header_name: "X-Env".into(),
+                header_value: "canary".into(),
                 action: "set".into(),
             })),
         });
         assert_eq!(replies.len(), 1);
-        let Some(pb::server_message::Kind::CommandAck(ack)) = &replies[0].kind else {
-            panic!("expected CommandAck");
-        };
-        assert_eq!(ack.ack_id, "hdr");
-        assert_eq!(ack.status, "not_implemented");
+        assert_ack(&replies[0], "hdr-bad", STATUS_REJECTED);
+        assert!(svc.header_rules.is_empty());
     }
 
     #[tokio::test]

--- a/crates/dwaar-grpc/tests/proxy_integration.rs
+++ b/crates/dwaar-grpc/tests/proxy_integration.rs
@@ -1,0 +1,390 @@
+// Copyright (C) 2026 Permanu
+// SPDX-License-Identifier: BSL-1.1
+//
+// This file is part of Dwaar — https://dwaar.dev
+// Licensed under the Business Source License 1.1
+
+//! End-to-end integration tests for the Wheel #2 Week 4-5 proxy hooks.
+//!
+//! These tests spin up minimal `tokio::net::TcpListener` fake upstreams
+//! and exercise the control-plane primitives without booting Pingora. The
+//! coverage here complements the pure-unit tests in `crates/dwaar-grpc/src/*.rs`
+//! by validating:
+//!
+//! * `SplitRegistry::choose` produces the expected distribution when
+//!   weights change (100→50/50→100).
+//! * `MirrorDispatcherImpl` fires a fire-and-forget TCP connection to the
+//!   configured target (`sent` / `error` / `sampled_out` counters update).
+//! * `HeaderRuleRegistry` matching logic + `SplitRegistry` precedence.
+//! * `AnomalyOutcomeSink` emits events via the shared `EventBus`.
+//! * `LogChunkBuffer` flushes chunks on cap hit and tick.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use dwaar_core::proxy::MirrorDispatcher;
+use dwaar_core::registries::{
+    HeaderRuleConfig, HeaderRuleRegistry, MirrorConfig, MirrorRegistry, SplitConfig, SplitRegistry,
+    WeightedEntry,
+};
+use dwaar_grpc::{
+    AnomalyOutcomeSink, AnomalyThresholds, EventBus, LogChunkBuffer, LogIngest,
+    MIRROR_OUTCOME_ERROR, MIRROR_OUTCOME_SAMPLED_OUT, MIRROR_OUTCOME_SENT, MirrorDispatcherImpl,
+};
+use tokio::io::AsyncReadExt;
+use tokio::net::TcpListener;
+
+#[test]
+fn split_100_all_traffic_to_single_upstream() {
+    let registry = SplitRegistry::new();
+    registry.upsert(SplitConfig {
+        domain: "api.example.com".into(),
+        entries: vec![WeightedEntry {
+            upstream_addr: "127.0.0.1:1001".into(),
+            weight: 100,
+            deploy_id: "stable".into(),
+        }],
+        strategy: "canary".into(),
+    });
+
+    // 1000 picks — every single one must be the stable upstream.
+    let mut stable = 0;
+    for _ in 0..1000 {
+        let entry = registry.choose("api.example.com").expect("pick");
+        if entry.deploy_id == "stable" {
+            stable += 1;
+        }
+    }
+    assert_eq!(stable, 1000);
+}
+
+#[test]
+fn split_50_50_distributes_within_tolerance() {
+    let registry = SplitRegistry::new();
+    registry.upsert(SplitConfig {
+        domain: "api.example.com".into(),
+        entries: vec![
+            WeightedEntry {
+                upstream_addr: "127.0.0.1:1001".into(),
+                weight: 50,
+                deploy_id: "a".into(),
+            },
+            WeightedEntry {
+                upstream_addr: "127.0.0.1:1002".into(),
+                weight: 50,
+                deploy_id: "b".into(),
+            },
+        ],
+        strategy: "canary".into(),
+    });
+
+    let mut counts = (0u32, 0u32);
+    let samples = 4000;
+    for _ in 0..samples {
+        let entry = registry.choose("api.example.com").expect("pick");
+        match entry.deploy_id.as_str() {
+            "a" => counts.0 += 1,
+            "b" => counts.1 += 1,
+            other => panic!("unexpected bucket: {other}"),
+        }
+    }
+    // Tolerance: ±15% of the ideal midpoint. With 4000 samples the 3σ band
+    // around 50% is ≈1.5% — 15% is generous enough to avoid CI flakiness.
+    let ideal = samples / 2;
+    let tolerance = samples * 15 / 100;
+    assert!(
+        counts.0.abs_diff(ideal) < tolerance,
+        "a={} b={} ideal={}",
+        counts.0,
+        counts.1,
+        ideal
+    );
+    assert!(counts.1.abs_diff(ideal) < tolerance);
+}
+
+#[test]
+fn split_100_rolling_back_to_single() {
+    // Weight transitions: 50/50 → 100/0 (simulating a canary rollback).
+    let registry = SplitRegistry::new();
+    registry.upsert(SplitConfig {
+        domain: "api.example.com".into(),
+        entries: vec![
+            WeightedEntry {
+                upstream_addr: "127.0.0.1:1001".into(),
+                weight: 50,
+                deploy_id: "stable".into(),
+            },
+            WeightedEntry {
+                upstream_addr: "127.0.0.1:1002".into(),
+                weight: 50,
+                deploy_id: "canary".into(),
+            },
+        ],
+        strategy: "canary".into(),
+    });
+
+    // Replace with 100/0 — canary rolled back.
+    registry.upsert(SplitConfig {
+        domain: "api.example.com".into(),
+        entries: vec![
+            WeightedEntry {
+                upstream_addr: "127.0.0.1:1001".into(),
+                weight: 100,
+                deploy_id: "stable".into(),
+            },
+            WeightedEntry {
+                upstream_addr: "127.0.0.1:1002".into(),
+                weight: 0,
+                deploy_id: "canary".into(),
+            },
+        ],
+        strategy: "canary".into(),
+    });
+
+    for _ in 0..500 {
+        let entry = registry.choose("api.example.com").expect("pick");
+        assert_eq!(entry.deploy_id, "stable");
+    }
+}
+
+#[test]
+fn header_rule_match_overrides_default_upstream() {
+    let registry = HeaderRuleRegistry::new();
+    let mut header_match = std::collections::HashMap::new();
+    header_match.insert("x-env".to_string(), "canary".to_string());
+    registry.upsert(HeaderRuleConfig {
+        domain: "api.example.com".into(),
+        header_match,
+        upstream_addr: "127.0.0.1:9001".into(),
+    });
+
+    let snap = registry
+        .snapshot_for("api.example.com")
+        .expect("rule recorded");
+
+    let canary_request = |name: &str| match name.to_ascii_lowercase().as_str() {
+        "x-env" => Some("canary".to_string()),
+        _ => None,
+    };
+    let stable_request = |name: &str| match name.to_ascii_lowercase().as_str() {
+        "x-env" => Some("stable".to_string()),
+        _ => None,
+    };
+    assert!(snap.matches(canary_request));
+    assert!(!snap.matches(stable_request));
+}
+
+#[tokio::test]
+async fn mirror_dispatcher_fires_against_real_listener() {
+    // Spin up a TcpListener that counts how many mirror hits it receives.
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let mirror_to = listener.local_addr().expect("local_addr");
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            let tx = tx.clone();
+            tokio::spawn(async move {
+                let mut buf = [0u8; 512];
+                let mut accum = Vec::new();
+                // Read the request headers once.
+                match tokio::time::timeout(Duration::from_millis(500), stream.read(&mut buf)).await
+                {
+                    Ok(Ok(n)) if n > 0 => {
+                        accum.extend_from_slice(&buf[..n]);
+                    }
+                    _ => {}
+                }
+                // Send a tiny HTTP/1.1 response so the client can close cleanly.
+                let _ = tokio::io::AsyncWriteExt::write_all(
+                    &mut stream,
+                    b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n",
+                )
+                .await;
+                let _ = tx.send(accum).await;
+            });
+        }
+    });
+
+    let registry = Arc::new(MirrorRegistry::new());
+    registry.upsert(MirrorConfig {
+        source_domain: "api.example.com".into(),
+        mirror_to: mirror_to.to_string(),
+        sample_rate_bps: 10_000, // 100% — always mirror
+    });
+
+    let dispatcher = MirrorDispatcherImpl::new(Arc::clone(&registry));
+    dispatcher.mirror(
+        "api.example.com",
+        "GET",
+        "/mirror-path",
+        &[("user-agent".to_string(), "dwaar-test".to_string())],
+    );
+
+    // Wait for the listener to record the mirror.
+    let received = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("mirror received within 2s")
+        .expect("channel open");
+    let raw = String::from_utf8_lossy(&received);
+    assert!(raw.contains("GET /mirror-path HTTP/1.1"));
+    assert!(raw.contains("Host: api.example.com"));
+    assert!(raw.contains("X-Dwaar-Mirror: 1"));
+    assert!(raw.contains("user-agent: dwaar-test"));
+
+    // Give the spawned task one more tick to update the counter.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let snapshot = dispatcher.metrics().snapshot();
+    assert!(
+        snapshot.iter().any(|(k, _)| k.2 == MIRROR_OUTCOME_SENT),
+        "expected at least one sent outcome, got {snapshot:?}"
+    );
+}
+
+#[tokio::test]
+async fn mirror_dispatcher_records_sampled_out_for_zero_rate() {
+    let registry = Arc::new(MirrorRegistry::new());
+    registry.upsert(MirrorConfig {
+        source_domain: "api.example.com".into(),
+        mirror_to: "127.0.0.1:9".into(),
+        sample_rate_bps: 0,
+    });
+    let dispatcher = MirrorDispatcherImpl::new(registry);
+    for _ in 0..5 {
+        dispatcher.mirror("api.example.com", "GET", "/", &[]);
+    }
+    let snap = dispatcher.metrics().snapshot();
+    assert!(
+        snap.iter()
+            .any(|(k, v)| k.2 == MIRROR_OUTCOME_SAMPLED_OUT && *v == 5)
+    );
+    assert!(!snap.iter().any(|(k, _)| k.2 == MIRROR_OUTCOME_SENT));
+}
+
+#[tokio::test]
+async fn mirror_dispatcher_records_error_when_target_unreachable() {
+    let registry = Arc::new(MirrorRegistry::new());
+    // Bind to a port, drop the listener, then mirror to the freed port.
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    drop(listener);
+    registry.upsert(MirrorConfig {
+        source_domain: "api.example.com".into(),
+        mirror_to: addr.to_string(),
+        sample_rate_bps: 10_000,
+    });
+    let dispatcher = MirrorDispatcherImpl::new(registry);
+    dispatcher.mirror("api.example.com", "GET", "/", &[]);
+
+    // Give the detached task time to attempt and fail.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    let snap = dispatcher.metrics().snapshot();
+    assert!(
+        snap.iter().any(|(k, _)| k.2 == MIRROR_OUTCOME_ERROR),
+        "expected error outcome, snapshot={snap:?}"
+    );
+}
+
+#[tokio::test]
+async fn anomaly_sink_emits_via_event_bus_on_error_rate() {
+    let bus = Arc::new(EventBus::new());
+    let mut sub = bus.subscribe();
+    let sink = AnomalyOutcomeSink::with_thresholds(
+        Arc::clone(&bus),
+        AnomalyThresholds {
+            error_rate_min_requests: 10,
+            ..AnomalyThresholds::default()
+        },
+    );
+    // 10 clean requests, then 10 errors → 50% rate.
+    for _ in 0..10 {
+        dwaar_core::proxy::RequestOutcomeSink::record(
+            &sink,
+            "api.example.com",
+            200,
+            Duration::from_millis(10),
+        );
+    }
+    for _ in 0..10 {
+        dwaar_core::proxy::RequestOutcomeSink::record(
+            &sink,
+            "api.example.com",
+            503,
+            Duration::from_millis(10),
+        );
+    }
+
+    let msg = tokio::time::timeout(Duration::from_millis(200), sub.next())
+        .await
+        .expect("anomaly event fired")
+        .expect("bus open");
+    match &msg.kind {
+        Some(dwaar_grpc::pb::server_message::Kind::AnomalyEvent(ev)) => {
+            assert_eq!(ev.domain, "api.example.com");
+            assert_eq!(ev.anomaly_type, "error_rate");
+            assert!(ev.severity > 0.0);
+        }
+        other => panic!("expected AnomalyEvent, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn log_buffer_batches_up_to_cap_then_flushes() {
+    let bus = Arc::new(EventBus::new());
+    let mut sub = bus.subscribe();
+    // Tick-based flush: use a very short interval to avoid flake.
+    let buf = LogChunkBuffer::with_interval(Arc::clone(&bus), Duration::from_millis(25));
+
+    for i in 0..5 {
+        buf.append(&LogIngest {
+            domain: "api.example.com".into(),
+            deploy_id: "d1".into(),
+            line: format!("line-{i}").into_bytes(),
+        });
+    }
+    tokio::time::sleep(Duration::from_millis(40)).await;
+    buf.tick();
+
+    let msg = tokio::time::timeout(Duration::from_millis(200), sub.next())
+        .await
+        .expect("chunk flushed")
+        .expect("bus open");
+    match &msg.kind {
+        Some(dwaar_grpc::pb::server_message::Kind::LogChunk(chunk)) => {
+            assert_eq!(chunk.domain, "api.example.com");
+            assert_eq!(chunk.deploy_id, "d1");
+            #[allow(clippy::naive_bytecount)]
+            let lines = chunk.payload.iter().filter(|&&b| b == b'\n').count();
+            assert_eq!(lines, 5);
+        }
+        other => panic!("expected LiveLogChunk, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn bus_drops_oldest_on_subscriber_overrun_and_publisher_never_blocks() {
+    let bus = Arc::new(EventBus::with_capacity(2));
+    let _sub = bus.subscribe();
+
+    // Fire a burst of 100 events at a 2-deep subscriber — publisher must
+    // return without blocking; bus records drops.
+    let t0 = tokio::time::Instant::now();
+    for i in 0..100 {
+        bus.publish_anomaly(dwaar_grpc::pb::AnomalyEvent {
+            domain: format!("d{i}"),
+            anomaly_type: "error_rate".into(),
+            severity: 0.5,
+            detail: String::new(),
+            observed_at_unix_ms: 0,
+        });
+    }
+    let elapsed = t0.elapsed();
+    assert!(
+        elapsed < Duration::from_millis(250),
+        "publisher blocked — took {elapsed:?}"
+    );
+    assert!(bus.dropped_count() > 0, "expected at least one drop");
+}


### PR DESCRIPTION
## Summary

Ships Wheel #2 Weeks 4–5 of the substrate contract.

- **Week 4 — proxy hot-path integration.** `DwaarProxy::request_filter` now consults a `ControlPlaneHooks { splits, header_rules }` bundle and a `MirrorDispatcher` trait. Header rules win over traffic splits (more specific); splits produce a weighted upstream pick; mirrors fire as detached tokio tasks that replay method + path + headers without touching the primary response path. New Prometheus counter `dwaar_mirror_requests_total{source_domain, mirror_to, outcome={sent|sampled_out|error}}`.
- **Week 4 — `SetHeaderRule` handler.** Replaces the `not_implemented` stub with a real handler over a new `HeaderRuleRegistry`. Registries moved from `dwaar-grpc` to `dwaar_core::registries` to avoid a circular dep.
- **Week 5 — event stream.** `EventBus` multiplexes `AnomalyEvent`, `TrafficSpikeEvent`, and `LiveLogChunk` to every connected peer via bounded mpsc (depth 256, oldest-drop on backpressure, per-bus drop counter). Per-domain `AnomalyDetector` fires on 5xx rate > 1 % (60 s window), P95 latency > 2× the 10-min mean, and sustained RPS > 2× the 5-min moving average ≥ 30 s. `LogChunkBuffer` batches every 200 ms, caps at 100 lines / 64 KB per chunk.
- **Version bump to 0.3.3** in `crates/dwaar-cli/Cargo.toml`, `LICENSE`, and `CHANGELOG.md`.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo build --workspace` clean.
- [x] `cargo test --workspace --lib --bins --tests --exclude dwaar-cli` all green (pre-existing `dwaar-cli/tests/proxy_integration.rs` flakes on port 8080 without my changes; unrelated to this PR).
- [x] `cargo deny check` clean.
- [x] New integration tests in `crates/dwaar-grpc/tests/proxy_integration.rs` exercise 100→50/50→100 split transitions, mirror dispatch against a real `TcpListener`, mirror error / sampled-out counters, header-rule matching, bus backpressure, anomaly emission, and log-chunk batching.