### PR TITLE
feat(analytics): UTM params + status-class emission + version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-cli"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.3.3
+Licensed Work:        Dwaar 0.3.4
                       The Licensed Work is
                       (c) 2026 Permanu
 
@@ -65,7 +65,7 @@ Additional Use Grant: You may use, copy, modify, create derivative works of,
                         of the Licensed Work as part of a commercial
                         infrastructure or platform product.
 
-Change Date:          2036-04-16
+Change Date:          2036-04-18
 
 Change License:       GNU Affero General Public License v3.0
 

--- a/crates/dwaar-admin/src/handlers.rs
+++ b/crates/dwaar-admin/src/handlers.rs
@@ -295,6 +295,7 @@ mod tests {
         dm.ingest_log(&dwaar_analytics::aggregation::AggEvent {
             host: "test.example.com".into(),
             path: "/home".into(),
+            query: None,
             status: 200,
             bytes_sent: 1024,
             client_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1)),

--- a/crates/dwaar-analytics/benches/aggregation.rs
+++ b/crates/dwaar-analytics/benches/aggregation.rs
@@ -34,6 +34,21 @@ fn sample_event(i: u32) -> AggEvent {
     AggEvent {
         host: "example.com".into(),
         path: format!("/page/{}", i % 500).into(),
+        // Every 4th event carries a UTM query so the benchmark measures
+        // the cost of the UTM extraction path end-to-end, not just the
+        // no-query fast exit.
+        query: if i.is_multiple_of(4) {
+            Some(
+                format!(
+                    "utm_source=src{}&utm_medium=cpc&utm_campaign=campaign{}",
+                    i % 10,
+                    i % 7
+                )
+                .into(),
+            )
+        } else {
+            None
+        },
         status: if i.is_multiple_of(20) { 404 } else { 200 },
         bytes_sent: 1024 + u64::from(i % 10_000),
         client_ip: IpAddr::V4(Ipv4Addr::from(i)),

--- a/crates/dwaar-analytics/src/aggregation/mod.rs
+++ b/crates/dwaar-analytics/src/aggregation/mod.rs
@@ -37,6 +37,12 @@ const CHANNEL_CAPACITY: usize = 8192;
 pub struct AggEvent {
     pub host: Arc<str>,
     pub path: Arc<str>,
+    /// Raw request query string (without the leading `?`), if present.
+    /// Used by [`DomainMetrics::ingest_log`] to extract marketing-attribution
+    /// UTM parameters via [`extract_utm_params`] and nothing else — the
+    /// raw query is never persisted to any aggregate. `None` when the
+    /// request carried no query string.
+    pub query: Option<Arc<str>>,
     pub status: u16,
     pub bytes_sent: u64,
     pub client_ip: IpAddr,
@@ -61,6 +67,26 @@ const TOP_COUNTRIES_N: usize = 250;
 /// cardinality can never exceed the number of buckets even if a new
 /// classifier branch is added.
 const DEVICE_BUCKETS: usize = 5;
+/// UTM top-N caps. Source/campaign cardinality is higher than medium
+/// (medium is typically one of a dozen conventional values like
+/// `cpc|email|social|organic`), so we size the bounded counters to
+/// match observed real-world attribution shapes while still preventing
+/// unbounded label growth under adversarial input.
+const TOP_UTM_SOURCES_N: usize = 50;
+const TOP_UTM_MEDIUMS_N: usize = 20;
+const TOP_UTM_CAMPAIGNS_N: usize = 50;
+/// Per-UTM-value length cap to defend against adversarial ballast values
+/// designed to blow up the bounded counter's memory footprint. Longer
+/// than any legitimate campaign slug but short enough that 150
+/// (sources+campaigns combined) * 128 bytes = 19 KiB worst case.
+const UTM_VALUE_MAX_LEN: usize = 128;
+/// Fixed HTTP status class enum (1xx, 2xx, 3xx, 4xx, 5xx) — always
+/// emitted in order with zero counts included so downstream dashboards
+/// can render heatmaps without having to synthesize missing buckets.
+/// Matches the first five indices of [`DomainMetrics::status_codes`]
+/// (the sixth `other` bucket is never surfaced as a class — it is a
+/// catch-all for out-of-range codes, reported via `status_codes`).
+const STATUS_CLASS_LABELS: [&str; 5] = ["1xx", "2xx", "3xx", "4xx", "5xx"];
 
 /// Per-domain analytics aggregates.
 ///
@@ -78,6 +104,22 @@ pub struct DomainMetrics {
     /// cover the classifier output so the bounded counter can never
     /// exceed its capacity regardless of traffic.
     pub devices: BoundedCounter<String>,
+    /// UTM source counter (e.g. `google`, `newsletter`, `twitter`).
+    /// Top-N sampled to prevent unbounded label growth from campaigns
+    /// in the wild; the cap is set so the typical long tail of organic
+    /// traffic sources is captured without becoming a `DoS` vector.
+    /// Values are case-folded to lowercase at insertion time so
+    /// `"Google"` and `"google"` merge.
+    pub utm_sources: BoundedCounter<String>,
+    /// UTM medium counter (e.g. `cpc`, `email`, `social`, `organic`).
+    /// Tighter bound than source/campaign because the value space is
+    /// conventionally small.
+    pub utm_mediums: BoundedCounter<String>,
+    /// UTM campaign counter (e.g. `spring-launch-2026`, `black-friday`).
+    /// Same cap as source; campaign values are typically marketing-team
+    /// controlled, but we bound anyway to defend against adversarial
+    /// ballast traffic.
+    pub utm_campaigns: BoundedCounter<String>,
     pub status_codes: [u64; 6],
     pub bytes_sent: u64,
     pub web_vitals: WebVitals,
@@ -98,6 +140,9 @@ impl DomainMetrics {
             referrers: BoundedCounter::new(TOP_REFERRERS_N),
             countries: BoundedCounter::new(TOP_COUNTRIES_N),
             devices: BoundedCounter::new(DEVICE_BUCKETS),
+            utm_sources: BoundedCounter::new(TOP_UTM_SOURCES_N),
+            utm_mediums: BoundedCounter::new(TOP_UTM_MEDIUMS_N),
+            utm_campaigns: BoundedCounter::new(TOP_UTM_CAMPAIGNS_N),
             status_codes: [0; 6],
             bytes_sent: 0,
             web_vitals: WebVitals::new(),
@@ -141,6 +186,25 @@ impl DomainMetrics {
             None => "unknown",
         };
         self.devices.insert(device.to_string());
+
+        // Marketing-attribution UTM parameters — `utm_source`,
+        // `utm_medium`, `utm_campaign` only. `utm_term` and `utm_content`
+        // are intentionally skipped: both are low-signal for aggregated
+        // dashboards and high-cardinality (ad-network term lists explode
+        // bounded-counter capacity). Each extracted value is lowercased
+        // at insertion so `Google` and `google` merge into one bucket.
+        if let Some(ref query) = event.query {
+            let (source, medium, campaign) = extract_utm_params(query);
+            if let Some(s) = source {
+                self.utm_sources.insert(s);
+            }
+            if let Some(m) = medium {
+                self.utm_mediums.insert(m);
+            }
+            if let Some(c) = campaign {
+                self.utm_campaigns.insert(c);
+            }
+        }
     }
 
     /// Update from a client-side beacon event.
@@ -190,6 +254,20 @@ impl Default for DomainMetrics {
     }
 }
 
+/// Emit the `[1xx, 2xx, 3xx, 4xx, 5xx]` status-class counts as a
+/// label-count pair vector, always in order, with zero counts included.
+/// Drops the sixth `other` bucket because downstream dashboards
+/// already treat out-of-range codes separately via the raw
+/// `status_codes` array — folding them into a class label would
+/// conflate RFC-valid status codes with malformed-response counts.
+pub fn status_class_snapshot(status_codes: &[u64; 6]) -> Vec<(String, u64)> {
+    STATUS_CLASS_LABELS
+        .iter()
+        .enumerate()
+        .map(|(i, label)| ((*label).to_string(), status_codes[i]))
+        .collect()
+}
+
 /// Map HTTP status code to bucket index: [1xx, 2xx, 3xx, 4xx, 5xx, other].
 pub fn status_bucket(status: u16) -> usize {
     match status {
@@ -232,6 +310,67 @@ pub fn classify_device(ua: &str) -> &'static str {
         return "mobile";
     }
     "desktop"
+}
+
+/// Extract the three tracked UTM attribution parameters from a raw
+/// query string (without the leading `?`). Returns lowercased,
+/// length-capped values ready for insertion into the per-domain
+/// bounded counters. Any parameter absent or empty after trimming is
+/// returned as `None` so the caller can skip the insert entirely.
+///
+/// Only `utm_source`, `utm_medium`, and `utm_campaign` are tracked —
+/// `utm_term` and `utm_content` are intentionally dropped because both
+/// are low-signal for aggregated dashboards and have unbounded
+/// real-world cardinality (ad-network term lists, dynamic content
+/// variants) that would defeat the bounded counter caps.
+///
+/// The parser is deliberately simple — no percent-decoding, no
+/// fragment handling, no repeated-key semantics — because:
+/// 1. UTM values in the wild are overwhelmingly ASCII slugs that
+///    need no decoding to stay unique.
+/// 2. Percent-decoding the raw query string would pull in the `url`
+///    crate, violating the no-new-deps constraint for this cut.
+/// 3. Repeated keys are handled last-wins, which matches the
+///    behavior of every major analytics platform.
+///
+/// Values longer than [`UTM_VALUE_MAX_LEN`] are dropped (not
+/// truncated) so adversarial inputs cannot grow the counter value
+/// keys beyond the defensive cap.
+pub fn extract_utm_params(query: &str) -> (Option<String>, Option<String>, Option<String>) {
+    let mut source: Option<String> = None;
+    let mut medium: Option<String> = None;
+    let mut campaign: Option<String> = None;
+
+    for pair in query.split('&') {
+        if pair.is_empty() {
+            continue;
+        }
+        let Some((raw_key, raw_val)) = pair.split_once('=') else {
+            continue;
+        };
+        // Only three keys matter; reject anything else without
+        // allocating a new String. Case-insensitive key comparison
+        // because campaign tools produce both `UTM_SOURCE` and
+        // `utm_source` in the wild.
+        let slot = if raw_key.eq_ignore_ascii_case("utm_source") {
+            &mut source
+        } else if raw_key.eq_ignore_ascii_case("utm_medium") {
+            &mut medium
+        } else if raw_key.eq_ignore_ascii_case("utm_campaign") {
+            &mut campaign
+        } else {
+            continue;
+        };
+
+        let trimmed = raw_val.trim();
+        if trimmed.is_empty() || trimmed.len() > UTM_VALUE_MAX_LEN {
+            continue;
+        }
+        // Last-wins semantics: `?utm_source=a&utm_source=b` → `b`.
+        *slot = Some(trimmed.to_lowercase());
+    }
+
+    (source, medium, campaign)
 }
 
 /// Extract domain from a URL (e.g., `https://google.com/search` → `google.com`).
@@ -310,6 +449,7 @@ mod tests {
         let dummy = AggEvent {
             host: "test.com".into(),
             path: "/".into(),
+            query: None,
             status: 200,
             bytes_sent: 0,
             client_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
@@ -363,6 +503,7 @@ mod tests {
         let event = AggEvent {
             host: "example.com".into(),
             path: "/home".into(),
+            query: None,
             status: 200,
             bytes_sent: 1024,
             client_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
@@ -440,6 +581,7 @@ mod tests {
         let event = AggEvent {
             host: "example.com".into(),
             path: "/".into(),
+            query: None,
             status: 200,
             bytes_sent: 128,
             client_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
@@ -450,5 +592,164 @@ mod tests {
         };
         dm.ingest_log(&event);
         assert_eq!(dm.devices.top()[0].0, "unknown");
+    }
+
+    /// Table-driven UTM extraction coverage. Each row exercises one
+    /// axis of the parser (happy path, case folding, missing params,
+    /// malformed syntax, length cap, repeated keys, low-signal keys we
+    /// deliberately drop) so a regression in any single branch fails
+    /// its own row loudly.
+    #[test]
+    fn extract_utm_params_table_driven() {
+        struct Case {
+            name: &'static str,
+            query: &'static str,
+            want_source: Option<&'static str>,
+            want_medium: Option<&'static str>,
+            want_campaign: Option<&'static str>,
+        }
+        let cases = [
+            Case {
+                name: "all three present",
+                query: "utm_source=google&utm_medium=cpc&utm_campaign=spring_launch",
+                want_source: Some("google"),
+                want_medium: Some("cpc"),
+                want_campaign: Some("spring_launch"),
+            },
+            Case {
+                name: "case folded values merge",
+                query: "utm_source=Google&utm_medium=EMAIL",
+                want_source: Some("google"),
+                want_medium: Some("email"),
+                want_campaign: None,
+            },
+            Case {
+                name: "case insensitive keys",
+                query: "UTM_SOURCE=twitter&Utm_Medium=social",
+                want_source: Some("twitter"),
+                want_medium: Some("social"),
+                want_campaign: None,
+            },
+            Case {
+                name: "missing utm entirely",
+                query: "q=foo&page=2",
+                want_source: None,
+                want_medium: None,
+                want_campaign: None,
+            },
+            Case {
+                name: "empty query",
+                query: "",
+                want_source: None,
+                want_medium: None,
+                want_campaign: None,
+            },
+            Case {
+                name: "malformed pairs ignored",
+                query: "utm_source=reddit&brokenpair&utm_campaign=winter",
+                want_source: Some("reddit"),
+                want_medium: None,
+                want_campaign: Some("winter"),
+            },
+            Case {
+                name: "empty value dropped",
+                query: "utm_source=&utm_campaign=  &utm_medium=email",
+                want_source: None,
+                want_medium: Some("email"),
+                want_campaign: None,
+            },
+            Case {
+                name: "utm_term and utm_content ignored",
+                query: "utm_source=google&utm_term=shoes&utm_content=ad1",
+                want_source: Some("google"),
+                want_medium: None,
+                want_campaign: None,
+            },
+            Case {
+                name: "repeated key last wins",
+                query: "utm_source=a&utm_source=b",
+                want_source: Some("b"),
+                want_medium: None,
+                want_campaign: None,
+            },
+        ];
+        for c in cases {
+            let (s, m, cp) = extract_utm_params(c.query);
+            assert_eq!(
+                s.as_deref(),
+                c.want_source,
+                "{}: source mismatch for {:?}",
+                c.name,
+                c.query
+            );
+            assert_eq!(
+                m.as_deref(),
+                c.want_medium,
+                "{}: medium mismatch for {:?}",
+                c.name,
+                c.query
+            );
+            assert_eq!(
+                cp.as_deref(),
+                c.want_campaign,
+                "{}: campaign mismatch for {:?}",
+                c.name,
+                c.query
+            );
+        }
+    }
+
+    #[test]
+    fn extract_utm_params_drops_oversized_values() {
+        // Adversarial ballast: source value exceeds UTM_VALUE_MAX_LEN so
+        // the key survives the parse but the value is dropped to keep
+        // the bounded counter's key-space small.
+        let huge = "x".repeat(UTM_VALUE_MAX_LEN + 1);
+        let q = format!("utm_source={huge}&utm_medium=cpc");
+        let (source, medium, _) = extract_utm_params(&q);
+        assert!(source.is_none(), "oversized source must be dropped");
+        assert_eq!(medium.as_deref(), Some("cpc"));
+    }
+
+    #[test]
+    fn ingest_log_extracts_utm_into_bounded_counters() {
+        let mut dm = DomainMetrics::new();
+        let event = AggEvent {
+            host: "example.com".into(),
+            path: "/landing".into(),
+            query: Some("utm_source=Google&utm_medium=cpc&utm_campaign=Spring_2026".into()),
+            status: 200,
+            bytes_sent: 512,
+            client_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            country: None,
+            referer: None,
+            user_agent: None,
+            is_bot: false,
+        };
+        dm.ingest_log(&event);
+        assert_eq!(dm.utm_sources.top()[0].0, "google");
+        assert_eq!(dm.utm_mediums.top()[0].0, "cpc");
+        assert_eq!(dm.utm_campaigns.top()[0].0, "spring_2026");
+    }
+
+    #[test]
+    fn ingest_log_without_query_leaves_utm_counters_empty() {
+        let mut dm = DomainMetrics::new();
+        let event = AggEvent {
+            host: "example.com".into(),
+            path: "/".into(),
+            query: None,
+            status: 200,
+            bytes_sent: 0,
+            client_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3)),
+            country: None,
+            referer: None,
+            user_agent: None,
+            is_bot: false,
+        };
+        dm.ingest_log(&event);
+        assert!(dm.utm_sources.is_empty());
+        assert!(dm.utm_mediums.is_empty());
+        assert!(dm.utm_campaigns.is_empty());
     }
 }

--- a/crates/dwaar-analytics/src/aggregation/service.rs
+++ b/crates/dwaar-analytics/src/aggregation/service.rs
@@ -247,6 +247,15 @@ struct FlushSnapshot {
     /// [`crate::sink::DomainMetricsSnapshot::devices`] — same data,
     /// different wire format (stdout-legacy JSON vs socket sink).
     devices: Vec<DeviceCount>,
+    /// Top-N UTM source / medium / campaign counters. Mirrors the socket
+    /// sink so consumers tailing the stdout legacy path see the same
+    /// attribution numbers as the agent does. Lowercased at ingest.
+    utm_sources: Vec<UtmCount>,
+    utm_mediums: Vec<UtmCount>,
+    utm_campaigns: Vec<UtmCount>,
+    /// HTTP status classes (1xx..5xx) emitted in order with zero counts
+    /// included. Sibling of [`crate::sink::DomainMetricsSnapshot::status_classes`].
+    status_classes: Vec<StatusClassCount>,
     status_codes: StatusCodes,
     bytes_sent: u64,
     web_vitals: VitalsSnapshot,
@@ -273,6 +282,23 @@ struct CountryCount {
 #[derive(Debug, Serialize)]
 struct DeviceCount {
     device: String,
+    count: u64,
+}
+
+/// One UTM attribution entry for the stdout-legacy flush. Field name
+/// is deliberately generic (`value`) so a single struct handles
+/// `utm_source`, `utm_medium`, and `utm_campaign` without three
+/// near-identical types; the owning field on `FlushSnapshot` carries
+/// the dimension.
+#[derive(Debug, Serialize)]
+struct UtmCount {
+    value: String,
+    count: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct StatusClassCount {
+    class: String,
     count: u64,
 }
 
@@ -339,6 +365,28 @@ impl FlushSnapshot {
                 .into_iter()
                 .map(|(device, count)| DeviceCount { device, count })
                 .collect(),
+            utm_sources: m
+                .utm_sources
+                .top()
+                .into_iter()
+                .map(|(value, count)| UtmCount { value, count })
+                .collect(),
+            utm_mediums: m
+                .utm_mediums
+                .top()
+                .into_iter()
+                .map(|(value, count)| UtmCount { value, count })
+                .collect(),
+            utm_campaigns: m
+                .utm_campaigns
+                .top()
+                .into_iter()
+                .map(|(value, count)| UtmCount { value, count })
+                .collect(),
+            status_classes: super::status_class_snapshot(&m.status_codes)
+                .into_iter()
+                .map(|(class, count)| StatusClassCount { class, count })
+                .collect(),
             status_codes: StatusCodes {
                 s1xx: m.status_codes[0],
                 s2xx: m.status_codes[1],
@@ -378,6 +426,7 @@ mod tests {
         AggEvent {
             host: host.into(),
             path: path.into(),
+            query: None,
             status,
             bytes_sent: 1024,
             client_ip: std::net::IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),

--- a/crates/dwaar-analytics/src/aggregation/snapshot.rs
+++ b/crates/dwaar-analytics/src/aggregation/snapshot.rs
@@ -48,6 +48,24 @@ pub struct StatusCodeBreakdown {
     pub other: u64,
 }
 
+/// HTTP status-class count entry for the Admin API. Always emitted in
+/// order 1xx..5xx with zero counts included so frontend heatmaps can
+/// key on a stable label set.
+#[derive(Debug, Serialize)]
+pub struct StatusClassEntry {
+    pub class: String,
+    pub count: u64,
+}
+
+/// One UTM attribution entry for the Admin API. A single struct covers
+/// `utm_source`, `utm_medium`, and `utm_campaign` — the owning field
+/// on [`AnalyticsSnapshot`] carries the dimension.
+#[derive(Debug, Serialize)]
+pub struct UtmEntry {
+    pub value: String,
+    pub count: u64,
+}
+
 /// Percentile snapshot for LCP, CLS, and INP Web Vitals.
 ///
 /// Read via `peek_*_percentiles` — intentionally does not flush the
@@ -86,6 +104,16 @@ pub struct AnalyticsSnapshot {
     pub referrers: Vec<ReferrerEntry>,
     pub countries: Vec<CountryEntry>,
     pub status_codes: StatusCodeBreakdown,
+    /// HTTP status classes 1xx..5xx in order with zero counts included.
+    /// Sibling of `status_codes` but shaped for dashboards that want a
+    /// stable label enumeration rather than a struct of fields.
+    pub status_classes: Vec<StatusClassEntry>,
+    /// Top-N UTM attribution counters. Lowercased and length-capped at
+    /// ingest; bounded at 50/20/50 respectively so the Admin API
+    /// response stays small regardless of traffic.
+    pub utm_sources: Vec<UtmEntry>,
+    pub utm_mediums: Vec<UtmEntry>,
+    pub utm_campaigns: Vec<UtmEntry>,
     pub bytes_sent: u64,
     pub web_vitals: VitalsSnapshot,
     /// Bot vs human pageview split. Cumulative since the last 60s
@@ -139,6 +167,28 @@ impl AnalyticsSnapshot {
             s5xx: sc[4],
             other: sc[5],
         };
+        let status_classes = crate::aggregation::status_class_snapshot(sc)
+            .into_iter()
+            .map(|(class, count)| StatusClassEntry { class, count })
+            .collect();
+        let utm_sources = m
+            .utm_sources
+            .top()
+            .into_iter()
+            .map(|(value, count)| UtmEntry { value, count })
+            .collect();
+        let utm_mediums = m
+            .utm_mediums
+            .top()
+            .into_iter()
+            .map(|(value, count)| UtmEntry { value, count })
+            .collect();
+        let utm_campaigns = m
+            .utm_campaigns
+            .top()
+            .into_iter()
+            .map(|(value, count)| UtmEntry { value, count })
+            .collect();
 
         let web_vitals = VitalsSnapshot {
             lcp: m.web_vitals.peek_lcp_percentiles(),
@@ -162,6 +212,10 @@ impl AnalyticsSnapshot {
             referrers,
             countries,
             status_codes,
+            status_classes,
+            utm_sources,
+            utm_mediums,
+            utm_campaigns,
             bytes_sent: m.bytes_sent,
             web_vitals,
             bot_views: m.bot_views,
@@ -183,6 +237,7 @@ mod tests {
         AggEvent {
             host: "test.example.com".into(),
             path: path.into(),
+            query: None,
             status,
             bytes_sent: 1024,
             client_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),

--- a/crates/dwaar-analytics/src/sink.rs
+++ b/crates/dwaar-analytics/src/sink.rs
@@ -46,6 +46,19 @@ pub struct DomainMetricsSnapshot {
     /// in [`crate::aggregation::classify_device`]. Cardinality is
     /// bounded at the enum size so downstream emitters cannot explode.
     pub devices: Vec<(String, u64)>,
+    /// Top-N UTM source values (e.g. `google`, `newsletter`). Lowercased
+    /// at ingest; bounded at the counter cap so the agent cannot fan
+    /// out an unbounded label set to `VictoriaMetrics`.
+    pub utm_sources: Vec<(String, u64)>,
+    /// Top-N UTM medium values (e.g. `cpc`, `email`, `social`).
+    pub utm_mediums: Vec<(String, u64)>,
+    /// Top-N UTM campaign values (e.g. `spring-launch-2026`).
+    pub utm_campaigns: Vec<(String, u64)>,
+    /// HTTP status-class counts across the fixed 1xx..5xx enum, emitted
+    /// in order with zero counts included so downstream heatmaps do not
+    /// have to synthesize missing buckets. Sourced from the first five
+    /// indices of [`crate::aggregation::DomainMetrics::status_codes`].
+    pub status_classes: Vec<(String, u64)>,
     pub status_codes: [u64; 6],
     pub bytes_sent: u64,
     pub lcp: Percentiles,
@@ -65,6 +78,10 @@ impl DomainMetricsSnapshot {
             referrers: m.referrers.top(),
             countries: m.countries.top(),
             devices: m.devices.top(),
+            utm_sources: m.utm_sources.top(),
+            utm_mediums: m.utm_mediums.top(),
+            utm_campaigns: m.utm_campaigns.top(),
+            status_classes: crate::aggregation::status_class_snapshot(&m.status_codes),
             status_codes: m.status_codes,
             bytes_sent: m.bytes_sent,
             lcp: m.web_vitals.peek_lcp_percentiles(),
@@ -270,6 +287,7 @@ mod tests {
                 } else {
                     "/about".into()
                 },
+                query: None,
                 status: 200,
                 bytes_sent: 512,
                 client_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, i as u8 + 1)),
@@ -301,6 +319,83 @@ mod tests {
         let json = serde_json::to_string(&snap).expect("serialize");
         assert!(json.contains("\"domain\":\"test.example.com\""));
         assert!(json.contains("\"unique_visitors\":0"));
+    }
+
+    #[test]
+    fn snapshot_surfaces_utm_and_status_classes() {
+        use crate::aggregation::AggEvent;
+        use std::net::{IpAddr, Ipv4Addr};
+
+        // Three requests so each status class is populated differently:
+        // 2xx x2, 4xx x1, 5xx x1. UTM comes in on the first event only so
+        // source/medium/campaign appear once each after ingest.
+        let mut dm = DomainMetrics::new();
+        let events = [
+            (
+                200,
+                Some("utm_source=Google&utm_medium=cpc&utm_campaign=Spring_2026"),
+            ),
+            (201, None),
+            (404, None),
+            (503, None),
+        ];
+        for (i, (status, query)) in events.into_iter().enumerate() {
+            dm.ingest_log(&AggEvent {
+                host: "test.example.com".into(),
+                path: "/".into(),
+                query: query.map(Into::into),
+                status,
+                bytes_sent: 100,
+                client_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, i as u8 + 1)),
+                country: None,
+                referer: None,
+                user_agent: None,
+                is_bot: false,
+            });
+        }
+
+        let snap = DomainMetricsSnapshot::from_metrics("test.example.com", &dm);
+
+        // UTM fan-out: case-folded values each counted once.
+        let sources: std::collections::HashMap<_, _> = snap.utm_sources.iter().cloned().collect();
+        assert_eq!(sources.get("google").copied(), Some(1));
+        let mediums: std::collections::HashMap<_, _> = snap.utm_mediums.iter().cloned().collect();
+        assert_eq!(mediums.get("cpc").copied(), Some(1));
+        let campaigns: std::collections::HashMap<_, _> =
+            snap.utm_campaigns.iter().cloned().collect();
+        assert_eq!(campaigns.get("spring_2026").copied(), Some(1));
+
+        // Status classes: always all 5 labels present, in order.
+        assert_eq!(snap.status_classes.len(), 5);
+        let classes: std::collections::HashMap<_, _> =
+            snap.status_classes.iter().cloned().collect();
+        assert_eq!(classes.get("1xx").copied(), Some(0));
+        assert_eq!(classes.get("2xx").copied(), Some(2));
+        assert_eq!(classes.get("3xx").copied(), Some(0));
+        assert_eq!(classes.get("4xx").copied(), Some(1));
+        assert_eq!(classes.get("5xx").copied(), Some(1));
+        // Order is stable 1xx..5xx so downstream heatmaps can rely on it.
+        let labels: Vec<_> = snap
+            .status_classes
+            .iter()
+            .map(|(l, _)| l.as_str())
+            .collect();
+        assert_eq!(labels, vec!["1xx", "2xx", "3xx", "4xx", "5xx"]);
+    }
+
+    #[test]
+    fn empty_metrics_emit_zero_status_classes() {
+        // Status classes must always surface, even when no requests
+        // landed yet, so the agent can propagate a zero baseline to
+        // VictoriaMetrics the moment a new domain appears.
+        let snap = test_snapshot();
+        assert_eq!(snap.status_classes.len(), 5);
+        for (_, count) in &snap.status_classes {
+            assert_eq!(*count, 0);
+        }
+        assert!(snap.utm_sources.is_empty());
+        assert!(snap.utm_mediums.is_empty());
+        assert!(snap.utm_campaigns.is_empty());
     }
 
     #[test]

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.3.3"
+version = "0.3.4"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -2296,9 +2296,13 @@ impl ProxyHttp for DwaarProxy {
         if let Some(ref agg) = self.agg_sender {
             // AggEvent fields are Arc<str>: construction pays one Arc alloc per field,
             // but subsequent clones (at the batch boundary) are pointer bumps only.
+            // `query` is cloned (not moved) because `RequestLog` below still
+            // needs the original — the aggregator reads only the UTM
+            // parameters from it and never retains the raw string.
             let event = AggEvent {
                 host: Arc::from(host.as_str()),
                 path: Arc::from(path.as_str()),
+                query: query.as_deref().map(Arc::from),
                 status,
                 bytes_sent,
                 client_ip,


### PR DESCRIPTION
## Summary

Three deferred analytics items collapse into one release cut + patch bump.

- **UTM params** — extract `utm_source` / `utm_medium` / `utm_campaign` from the request query string and aggregate into three `BoundedCounter`s (50 / 20 / 50). Values are case-folded on insert so `Google` and `google` merge. `utm_term` and `utm_content` intentionally skipped — low signal for aggregated dashboards, high real-world cardinality.
- **Status classes** — `AggEvent` already computes `1xx/2xx/3xx/4xx/5xx` counters; this PR surfaces them on `DomainMetricsSnapshot`, `FlushSnapshot`, and `AnalyticsSnapshot` in stable order with zero counts included so heatmaps key on a fixed label set.
- **Version bump** — `dwaar-cli` 0.3.3 → 0.3.4 + `LICENSE` (`Licensed Work` + `Change Date`) so the Permanu installer auto-update picks up the release (per `feedback_dwaar_version_bump`).

Bounded-counter caps prevent unbounded label growth even under adversarial input. A per-value length cap (`UTM_VALUE_MAX_LEN = 128`) defends against ballast values designed to blow up the counter's key-space footprint.

Sibling PR in **permanu/Deploy** regenerates the proto + fans these labels out to VictoriaMetrics.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p dwaar-analytics --all-targets -- -D warnings` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean across the full workspace
- [x] `cargo test -p dwaar-analytics -p dwaar-admin -p dwaar-core` — 538 tests pass (19 + 4 + 9 + 196 + 308 + 2)
- [x] Table-driven unit tests cover: normal, missing, case-folding, malformed query, repeated keys, length cap, `utm_term`/`utm_content` explicitly ignored
- [x] Snapshot builder tests cover: UTM fan-out, status-class fan-out, zero-baseline emission on empty metrics
- [x] Bench (`benches/aggregation.rs`) updated so the hot path exercises the UTM extraction branch 25% of the time

(Pre-existing `proxy_integration` tests fail on the local dev machine due to port 8080 TIME_WAIT — unrelated to this change; all analytics/admin/core suites pass.)