### PR TITLE
feat(analytics): UTM term + content labels + v0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-cli"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.3.4
+Licensed Work:        Dwaar 0.3.5
                       The Licensed Work is
                       (c) 2026 Permanu
 

--- a/crates/dwaar-analytics/benches/aggregation.rs
+++ b/crates/dwaar-analytics/benches/aggregation.rs
@@ -36,13 +36,18 @@ fn sample_event(i: u32) -> AggEvent {
         path: format!("/page/{}", i % 500).into(),
         // Every 4th event carries a UTM query so the benchmark measures
         // the cost of the UTM extraction path end-to-end, not just the
-        // no-query fast exit.
+        // no-query fast exit. Term and content are cycled on a finer
+        // spread than source/medium/campaign to stress the tighter
+        // bounded-counter caps (25 vs 50) on those dimensions.
         query: if i.is_multiple_of(4) {
             Some(
                 format!(
-                    "utm_source=src{}&utm_medium=cpc&utm_campaign=campaign{}",
+                    "utm_source=src{}&utm_medium=cpc&utm_campaign=campaign{}\
+                     &utm_term=term{}&utm_content=ad{}",
                     i % 10,
-                    i % 7
+                    i % 7,
+                    i % 12,
+                    i % 15
                 )
                 .into(),
             )

--- a/crates/dwaar-analytics/src/aggregation/mod.rs
+++ b/crates/dwaar-analytics/src/aggregation/mod.rs
@@ -72,9 +72,18 @@ const DEVICE_BUCKETS: usize = 5;
 /// `cpc|email|social|organic`), so we size the bounded counters to
 /// match observed real-world attribution shapes while still preventing
 /// unbounded label growth under adversarial input.
+///
+/// Term and content are capped tighter (25 vs 50) because their value
+/// space is the most ad-hoc of the five UTM dimensions: term typically
+/// carries ad-network keyword bids (long tail — thousands of variants
+/// per campaign) and content typically carries A/B creative identifiers
+/// (dynamic across ad rotations). Keeping these two counters small is
+/// the primary cardinality-risk mitigation for shipping them at all.
 const TOP_UTM_SOURCES_N: usize = 50;
 const TOP_UTM_MEDIUMS_N: usize = 20;
 const TOP_UTM_CAMPAIGNS_N: usize = 50;
+const TOP_UTM_TERMS_N: usize = 25;
+const TOP_UTM_CONTENTS_N: usize = 25;
 /// Per-UTM-value length cap to defend against adversarial ballast values
 /// designed to blow up the bounded counter's memory footprint. Longer
 /// than any legitimate campaign slug but short enough that 150
@@ -120,6 +129,16 @@ pub struct DomainMetrics {
     /// controlled, but we bound anyway to defend against adversarial
     /// ballast traffic.
     pub utm_campaigns: BoundedCounter<String>,
+    /// UTM term counter (e.g. `running+shoes`, `crm_software`). Typically
+    /// carries ad-network keyword bids, which have the highest real-world
+    /// cardinality of any UTM dimension — hence the tighter cap (25 vs
+    /// 50 for source/campaign). Values are case-folded to lowercase and
+    /// length-capped at insertion time just like the other UTM fields.
+    pub utm_terms: BoundedCounter<String>,
+    /// UTM content counter (e.g. `hero-cta-blue`, `v2-banner`). Typically
+    /// carries A/B creative identifiers that rotate across ad variants,
+    /// so cardinality is similarly ad-hoc to term — same tighter cap.
+    pub utm_contents: BoundedCounter<String>,
     pub status_codes: [u64; 6],
     pub bytes_sent: u64,
     pub web_vitals: WebVitals,
@@ -143,6 +162,8 @@ impl DomainMetrics {
             utm_sources: BoundedCounter::new(TOP_UTM_SOURCES_N),
             utm_mediums: BoundedCounter::new(TOP_UTM_MEDIUMS_N),
             utm_campaigns: BoundedCounter::new(TOP_UTM_CAMPAIGNS_N),
+            utm_terms: BoundedCounter::new(TOP_UTM_TERMS_N),
+            utm_contents: BoundedCounter::new(TOP_UTM_CONTENTS_N),
             status_codes: [0; 6],
             bytes_sent: 0,
             web_vitals: WebVitals::new(),
@@ -187,22 +208,29 @@ impl DomainMetrics {
         };
         self.devices.insert(device.to_string());
 
-        // Marketing-attribution UTM parameters — `utm_source`,
-        // `utm_medium`, `utm_campaign` only. `utm_term` and `utm_content`
-        // are intentionally skipped: both are low-signal for aggregated
-        // dashboards and high-cardinality (ad-network term lists explode
-        // bounded-counter capacity). Each extracted value is lowercased
-        // at insertion so `Google` and `google` merge into one bucket.
+        // Marketing-attribution UTM parameters across the full
+        // source/medium/campaign/term/content set. term/content are
+        // capped tighter than the other three because their value
+        // space is the most ad-hoc (keyword bids, A/B creative IDs);
+        // see `TOP_UTM_TERMS_N` / `TOP_UTM_CONTENTS_N` for the cap
+        // rationale. Each extracted value is lowercased at insertion
+        // so `Google` and `google` merge into one bucket.
         if let Some(ref query) = event.query {
-            let (source, medium, campaign) = extract_utm_params(query);
-            if let Some(s) = source {
+            let utm = extract_utm_params(query);
+            if let Some(s) = utm.source {
                 self.utm_sources.insert(s);
             }
-            if let Some(m) = medium {
+            if let Some(m) = utm.medium {
                 self.utm_mediums.insert(m);
             }
-            if let Some(c) = campaign {
+            if let Some(c) = utm.campaign {
                 self.utm_campaigns.insert(c);
+            }
+            if let Some(t) = utm.term {
+                self.utm_terms.insert(t);
+            }
+            if let Some(ct) = utm.content {
+                self.utm_contents.insert(ct);
             }
         }
     }
@@ -312,17 +340,28 @@ pub fn classify_device(ua: &str) -> &'static str {
     "desktop"
 }
 
-/// Extract the three tracked UTM attribution parameters from a raw
+/// Parsed UTM attribution values from a raw query string. Any
+/// parameter absent or empty after trimming is returned as `None` so
+/// the caller can skip inserts into the bounded counters entirely.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct UtmParams {
+    pub source: Option<String>,
+    pub medium: Option<String>,
+    pub campaign: Option<String>,
+    pub term: Option<String>,
+    pub content: Option<String>,
+}
+
+/// Extract the five tracked UTM attribution parameters from a raw
 /// query string (without the leading `?`). Returns lowercased,
 /// length-capped values ready for insertion into the per-domain
-/// bounded counters. Any parameter absent or empty after trimming is
-/// returned as `None` so the caller can skip the insert entirely.
+/// bounded counters.
 ///
-/// Only `utm_source`, `utm_medium`, and `utm_campaign` are tracked —
-/// `utm_term` and `utm_content` are intentionally dropped because both
-/// are low-signal for aggregated dashboards and have unbounded
-/// real-world cardinality (ad-network term lists, dynamic content
-/// variants) that would defeat the bounded counter caps.
+/// Covers `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, and
+/// `utm_content`. term/content carry tighter downstream caps
+/// (`TOP_UTM_TERMS_N`, `TOP_UTM_CONTENTS_N`) because their value space
+/// is the most ad-hoc — this function merely extracts; cardinality
+/// containment happens at the bounded-counter layer.
 ///
 /// The parser is deliberately simple — no percent-decoding, no
 /// fragment handling, no repeated-key semantics — because:
@@ -336,10 +375,8 @@ pub fn classify_device(ua: &str) -> &'static str {
 /// Values longer than [`UTM_VALUE_MAX_LEN`] are dropped (not
 /// truncated) so adversarial inputs cannot grow the counter value
 /// keys beyond the defensive cap.
-pub fn extract_utm_params(query: &str) -> (Option<String>, Option<String>, Option<String>) {
-    let mut source: Option<String> = None;
-    let mut medium: Option<String> = None;
-    let mut campaign: Option<String> = None;
+pub fn extract_utm_params(query: &str) -> UtmParams {
+    let mut out = UtmParams::default();
 
     for pair in query.split('&') {
         if pair.is_empty() {
@@ -348,16 +385,20 @@ pub fn extract_utm_params(query: &str) -> (Option<String>, Option<String>, Optio
         let Some((raw_key, raw_val)) = pair.split_once('=') else {
             continue;
         };
-        // Only three keys matter; reject anything else without
+        // Only the five UTM keys matter; reject anything else without
         // allocating a new String. Case-insensitive key comparison
         // because campaign tools produce both `UTM_SOURCE` and
         // `utm_source` in the wild.
         let slot = if raw_key.eq_ignore_ascii_case("utm_source") {
-            &mut source
+            &mut out.source
         } else if raw_key.eq_ignore_ascii_case("utm_medium") {
-            &mut medium
+            &mut out.medium
         } else if raw_key.eq_ignore_ascii_case("utm_campaign") {
-            &mut campaign
+            &mut out.campaign
+        } else if raw_key.eq_ignore_ascii_case("utm_term") {
+            &mut out.term
+        } else if raw_key.eq_ignore_ascii_case("utm_content") {
+            &mut out.content
         } else {
             continue;
         };
@@ -370,7 +411,7 @@ pub fn extract_utm_params(query: &str) -> (Option<String>, Option<String>, Optio
         *slot = Some(trimmed.to_lowercase());
     }
 
-    (source, medium, campaign)
+    out
 }
 
 /// Extract domain from a URL (e.g., `https://google.com/search` → `google.com`).
@@ -596,10 +637,11 @@ mod tests {
 
     /// Table-driven UTM extraction coverage. Each row exercises one
     /// axis of the parser (happy path, case folding, missing params,
-    /// malformed syntax, length cap, repeated keys, low-signal keys we
-    /// deliberately drop) so a regression in any single branch fails
-    /// its own row loudly.
+    /// malformed syntax, length cap, repeated keys, term/content
+    /// coverage) so a regression in any single branch fails its own
+    /// row loudly.
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn extract_utm_params_table_driven() {
         struct Case {
             name: &'static str,
@@ -607,28 +649,37 @@ mod tests {
             want_source: Option<&'static str>,
             want_medium: Option<&'static str>,
             want_campaign: Option<&'static str>,
+            want_term: Option<&'static str>,
+            want_content: Option<&'static str>,
         }
         let cases = [
             Case {
-                name: "all three present",
-                query: "utm_source=google&utm_medium=cpc&utm_campaign=spring_launch",
+                name: "all five present",
+                query: "utm_source=google&utm_medium=cpc&utm_campaign=spring_launch\
+                        &utm_term=running_shoes&utm_content=hero_blue",
                 want_source: Some("google"),
                 want_medium: Some("cpc"),
                 want_campaign: Some("spring_launch"),
+                want_term: Some("running_shoes"),
+                want_content: Some("hero_blue"),
             },
             Case {
                 name: "case folded values merge",
-                query: "utm_source=Google&utm_medium=EMAIL",
+                query: "utm_source=Google&utm_medium=EMAIL&utm_term=RUNNING&utm_content=HERO",
                 want_source: Some("google"),
                 want_medium: Some("email"),
                 want_campaign: None,
+                want_term: Some("running"),
+                want_content: Some("hero"),
             },
             Case {
-                name: "case insensitive keys",
-                query: "UTM_SOURCE=twitter&Utm_Medium=social",
-                want_source: Some("twitter"),
-                want_medium: Some("social"),
+                name: "case insensitive keys for term and content",
+                query: "UTM_TERM=shoes&Utm_Content=Variant_A",
+                want_source: None,
+                want_medium: None,
                 want_campaign: None,
+                want_term: Some("shoes"),
+                want_content: Some("variant_a"),
             },
             Case {
                 name: "missing utm entirely",
@@ -636,6 +687,8 @@ mod tests {
                 want_source: None,
                 want_medium: None,
                 want_campaign: None,
+                want_term: None,
+                want_content: None,
             },
             Case {
                 name: "empty query",
@@ -643,56 +696,80 @@ mod tests {
                 want_source: None,
                 want_medium: None,
                 want_campaign: None,
+                want_term: None,
+                want_content: None,
             },
             Case {
                 name: "malformed pairs ignored",
-                query: "utm_source=reddit&brokenpair&utm_campaign=winter",
+                query: "utm_source=reddit&brokenpair&utm_campaign=winter&utm_term=brand",
                 want_source: Some("reddit"),
                 want_medium: None,
                 want_campaign: Some("winter"),
+                want_term: Some("brand"),
+                want_content: None,
             },
             Case {
-                name: "empty value dropped",
-                query: "utm_source=&utm_campaign=  &utm_medium=email",
-                want_source: None,
-                want_medium: Some("email"),
+                name: "empty term and content dropped",
+                query: "utm_source=bing&utm_term=&utm_content=  &utm_medium=cpc",
+                want_source: Some("bing"),
+                want_medium: Some("cpc"),
                 want_campaign: None,
+                want_term: None,
+                want_content: None,
             },
             Case {
-                name: "utm_term and utm_content ignored",
+                name: "term and content captured alongside rest",
                 query: "utm_source=google&utm_term=shoes&utm_content=ad1",
                 want_source: Some("google"),
                 want_medium: None,
                 want_campaign: None,
+                want_term: Some("shoes"),
+                want_content: Some("ad1"),
             },
             Case {
-                name: "repeated key last wins",
-                query: "utm_source=a&utm_source=b",
-                want_source: Some("b"),
+                name: "repeated term last wins",
+                query: "utm_term=a&utm_term=b&utm_content=c&utm_content=d",
+                want_source: None,
                 want_medium: None,
                 want_campaign: None,
+                want_term: Some("b"),
+                want_content: Some("d"),
             },
         ];
         for c in cases {
-            let (s, m, cp) = extract_utm_params(c.query);
+            let got = extract_utm_params(c.query);
             assert_eq!(
-                s.as_deref(),
+                got.source.as_deref(),
                 c.want_source,
                 "{}: source mismatch for {:?}",
                 c.name,
                 c.query
             );
             assert_eq!(
-                m.as_deref(),
+                got.medium.as_deref(),
                 c.want_medium,
                 "{}: medium mismatch for {:?}",
                 c.name,
                 c.query
             );
             assert_eq!(
-                cp.as_deref(),
+                got.campaign.as_deref(),
                 c.want_campaign,
                 "{}: campaign mismatch for {:?}",
+                c.name,
+                c.query
+            );
+            assert_eq!(
+                got.term.as_deref(),
+                c.want_term,
+                "{}: term mismatch for {:?}",
+                c.name,
+                c.query
+            );
+            assert_eq!(
+                got.content.as_deref(),
+                c.want_content,
+                "{}: content mismatch for {:?}",
                 c.name,
                 c.query
             );
@@ -701,14 +778,16 @@ mod tests {
 
     #[test]
     fn extract_utm_params_drops_oversized_values() {
-        // Adversarial ballast: source value exceeds UTM_VALUE_MAX_LEN so
-        // the key survives the parse but the value is dropped to keep
-        // the bounded counter's key-space small.
+        // Adversarial ballast: term and content values exceed
+        // UTM_VALUE_MAX_LEN so the keys survive the parse but the
+        // values are dropped to keep the bounded counter's key-space
+        // small. Source stays populated as a control.
         let huge = "x".repeat(UTM_VALUE_MAX_LEN + 1);
-        let q = format!("utm_source={huge}&utm_medium=cpc");
-        let (source, medium, _) = extract_utm_params(&q);
-        assert!(source.is_none(), "oversized source must be dropped");
-        assert_eq!(medium.as_deref(), Some("cpc"));
+        let q = format!("utm_source=google&utm_term={huge}&utm_content={huge}");
+        let got = extract_utm_params(&q);
+        assert_eq!(got.source.as_deref(), Some("google"));
+        assert!(got.term.is_none(), "oversized term must be dropped");
+        assert!(got.content.is_none(), "oversized content must be dropped");
     }
 
     #[test]
@@ -717,7 +796,11 @@ mod tests {
         let event = AggEvent {
             host: "example.com".into(),
             path: "/landing".into(),
-            query: Some("utm_source=Google&utm_medium=cpc&utm_campaign=Spring_2026".into()),
+            query: Some(
+                "utm_source=Google&utm_medium=cpc&utm_campaign=Spring_2026\
+                 &utm_term=Running+Shoes&utm_content=Hero_Blue"
+                    .into(),
+            ),
             status: 200,
             bytes_sent: 512,
             client_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
@@ -730,6 +813,8 @@ mod tests {
         assert_eq!(dm.utm_sources.top()[0].0, "google");
         assert_eq!(dm.utm_mediums.top()[0].0, "cpc");
         assert_eq!(dm.utm_campaigns.top()[0].0, "spring_2026");
+        assert_eq!(dm.utm_terms.top()[0].0, "running+shoes");
+        assert_eq!(dm.utm_contents.top()[0].0, "hero_blue");
     }
 
     #[test]
@@ -751,5 +836,7 @@ mod tests {
         assert!(dm.utm_sources.is_empty());
         assert!(dm.utm_mediums.is_empty());
         assert!(dm.utm_campaigns.is_empty());
+        assert!(dm.utm_terms.is_empty());
+        assert!(dm.utm_contents.is_empty());
     }
 }

--- a/crates/dwaar-analytics/src/aggregation/service.rs
+++ b/crates/dwaar-analytics/src/aggregation/service.rs
@@ -247,12 +247,16 @@ struct FlushSnapshot {
     /// [`crate::sink::DomainMetricsSnapshot::devices`] — same data,
     /// different wire format (stdout-legacy JSON vs socket sink).
     devices: Vec<DeviceCount>,
-    /// Top-N UTM source / medium / campaign counters. Mirrors the socket
+    /// Top-N UTM counters across all five dimensions. Mirrors the socket
     /// sink so consumers tailing the stdout legacy path see the same
-    /// attribution numbers as the agent does. Lowercased at ingest.
+    /// attribution numbers as the agent does. Lowercased at ingest;
+    /// term/content are bounded tighter than source/medium/campaign
+    /// (see `TOP_UTM_TERMS_N` / `TOP_UTM_CONTENTS_N`).
     utm_sources: Vec<UtmCount>,
     utm_mediums: Vec<UtmCount>,
     utm_campaigns: Vec<UtmCount>,
+    utm_terms: Vec<UtmCount>,
+    utm_contents: Vec<UtmCount>,
     /// HTTP status classes (1xx..5xx) emitted in order with zero counts
     /// included. Sibling of [`crate::sink::DomainMetricsSnapshot::status_classes`].
     status_classes: Vec<StatusClassCount>,
@@ -286,10 +290,10 @@ struct DeviceCount {
 }
 
 /// One UTM attribution entry for the stdout-legacy flush. Field name
-/// is deliberately generic (`value`) so a single struct handles
-/// `utm_source`, `utm_medium`, and `utm_campaign` without three
-/// near-identical types; the owning field on `FlushSnapshot` carries
-/// the dimension.
+/// is deliberately generic (`value`) so a single struct handles all
+/// five UTM dimensions (`utm_source`, `utm_medium`, `utm_campaign`,
+/// `utm_term`, `utm_content`) without five near-identical types; the
+/// owning field on `FlushSnapshot` carries the dimension.
 #[derive(Debug, Serialize)]
 struct UtmCount {
     value: String,
@@ -379,6 +383,18 @@ impl FlushSnapshot {
                 .collect(),
             utm_campaigns: m
                 .utm_campaigns
+                .top()
+                .into_iter()
+                .map(|(value, count)| UtmCount { value, count })
+                .collect(),
+            utm_terms: m
+                .utm_terms
+                .top()
+                .into_iter()
+                .map(|(value, count)| UtmCount { value, count })
+                .collect(),
+            utm_contents: m
+                .utm_contents
                 .top()
                 .into_iter()
                 .map(|(value, count)| UtmCount { value, count })

--- a/crates/dwaar-analytics/src/aggregation/snapshot.rs
+++ b/crates/dwaar-analytics/src/aggregation/snapshot.rs
@@ -58,8 +58,9 @@ pub struct StatusClassEntry {
 }
 
 /// One UTM attribution entry for the Admin API. A single struct covers
-/// `utm_source`, `utm_medium`, and `utm_campaign` — the owning field
-/// on [`AnalyticsSnapshot`] carries the dimension.
+/// all five UTM dimensions (`utm_source`, `utm_medium`, `utm_campaign`,
+/// `utm_term`, `utm_content`) — the owning field on
+/// [`AnalyticsSnapshot`] carries the dimension.
 #[derive(Debug, Serialize)]
 pub struct UtmEntry {
     pub value: String,
@@ -109,11 +110,14 @@ pub struct AnalyticsSnapshot {
     /// stable label enumeration rather than a struct of fields.
     pub status_classes: Vec<StatusClassEntry>,
     /// Top-N UTM attribution counters. Lowercased and length-capped at
-    /// ingest; bounded at 50/20/50 respectively so the Admin API
-    /// response stays small regardless of traffic.
+    /// ingest; bounded at 50/20/50/25/25 respectively (term/content are
+    /// tighter because their value space is the most ad-hoc) so the
+    /// Admin API response stays small regardless of traffic.
     pub utm_sources: Vec<UtmEntry>,
     pub utm_mediums: Vec<UtmEntry>,
     pub utm_campaigns: Vec<UtmEntry>,
+    pub utm_terms: Vec<UtmEntry>,
+    pub utm_contents: Vec<UtmEntry>,
     pub bytes_sent: u64,
     pub web_vitals: VitalsSnapshot,
     /// Bot vs human pageview split. Cumulative since the last 60s
@@ -189,6 +193,18 @@ impl AnalyticsSnapshot {
             .into_iter()
             .map(|(value, count)| UtmEntry { value, count })
             .collect();
+        let utm_terms = m
+            .utm_terms
+            .top()
+            .into_iter()
+            .map(|(value, count)| UtmEntry { value, count })
+            .collect();
+        let utm_contents = m
+            .utm_contents
+            .top()
+            .into_iter()
+            .map(|(value, count)| UtmEntry { value, count })
+            .collect();
 
         let web_vitals = VitalsSnapshot {
             lcp: m.web_vitals.peek_lcp_percentiles(),
@@ -216,6 +232,8 @@ impl AnalyticsSnapshot {
             utm_sources,
             utm_mediums,
             utm_campaigns,
+            utm_terms,
+            utm_contents,
             bytes_sent: m.bytes_sent,
             web_vitals,
             bot_views: m.bot_views,

--- a/crates/dwaar-analytics/src/sink.rs
+++ b/crates/dwaar-analytics/src/sink.rs
@@ -54,6 +54,13 @@ pub struct DomainMetricsSnapshot {
     pub utm_mediums: Vec<(String, u64)>,
     /// Top-N UTM campaign values (e.g. `spring-launch-2026`).
     pub utm_campaigns: Vec<(String, u64)>,
+    /// Top-N UTM term values (e.g. `running_shoes`). Capped tighter than
+    /// source/medium/campaign (25 vs 50) because term carries the most
+    /// ad-hoc cardinality of any UTM dimension.
+    pub utm_terms: Vec<(String, u64)>,
+    /// Top-N UTM content values (e.g. `hero_blue`, `variant_a`). Same
+    /// tighter cap as `utm_terms` for the same cardinality reason.
+    pub utm_contents: Vec<(String, u64)>,
     /// HTTP status-class counts across the fixed 1xx..5xx enum, emitted
     /// in order with zero counts included so downstream heatmaps do not
     /// have to synthesize missing buckets. Sourced from the first five
@@ -81,6 +88,8 @@ impl DomainMetricsSnapshot {
             utm_sources: m.utm_sources.top(),
             utm_mediums: m.utm_mediums.top(),
             utm_campaigns: m.utm_campaigns.top(),
+            utm_terms: m.utm_terms.top(),
+            utm_contents: m.utm_contents.top(),
             status_classes: crate::aggregation::status_class_snapshot(&m.status_codes),
             status_codes: m.status_codes,
             bytes_sent: m.bytes_sent,
@@ -333,7 +342,10 @@ mod tests {
         let events = [
             (
                 200,
-                Some("utm_source=Google&utm_medium=cpc&utm_campaign=Spring_2026"),
+                Some(
+                    "utm_source=Google&utm_medium=cpc&utm_campaign=Spring_2026\
+                     &utm_term=Running&utm_content=Hero_Blue",
+                ),
             ),
             (201, None),
             (404, None),
@@ -364,6 +376,10 @@ mod tests {
         let campaigns: std::collections::HashMap<_, _> =
             snap.utm_campaigns.iter().cloned().collect();
         assert_eq!(campaigns.get("spring_2026").copied(), Some(1));
+        let terms: std::collections::HashMap<_, _> = snap.utm_terms.iter().cloned().collect();
+        assert_eq!(terms.get("running").copied(), Some(1));
+        let contents: std::collections::HashMap<_, _> = snap.utm_contents.iter().cloned().collect();
+        assert_eq!(contents.get("hero_blue").copied(), Some(1));
 
         // Status classes: always all 5 labels present, in order.
         assert_eq!(snap.status_classes.len(), 5);
@@ -396,6 +412,8 @@ mod tests {
         assert!(snap.utm_sources.is_empty());
         assert!(snap.utm_mediums.is_empty());
         assert!(snap.utm_campaigns.is_empty());
+        assert!(snap.utm_terms.is_empty());
+        assert!(snap.utm_contents.is_empty());
     }
 
     #[test]

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.3.4"
+version = "0.3.5"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false


### PR DESCRIPTION
## Summary

Completes UTM parameter coverage by emitting `utm_term` and `utm_content` alongside the existing source/medium/campaign labels shipped in #210. Term and content are capped tighter (25 vs 50) because their real-world value space (ad-network keyword bids, A/B creative identifiers) is the most ad-hoc of the five UTM dimensions — cardinality containment via a smaller bounded counter is the primary mitigation for shipping them at all.

## Changes

- `DomainMetrics` gains `utm_terms: BoundedCounter<25>` and `utm_contents: BoundedCounter<25>`.
- `extract_utm_params()` returns a `UtmParams` struct (replacing the 3-tuple) with all five fields; case-folding + trim + length-cap policy unchanged.
- Snapshot surface updated across all three sink types: `DomainMetricsSnapshot` (socket sink), `FlushSnapshot` (stdout legacy), `AnalyticsSnapshot` (Admin API).
- Benchmark updated to cycle term/content across the tighter 25-cap counter so the hot-path cost is measured end-to-end.
- Patch bump `dwaar-cli` `0.3.4 → 0.3.5` (+ LICENSE version string) per `feedback_dwaar_version_bump`.

## Constraints held

- Zero new crate dependencies.
- Existing 25-cap guardrail on term/content is preserved (not raised).
- Extraction parser stays simple (no percent-decoding, no new deps) — consistent with the #210 cut.

## Test plan

- [x] Table-driven `extract_utm_params_table_driven` extended to exercise term/content happy path, case-folding, case-insensitive keys, empty/missing, malformed pairs, length cap, repeated-key last-wins.
- [x] `extract_utm_params_drops_oversized_values` now verifies term/content are dropped alongside source.
- [x] `ingest_log_extracts_utm_into_bounded_counters` asserts all five counters populate from a single query string.
- [x] `ingest_log_without_query_leaves_utm_counters_empty` asserts term/content stay empty when no query is present.
- [x] `DomainMetricsSnapshot` + `AnalyticsSnapshot` + `FlushSnapshot` all surface the two new fields (verified via updated sink tests).
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo test -p dwaar-analytics -p dwaar-admin -p dwaar-core` — 196 + admin/core tests pass.

## Companion PR

Deploy side: https://github.com/permanu/Deploy (PR created immediately after this one) consumes the new `utm_terms` / `utm_contents` proto fields and fans them out to VictoriaMetrics as `deploy_analytics_utm_term_views` / `deploy_analytics_utm_content_views`.

## Follow-ups

- Tech lead to cut `v0.3.5` tag post-merge so the installer auto-update path picks up the new release.