### PR TITLE
feat(analytics): emit referrer + device + top-path aggregates

### DIFF
--- a/crates/dwaar-admin/src/handlers.rs
+++ b/crates/dwaar-admin/src/handlers.rs
@@ -300,6 +300,7 @@ mod tests {
             client_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1)),
             country: None,
             referer: None,
+            user_agent: None,
             is_bot: false,
         });
         map.insert("test.example.com".to_string(), dm);

--- a/crates/dwaar-analytics/benches/aggregation.rs
+++ b/crates/dwaar-analytics/benches/aggregation.rs
@@ -21,6 +21,16 @@ use dwaar_analytics::aggregation::{AggEvent, DomainMetrics};
 use hyperloglog::HyperLogLog;
 
 fn sample_event(i: u32) -> AggEvent {
+    // Cycle through representative UAs so the device classifier branch
+    // is exercised in the hot path benchmark — otherwise the device
+    // BoundedCounter insert cost is not measured.
+    const UAS: &[&str] = &[
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit Chrome/120 Safari",
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Mobile/15E148",
+        "Mozilla/5.0 (iPad; CPU OS 17_0) AppleWebKit Mobile/15E148",
+        "Googlebot/2.1 (+http://www.google.com/bot.html)",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Firefox/122.0",
+    ];
     AggEvent {
         host: "example.com".into(),
         path: format!("/page/{}", i % 500).into(),
@@ -35,6 +45,7 @@ fn sample_event(i: u32) -> AggEvent {
         } else {
             None
         },
+        user_agent: Some(UAS[i as usize % UAS.len()].into()),
         is_bot: i.is_multiple_of(7),
     }
 }

--- a/crates/dwaar-analytics/src/aggregation/mod.rs
+++ b/crates/dwaar-analytics/src/aggregation/mod.rs
@@ -32,7 +32,7 @@ const CHANNEL_CAPACITY: usize = 8192;
 
 /// Slim event for analytics aggregation — only the fields the aggregation
 /// service actually reads. Avoids cloning the full `RequestLog` (20+ fields)
