### PR TITLE
fix(ci): install protoc in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,18 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      # protoc is required by dwaar-grpc's build.rs (prost-build).
+      # ubuntu-latest runners don't ship it preinstalled; install on both
+      # platforms so the release is reproducible regardless of runner image.
+      - name: Install protoc (Linux)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+      - name: Install protoc (macOS)
+        if: startsWith(matrix.os, 'macos')
+        run: brew install protobuf
+
       - name: Install cross-compilation tools
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |


### PR DESCRIPTION
Release builds fail because dwaar-grpc's build.rs calls prost-build which needs protoc. Install it on Linux (apt) and macOS (brew) before cargo build. Unblocks v0.3.4 and v0.3.5 releases.