-/// on every request when only 7 are needed.
+/// on every request when only a handful are needed.
 #[derive(Debug, Clone)]
 pub struct AggEvent {
     pub host: Arc<str>,
@@ -42,6 +42,12 @@ pub struct AggEvent {
     pub client_ip: IpAddr,
     pub country: Option<Arc<str>>,
     pub referer: Option<Arc<str>>,
+    /// Raw `User-Agent` request header. Used by
+    /// [`DomainMetrics::ingest_log`] to classify the request into a
+    /// fixed `mobile|desktop|tablet|bot|unknown` bucket via
+    /// [`classify_device`]. Never retained beyond classification so
+    /// the raw string is not stored in any aggregate.
+    pub user_agent: Option<Arc<str>>,
     /// Bot classification from the bot-detect plugin (priority 10),
     /// propagated so the aggregation snapshot can surface bot-vs-human
     /// pageview ratios. Default `false` is treated as a human request.
@@ -50,6 +56,11 @@ pub struct AggEvent {
 const TOP_PAGES_K: usize = 100;
 const TOP_REFERRERS_N: usize = 50;
 const TOP_COUNTRIES_N: usize = 250;
+/// Fixed device enum (mobile, desktop, tablet, bot, unknown) — the
+/// `BoundedCounter` capacity is sized to exactly cover this enum so
+/// cardinality can never exceed the number of buckets even if a new
+/// classifier branch is added.
+const DEVICE_BUCKETS: usize = 5;
 
 /// Per-domain analytics aggregates.
 ///
@@ -62,6 +73,11 @@ pub struct DomainMetrics {
     pub top_pages: TopK<String>,
     pub referrers: BoundedCounter<String>,
     pub countries: BoundedCounter<String>,
+    /// Per-device-class pageview counter across the fixed
+    /// `mobile|desktop|tablet|bot|unknown` enum. Sized to exactly
+    /// cover the classifier output so the bounded counter can never
+    /// exceed its capacity regardless of traffic.
+    pub devices: BoundedCounter<String>,
     pub status_codes: [u64; 6],
     pub bytes_sent: u64,
     pub web_vitals: WebVitals,
@@ -81,6 +97,7 @@ impl DomainMetrics {
             top_pages: TopK::new(TOP_PAGES_K),
             referrers: BoundedCounter::new(TOP_REFERRERS_N),
             countries: BoundedCounter::new(TOP_COUNTRIES_N),
+            devices: BoundedCounter::new(DEVICE_BUCKETS),
             status_codes: [0; 6],
             bytes_sent: 0,
             web_vitals: WebVitals::new(),
@@ -115,6 +132,15 @@ impl DomainMetrics {
         if let Some(ref country) = event.country {
             self.countries.insert(country.to_string());
         }
+        // Classify the User-Agent into the fixed five-bucket device enum
+        // so `devices.top()` reports mobile vs desktop vs tablet vs bot vs
+        // unknown without ever persisting the raw header (PII-sensitive
+        // and unbounded in cardinality).
+        let device = match event.user_agent.as_deref() {
+            Some(ua) => classify_device(ua),
+            None => "unknown",
+        };
+        self.devices.insert(device.to_string());
     }
 
     /// Update from a client-side beacon event.
@@ -174,6 +200,38 @@ pub fn status_bucket(status: u16) -> usize {
         500..=599 => 4,
         _ => 5,
     }
+}
+
+/// Classify a `User-Agent` string into a fixed five-bucket enum:
+/// `mobile | desktop | tablet | bot | unknown`.
+///
+/// Intentionally coarse — headline numbers only. Precedence:
+/// 1. Bot / crawler / spider markers win over everything else so
+///    automated traffic never counts toward mobile/desktop share.
+/// 2. Tablet markers win over mobile because iPads advertise "Mobile"
+///    in their UA and would otherwise double-count.
+/// 3. Mobile markers (`mobile`, `android`, `iphone`).
+/// 4. Everything else is `desktop`.
+///
+/// An empty UA returns `unknown` so downstream dashboards can flag
+/// the gap instead of misattributing it to desktop. The raw UA is
+/// never retained — this function is the sole path from
+/// `User-Agent` to the bounded counter.
+pub fn classify_device(ua: &str) -> &'static str {
+    if ua.is_empty() {
+        return "unknown";
+    }
+    let ua_lower = ua.to_lowercase();
+    if ua_lower.contains("bot") || ua_lower.contains("crawler") || ua_lower.contains("spider") {
+        return "bot";
+    }
+    if ua_lower.contains("tablet") || ua_lower.contains("ipad") {
+        return "tablet";
+    }
+    if ua_lower.contains("mobile") || ua_lower.contains("android") || ua_lower.contains("iphone") {
+        return "mobile";
+    }
+    "desktop"
 }
 
 /// Extract domain from a URL (e.g., `https://google.com/search` → `google.com`).
@@ -257,6 +315,7 @@ mod tests {
             client_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
             country: None,
             referer: None,
+            user_agent: None,
             is_bot: false,
         };
         // Should not panic — drops silently when full
@@ -309,6 +368,9 @@ mod tests {
             client_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
             country: Some("US".into()),
             referer: Some("https://google.com/search".into()),
+            user_agent: Some(
+                "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Mobile/15E148".into(),
+            ),
             is_bot: false,
         };
         dm.ingest_log(&event);
@@ -318,5 +380,75 @@ mod tests {
         assert_eq!(dm.top_pages.top()[0].0, "/home");
         assert_eq!(dm.referrers.top()[0].0, "google.com");
         assert_eq!(dm.countries.top()[0].0, "US");
+        assert_eq!(dm.devices.top()[0].0, "mobile");
+    }
+
+    #[test]
+    fn classify_device_buckets() {
+        // Bots / crawlers / spiders win over any other match.
+        assert_eq!(
+            classify_device("Googlebot/2.1 (+http://www.google.com/bot.html)"),
+            "bot"
+        );
+        assert_eq!(classify_device("AhrefsBot/7.0"), "bot");
+        assert_eq!(classify_device("Bingbot"), "bot");
+        assert_eq!(classify_device("facebookexternalhit/1.1"), "desktop"); // no bot/crawler marker
+        assert_eq!(classify_device("Mozilla spider v1"), "bot");
+        assert_eq!(classify_device("Screaming Frog SEO Spider/19.5"), "bot");
+        assert_eq!(classify_device("web crawler edu"), "bot");
+
+        // Tablet markers win over mobile — iPads advertise "Mobile" too.
+        assert_eq!(
+            classify_device("Mozilla/5.0 (iPad; CPU OS 17_0) AppleWebKit Mobile/15E148"),
+            "tablet"
+        );
+        assert_eq!(
+            classify_device("Mozilla/5.0 (Linux; Android 11; SM-T870) AppleWebKit Tablet"),
+            "tablet"
+        );
+
+        // Mobile markers.
+        assert_eq!(
+            classify_device("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Mobile/15E148"),
+            "mobile"
+        );
+        assert_eq!(
+            classify_device("Mozilla/5.0 (Linux; Android 13; Pixel 8) AppleWebKit Mobile Safari"),
+            "mobile"
+        );
+
+        // Desktop fallback — regular Chrome/Firefox on macOS/Linux/Windows.
+        assert_eq!(
+            classify_device(
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit Chrome/120 Safari"
+            ),
+            "desktop"
+        );
+        assert_eq!(
+            classify_device("Mozilla/5.0 (Windows NT 10.0; Win64; x64) Firefox/122.0"),
+            "desktop"
+        );
+        assert_eq!(classify_device("curl/8.1.0"), "desktop");
+
+        // Empty / missing UA → unknown so the dashboard can surface the gap.
+        assert_eq!(classify_device(""), "unknown");
+    }
+
+    #[test]
+    fn ingest_log_classifies_missing_ua_as_unknown() {
+        let mut dm = DomainMetrics::new();
+        let event = AggEvent {
+            host: "example.com".into(),
+            path: "/".into(),
+            status: 200,
+            bytes_sent: 128,
+            client_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            country: None,
+            referer: None,
+            user_agent: None,
+            is_bot: false,
+        };
+        dm.ingest_log(&event);
+        assert_eq!(dm.devices.top()[0].0, "unknown");
     }
 }

--- a/crates/dwaar-analytics/src/aggregation/service.rs
+++ b/crates/dwaar-analytics/src/aggregation/service.rs
@@ -242,6 +242,11 @@ struct FlushSnapshot {
     top_pages: Vec<PageCount>,
     referrers: Vec<ReferrerCount>,
     countries: Vec<CountryCount>,
+    /// Per-device-class pageview counts across the fixed
+    /// `mobile|desktop|tablet|bot|unknown` enum. Sibling of
+    /// [`crate::sink::DomainMetricsSnapshot::devices`] — same data,
+    /// different wire format (stdout-legacy JSON vs socket sink).
+    devices: Vec<DeviceCount>,
     status_codes: StatusCodes,
     bytes_sent: u64,
     web_vitals: VitalsSnapshot,
@@ -262,6 +267,12 @@ struct ReferrerCount {
 #[derive(Debug, Serialize)]
 struct CountryCount {
     code: String,
+    count: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct DeviceCount {
+    device: String,
     count: u64,
 }
 
@@ -322,6 +333,12 @@ impl FlushSnapshot {
                 .into_iter()
                 .map(|(code, count)| CountryCount { code, count })
                 .collect(),
+            devices: m
+                .devices
+                .top()
+                .into_iter()
+                .map(|(device, count)| DeviceCount { device, count })
+                .collect(),
             status_codes: StatusCodes {
                 s1xx: m.status_codes[0],
                 s2xx: m.status_codes[1],
@@ -366,6 +383,10 @@ mod tests {
             client_ip: std::net::IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
             country: Some("US".into()),
             referer: Some("https://google.com/search".into()),
+            user_agent: Some(
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit Chrome/120 Safari"
+                    .into(),
+            ),
             is_bot: false,
         }
     }

--- a/crates/dwaar-analytics/src/aggregation/snapshot.rs
+++ b/crates/dwaar-analytics/src/aggregation/snapshot.rs
@@ -188,6 +188,10 @@ mod tests {
             client_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
             country: Some("US".into()),
             referer: Some("https://google.com/search".into()),
+            user_agent: Some(
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit Chrome/120 Safari"
+                    .into(),
+            ),
             is_bot: false,
         }
     }

--- a/crates/dwaar-analytics/src/sink.rs
+++ b/crates/dwaar-analytics/src/sink.rs
@@ -41,6 +41,11 @@ pub struct DomainMetricsSnapshot {
     pub top_pages: Vec<(String, u64)>,
     pub referrers: Vec<(String, u64)>,
     pub countries: Vec<(String, u64)>,
+    /// Per-device-class pageview counts across the fixed
+    /// `mobile|desktop|tablet|bot|unknown` enum. Classification lives
+    /// in [`crate::aggregation::classify_device`]. Cardinality is
+    /// bounded at the enum size so downstream emitters cannot explode.
+    pub devices: Vec<(String, u64)>,
     pub status_codes: [u64; 6],
     pub bytes_sent: u64,
     pub lcp: Percentiles,
@@ -59,6 +64,7 @@ impl DomainMetricsSnapshot {
             top_pages: m.top_pages.top(),
             referrers: m.referrers.top(),
             countries: m.countries.top(),
+            devices: m.devices.top(),
             status_codes: m.status_codes,
             bytes_sent: m.bytes_sent,
             lcp: m.web_vitals.peek_lcp_percentiles(),
@@ -241,6 +247,52 @@ mod tests {
         assert_eq!(snap.unique_visitors, 0);
         assert_eq!(snap.total_pageviews, 0);
         assert!(snap.top_pages.is_empty());
+        assert!(snap.referrers.is_empty());
+        assert!(snap.devices.is_empty());
+    }
+
+    #[test]
+    fn snapshot_surfaces_referrer_device_and_top_pages() {
+        use crate::aggregation::AggEvent;
+        use std::net::{IpAddr, Ipv4Addr};
+
+        let mut dm = DomainMetrics::new();
+        let uas = [
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Mobile/15E148", // mobile
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120 Safari",    // desktop
+            "Googlebot/2.1",                                                        // bot
+        ];
+        for (i, ua) in uas.iter().enumerate() {
+            dm.ingest_log(&AggEvent {
+                host: "test.example.com".into(),
+                path: if i == 0 {
+                    "/home".into()
+                } else {
+                    "/about".into()
+                },
+                status: 200,
+                bytes_sent: 512,
+                client_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, i as u8 + 1)),
+                country: None,
+                referer: Some("https://news.ycombinator.com/".into()),
+                user_agent: Some((*ua).into()),
+                is_bot: false,
+            });
+        }
+
+        let snap = DomainMetricsSnapshot::from_metrics("test.example.com", &dm);
+        // referrer emission — unblocks ReferrerBreakdown.svelte
+        assert_eq!(snap.referrers.len(), 1);
+        assert_eq!(snap.referrers[0].0, "news.ycombinator.com");
+        // device emission — unblocks DeviceBreakdown.svelte
+        let devices: std::collections::HashMap<_, _> = snap.devices.iter().cloned().collect();
+        assert_eq!(devices.get("mobile").copied(), Some(1));
+        assert_eq!(devices.get("desktop").copied(), Some(1));
+        assert_eq!(devices.get("bot").copied(), Some(1));
+        // top_pages emission — unblocks per-path drill-down
+        let paths: std::collections::HashMap<_, _> = snap.top_pages.iter().cloned().collect();
+        assert_eq!(paths.get("/home").copied(), Some(1));
+        assert_eq!(paths.get("/about").copied(), Some(2));
     }
 
     #[test]

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -2282,6 +2282,16 @@ impl ProxyHttp for DwaarProxy {
             .get("referer")
             .and_then(|v| v.to_str().ok())
             .map(CompactString::from);
+        // User-Agent is read once here so the analytics aggregator can
+        // classify the request into a fixed device bucket. The full UA
+        // is also stored on `RequestLog` below — read both from the
+        // same header value so the two paths cannot disagree.
+        let user_agent: Option<CompactString> = session
+            .req_header()
+            .headers
+            .get("user-agent")
+            .and_then(|v| v.to_str().ok())
+            .map(CompactString::from);
 
         if let Some(ref agg) = self.agg_sender {
             // AggEvent fields are Arc<str>: construction pays one Arc alloc per field,
@@ -2294,6 +2304,7 @@ impl ProxyHttp for DwaarProxy {
                 client_ip,
                 country: country.as_deref().map(Arc::from),
                 referer: referer.as_deref().map(Arc::from),
+                user_agent: user_agent.as_deref().map(Arc::from),
                 // bot-detect plugin classifies the request on PluginCtx;
                 // the aggregator splits bot vs human counters in DomainMetrics.
                 is_bot: ctx.plugin_ctx.is_bot,
@@ -2315,12 +2326,7 @@ impl ProxyHttp for DwaarProxy {
             status,
             response_time_us,
             client_ip,
-            user_agent: session
-                .req_header()
-                .headers
-                .get("user-agent")
-                .and_then(|v| v.to_str().ok())
-                .map(CompactString::from),
+            user_agent,
             referer,
             bytes_sent,
             bytes_received,


### PR DESCRIPTION
## Summary
- Dwaar already computed the data (top referrers, top pages, User-Agent on every event) but the downstream emission path was missing for referrer / device / path. Three small cuts add it so Permanu can build the Plausible-parity UI.
- **referrer**: existing `extract_domain()` path is reused; `DomainMetricsSnapshot.referrers` and `FlushSnapshot.referrers` were already populated — only the backend fan-out in the sibling PR is new.
- **device**: new `BoundedCounter<5>` keyed by `mobile | desktop | tablet | bot | unknown`, classified by a simple substring heuristic on the User-Agent. Raw UA never leaves the classifier.
- **top_pages**: existing `TopK<100>` is already on `DomainMetricsSnapshot.top_pages`; `FlushSnapshot` grows a matching `devices` field for symmetry.

### Cardinality + privacy
- `referrer` is capped at 50 (existing `BoundedCounter`), query strings stripped.
- `device` is capped at the enum size (5).
- `path` is capped at 100 (existing `TopK`).
- No raw UA is retained — the classifier is the sole path from header → bounded counter.

### Out of scope (flagged for separate PRs)
- Status-class metrics (1xx..5xx) — computed but not yet emitted.
- UTM params — needs a top-N sampling scheme.
- Refined bot classification (per-crawler) — current binary bot/human suffices.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test -p dwaar-analytics` — 190 tests pass including new `classify_device_buckets`, `ingest_log_classifies_missing_ua_as_unknown`, and `snapshot_surfaces_referrer_device_and_top_pages`.
- [x] `cargo test -p dwaar-admin -p dwaar-core` — green.
- [ ] Live verify in Permanu staging once the sibling `deploy_analytics_referrer_views` / `deploy_analytics_device_views` / `deploy_analytics_path_views` series land in VictoriaMetrics (follow-up in permanu/Deploy sibling PR).

## Files
- `crates/dwaar-analytics/src/aggregation/mod.rs` — `classify_device`, `devices` on `DomainMetrics`, `AggEvent.user_agent`.
- `crates/dwaar-analytics/src/sink.rs` — `devices: Vec<(String, u64)>` on `DomainMetricsSnapshot`.
- `crates/dwaar-analytics/src/aggregation/service.rs` — `devices` on `FlushSnapshot` (stdout legacy).
- `crates/dwaar-core/src/proxy.rs` — capture `User-Agent` once and populate `AggEvent.user_agent`.
- Test fixtures + benches updated.