### PR TITLE
feat(analytics): response-latency bucket histogram + v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6] - 2026-04-18
+
+### Added
+
+- **Response-latency bucket histogram** — on every request,
+  `DomainMetrics` now records the server-observed response latency in a
+  fixed ten-bucket histogram (`BucketHistogram`). Edges in milliseconds:
+  `[10, 50, 100, 250, 500, 1000, 2500, 5000, 10000, +Inf]`. Cardinality
+  is bounded at ten labels by construction, so downstream VictoriaMetrics
+  fan-out is capped at `10 × domains` regardless of traffic volume.
+- **`response_latency_buckets` on every analytics snapshot** — the
+  histogram surfaces on `DomainMetricsSnapshot` (socket sink),
+  `FlushSnapshot` (stdout-legacy), and `AnalyticsSnapshot` (Admin API)
+  in the same `(le_label, count)` shape so consumers can parse any of
+  the three paths with one decoder. Always emitted in order with zero
+  counts included — downstream heatmaps key on a stable label axis.
+- **Window-delta semantics** — the histogram is zeroed by `flush()`
+  after serialisation, matching the existing `status_codes` /
+  `bytes_sent` / bot-vs-human per-window reset discipline so operators
+  reading the flushed stream see deltas across windows rather than a
+  perpetually growing lifetime total.
+
+### Changed
+
+- `AggEvent` gains a `response_latency_us: u64` field so the proxy
+  hot-path can propagate the already-measured `response_time_us` into
+  the analytics aggregator without duplicating the clock read. The
+  microsecond unit matches `RequestLog::response_time_us` verbatim.
+
 ## [0.3.3] - 2026-04-17
 
 Wheel #2 Weeks 4–5 — proxy hot-path integration and server-initiated event

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-cli"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.3.5
+Licensed Work:        Dwaar 0.3.6
                       The Licensed Work is
                       (c) 2026 Permanu
 

--- a/crates/dwaar-admin/src/handlers.rs
+++ b/crates/dwaar-admin/src/handlers.rs
@@ -303,6 +303,7 @@ mod tests {
             referer: None,
             user_agent: None,
             is_bot: false,
+            response_latency_us: 0,
         });
         map.insert("test.example.com".to_string(), dm);
         map

--- a/crates/dwaar-analytics/benches/aggregation.rs
+++ b/crates/dwaar-analytics/benches/aggregation.rs
@@ -67,6 +67,10 @@ fn sample_event(i: u32) -> AggEvent {
         },
         user_agent: Some(UAS[i as usize % UAS.len()].into()),
         is_bot: i.is_multiple_of(7),
+        // Vary latency across the full bucket range so the benchmark
+        // exercises the partition_point lookup across every bucket
+        // rather than pinning all observations to one slot.
+        response_latency_us: u64::from(i % 20_000) * 1_000,
     }
 }
 

--- a/crates/dwaar-analytics/src/aggregation/latency_histogram.rs
+++ b/crates/dwaar-analytics/src/aggregation/latency_histogram.rs
@@ -9,15 +9,15 @@
 //! Each request's server-observed response time lands in one of ten
 //! cumulative buckets (edges in milliseconds). The bucket edges are
 //! deliberately static — the same ten labels emit across every flush
-//! so the downstream heatmap keys on a stable axis and VictoriaMetrics
+//! so the downstream heatmap keys on a stable axis and `VictoriaMetrics`
 //! cardinality is bounded at `10 × domains` regardless of traffic.
 //!
-//! # Why fixed edges, not a TDigest
+//! # Why fixed edges, not a `TDigest`
 //!
-//! [`crate::aggregation::web_vitals::WebVitals`] already uses TDigest
+//! [`crate::aggregation::web_vitals::WebVitals`] already uses `TDigest`
 //! for LCP/CLS/INP because those feeds only care about p75. Request
 //! latency additionally needs a heatmap-friendly shape (distribution
-//! over time), and TDigest percentiles don't serialise cleanly into
+//! over time), and `TDigest` percentiles don't serialise cleanly into
 //! heatmap-cell buckets. A fixed histogram keeps the wire format
 //! compact (ten `(le, count)` pairs) and lets the frontend render
 //! the heatmap with no additional bucketing work.
@@ -149,21 +149,66 @@ mod tests {
             expected_bucket: usize,
         }
         let cases = [
-            Case { latency_ms: 0, expected_bucket: 0 },     // sub-10ms
-            Case { latency_ms: 5, expected_bucket: 0 },     // sub-10ms
-            Case { latency_ms: 10, expected_bucket: 0 },    // = 10ms edge → first bucket
-            Case { latency_ms: 11, expected_bucket: 1 },    // 10–50ms
-            Case { latency_ms: 50, expected_bucket: 1 },    // = 50ms edge
-            Case { latency_ms: 99, expected_bucket: 2 },    // 50–100ms
-            Case { latency_ms: 200, expected_bucket: 3 },   // 100–250ms
-            Case { latency_ms: 400, expected_bucket: 4 },   // 250–500ms
-            Case { latency_ms: 999, expected_bucket: 5 },   // 500–1000ms
-            Case { latency_ms: 1500, expected_bucket: 6 },  // 1000–2500ms
-            Case { latency_ms: 4000, expected_bucket: 7 },  // 2500–5000ms
-            Case { latency_ms: 7500, expected_bucket: 8 },  // 5000–10000ms
-            Case { latency_ms: 10_000, expected_bucket: 8 }, // = 10 s edge
-            Case { latency_ms: 15_000, expected_bucket: 9 }, // +Inf
-            Case { latency_ms: u64::MAX, expected_bucket: 9 }, // +Inf
+            Case {
+                latency_ms: 0,
+                expected_bucket: 0,
+            }, // sub-10ms
+            Case {
+                latency_ms: 5,
+                expected_bucket: 0,
+            }, // sub-10ms
+            Case {
+                latency_ms: 10,
+                expected_bucket: 0,
+            }, // = 10ms edge → first bucket
+            Case {
+                latency_ms: 11,
+                expected_bucket: 1,
+            }, // 10–50ms
+            Case {
+                latency_ms: 50,
+                expected_bucket: 1,
+            }, // = 50ms edge
+            Case {
+                latency_ms: 99,
+                expected_bucket: 2,
+            }, // 50–100ms
+            Case {
+                latency_ms: 200,
+                expected_bucket: 3,
+            }, // 100–250ms
+            Case {
+                latency_ms: 400,
+                expected_bucket: 4,
+            }, // 250–500ms
+            Case {
+                latency_ms: 999,
+                expected_bucket: 5,
+            }, // 500–1000ms
+            Case {
+                latency_ms: 1500,
+                expected_bucket: 6,
+            }, // 1000–2500ms
+            Case {
+                latency_ms: 4000,
+                expected_bucket: 7,
+            }, // 2500–5000ms
+            Case {
+                latency_ms: 7500,
+                expected_bucket: 8,
+            }, // 5000–10000ms
+            Case {
+                latency_ms: 10_000,
+                expected_bucket: 8,
+            }, // = 10 s edge
+            Case {
+                latency_ms: 15_000,
+                expected_bucket: 9,
+            }, // +Inf
+            Case {
+                latency_ms: u64::MAX,
+                expected_bucket: 9,
+            }, // +Inf
         ];
         for c in cases {
             let mut h = BucketHistogram::new();
@@ -194,7 +239,9 @@ mod tests {
         let labels: Vec<_> = snap.iter().map(|(l, _)| l.as_str()).collect();
         assert_eq!(
             labels,
-            vec!["10", "50", "100", "250", "500", "1000", "2500", "5000", "10000", "+Inf"]
+            vec![
+                "10", "50", "100", "250", "500", "1000", "2500", "5000", "10000", "+Inf"
+            ]
         );
 
         // Counts follow the label order.

--- a/crates/dwaar-analytics/src/aggregation/latency_histogram.rs
+++ b/crates/dwaar-analytics/src/aggregation/latency_histogram.rs
@@ -1,0 +1,227 @@
+// Copyright (C) 2026 Permanu
+// SPDX-License-Identifier: BSL-1.1
+//
+// This file is part of Dwaar — https://dwaar.dev
+// Licensed under the Business Source License 1.1
+
+//! Fixed-cardinality response-latency bucket histogram.
+//!
+//! Each request's server-observed response time lands in one of ten
+//! cumulative buckets (edges in milliseconds). The bucket edges are
+//! deliberately static — the same ten labels emit across every flush
+//! so the downstream heatmap keys on a stable axis and VictoriaMetrics
+//! cardinality is bounded at `10 × domains` regardless of traffic.
+//!
+//! # Why fixed edges, not a TDigest
+//!
+//! [`crate::aggregation::web_vitals::WebVitals`] already uses TDigest
+//! for LCP/CLS/INP because those feeds only care about p75. Request
+//! latency additionally needs a heatmap-friendly shape (distribution
+//! over time), and TDigest percentiles don't serialise cleanly into
+//! heatmap-cell buckets. A fixed histogram keeps the wire format
+//! compact (ten `(le, count)` pairs) and lets the frontend render
+//! the heatmap with no additional bucketing work.
+//!
+//! # Bucket edges
+//!
+//! The ten edges `[10, 50, 100, 250, 500, 1000, 2500, 5000, 10000, +Inf]`
+//! span from sub-10ms static hits through multi-second upstream calls.
+//! They match the default Prometheus histogram for HTTP duration and
+//! the shape operators already read when triaging latency incidents.
+
+use serde::Serialize;
+
+/// Bucket upper-bounds in milliseconds. The final `+Inf` bucket catches
+/// everything above 10 s so no request is ever dropped from the count.
+///
+/// Exposed as `&'static [&'static str]` for the snapshot path so no
+/// allocation happens per-flush — the labels are baked into the binary.
+pub const BUCKET_EDGES_MS: [u64; 9] = [10, 50, 100, 250, 500, 1000, 2500, 5000, 10000];
+
+/// Labels emitted on each bucket's `le` dimension. Matches the Prometheus
+/// convention of labelling the cumulative upper-bound with `+Inf` for
+/// the catch-all bucket. Kept as `&'static str` so the snapshot path
+/// copies a `String` only when producing wire output.
+pub const BUCKET_LABELS: [&str; 10] = [
+    "10", "50", "100", "250", "500", "1000", "2500", "5000", "10000", "+Inf",
+];
+
+/// Ten-bucket latency histogram. Cardinality is fixed at construction
+/// time so the memory footprint is 80 B per domain regardless of
+/// traffic volume (ten `u64` counts).
+///
+/// Counts are **non-cumulative** internally (one count per bucket),
+/// which keeps the increment path a single array write. The wire
+/// format emitted by [`Self::snapshot`] also uses non-cumulative
+/// counts — the heatmap renderer sums as needed; exposing cumulative
+/// counts here would force every consumer to undo the sum.
+#[derive(Debug, Clone, Default)]
+pub struct BucketHistogram {
+    counts: [u64; 10],
+}
+
+impl BucketHistogram {
+    /// Zeroed histogram. Equivalent to `Default::default()` — the
+    /// explicit constructor mirrors the other aggregation structs so
+    /// `DomainMetrics::new` reads consistently.
+    pub const fn new() -> Self {
+        Self { counts: [0; 10] }
+    }
+
+    /// Record one observation. `latency_ms` is the server-observed
+    /// response latency in milliseconds. Values above the last finite
+    /// edge land in the `+Inf` bucket so no request is ever dropped.
+    ///
+    /// Hot path: called once per request from the aggregation service.
+    /// The branch-free `partition_point` call runs in `O(log n)` over
+    /// the ten edges — an unmeasurable cost next to the `DashMap`
+    /// lookup that guards it.
+    pub fn record(&mut self, latency_ms: u64) {
+        // partition_point returns the index of the first edge strictly
+        // greater than latency_ms, which is also the bucket the
+        // observation belongs to. A latency equal to an edge (e.g. 50
+        // on the 50 ms edge) lands in the 100 ms bucket — matches the
+        // Prometheus-style `le` (less-than-or-equal) semantics where
+        // the edge is the inclusive upper-bound.
+        let idx = BUCKET_EDGES_MS.partition_point(|&edge| edge < latency_ms);
+        self.counts[idx] += 1;
+    }
+
+    /// Total observations across every bucket. Primarily a test helper,
+    /// but also useful as a sanity check in downstream consumers that
+    /// want to derive a denominator for percentile-like calculations.
+    pub fn total(&self) -> u64 {
+        self.counts.iter().sum()
+    }
+
+    /// Non-cumulative counts, bucket-index-aligned with
+    /// [`BUCKET_LABELS`]. Primarily exposed for tests; production code
+    /// should use [`Self::snapshot`] which attaches the label strings.
+    pub fn counts(&self) -> &[u64; 10] {
+        &self.counts
+    }
+
+    /// Per-bucket `(label, count)` wire snapshot, always emitted in
+    /// order with zero counts included so the frontend heatmap keys
+    /// on a stable label set. Allocates one `String` per bucket
+    /// (ten heap allocations per flush per domain) — acceptable because
+    /// the flush cadence is 60 s.
+    pub fn snapshot(&self) -> Vec<(String, u64)> {
+        BUCKET_LABELS
+            .iter()
+            .zip(self.counts.iter())
+            .map(|(label, count)| ((*label).to_string(), *count))
+            .collect()
+    }
+}
+
+/// Serde-friendly single-bucket entry. Matches the per-dimension entry
+/// types used elsewhere in the snapshot (e.g. `StatusClassCount`) so
+/// the wire shape stays visually consistent across aggregations.
+#[derive(Debug, Clone, Serialize)]
+pub struct BucketCount {
+    /// Bucket upper-bound label. One of the ten `BUCKET_LABELS` values.
+    pub le: String,
+    /// Non-cumulative count of observations whose latency landed in
+    /// the half-open interval `(previous_edge, this_edge]`.
+    pub count: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_is_empty() {
+        let h = BucketHistogram::new();
+        assert_eq!(h.total(), 0);
+        assert_eq!(h.counts(), &[0u64; 10]);
+    }
+
+    #[test]
+    fn record_routes_each_edge_into_expected_bucket() {
+        // Table-driven: one observation per bucket, then assert the
+        // count lands in exactly the right slot. Also covers the
+        // inclusive-edge semantics (50 ms → second bucket because
+        // 50 is ≤ the 50 ms edge).
+        struct Case {
+            latency_ms: u64,
+            expected_bucket: usize,
+        }
+        let cases = [
+            Case { latency_ms: 0, expected_bucket: 0 },     // sub-10ms
+            Case { latency_ms: 5, expected_bucket: 0 },     // sub-10ms
+            Case { latency_ms: 10, expected_bucket: 0 },    // = 10ms edge → first bucket
+            Case { latency_ms: 11, expected_bucket: 1 },    // 10–50ms
+            Case { latency_ms: 50, expected_bucket: 1 },    // = 50ms edge
+            Case { latency_ms: 99, expected_bucket: 2 },    // 50–100ms
+            Case { latency_ms: 200, expected_bucket: 3 },   // 100–250ms
+            Case { latency_ms: 400, expected_bucket: 4 },   // 250–500ms
+            Case { latency_ms: 999, expected_bucket: 5 },   // 500–1000ms
+            Case { latency_ms: 1500, expected_bucket: 6 },  // 1000–2500ms
+            Case { latency_ms: 4000, expected_bucket: 7 },  // 2500–5000ms
+            Case { latency_ms: 7500, expected_bucket: 8 },  // 5000–10000ms
+            Case { latency_ms: 10_000, expected_bucket: 8 }, // = 10 s edge
+            Case { latency_ms: 15_000, expected_bucket: 9 }, // +Inf
+            Case { latency_ms: u64::MAX, expected_bucket: 9 }, // +Inf
+        ];
+        for c in cases {
+            let mut h = BucketHistogram::new();
+            h.record(c.latency_ms);
+            assert_eq!(
+                h.counts()[c.expected_bucket],
+                1,
+                "latency {} ms should land in bucket {}",
+                c.latency_ms,
+                c.expected_bucket
+            );
+            assert_eq!(h.total(), 1);
+        }
+    }
+
+    #[test]
+    fn snapshot_is_stable_and_labeled() {
+        let mut h = BucketHistogram::new();
+        h.record(5); // bucket 0
+        h.record(60); // bucket 2
+        h.record(60); // bucket 2
+        h.record(20_000); // bucket 9 (+Inf)
+
+        let snap = h.snapshot();
+        assert_eq!(snap.len(), 10, "ten buckets always emitted");
+
+        // Labels must appear in the fixed order so the heatmap axis stays stable.
+        let labels: Vec<_> = snap.iter().map(|(l, _)| l.as_str()).collect();
+        assert_eq!(
+            labels,
+            vec!["10", "50", "100", "250", "500", "1000", "2500", "5000", "10000", "+Inf"]
+        );
+
+        // Counts follow the label order.
+        let counts: Vec<_> = snap.iter().map(|(_, c)| *c).collect();
+        assert_eq!(counts, vec![1, 0, 2, 0, 0, 0, 0, 0, 0, 1]);
+    }
+
+    #[test]
+    fn snapshot_emits_zeroes_when_empty() {
+        // Downstream heatmap relies on every bucket being present even
+        // when no traffic has landed; otherwise an empty dashboard
+        // column could be mistaken for missing data rather than zero.
+        let h = BucketHistogram::new();
+        let snap = h.snapshot();
+        assert_eq!(snap.len(), 10);
+        for (_, count) in &snap {
+            assert_eq!(*count, 0);
+        }
+    }
+
+    #[test]
+    fn record_accumulates_across_many_observations() {
+        let mut h = BucketHistogram::new();
+        for _ in 0..1_000 {
+            h.record(15); // always bucket 1 (10–50ms)
+        }
+        assert_eq!(h.counts()[1], 1_000);
+        assert_eq!(h.total(), 1_000);
+    }
+}

--- a/crates/dwaar-analytics/src/aggregation/mod.rs
+++ b/crates/dwaar-analytics/src/aggregation/mod.rs
@@ -11,6 +11,7 @@
 //! consumes both channels and flushes snapshots every 60 seconds.
 
 pub mod bounded_counter;
+pub mod latency_histogram;
 pub mod minute_buckets;
 pub mod service;
 pub mod snapshot;
@@ -24,6 +25,7 @@ use tokio::sync::mpsc;
 use tracing::warn;
 
 use self::bounded_counter::BoundedCounter;
+use self::latency_histogram::BucketHistogram;
 use self::minute_buckets::MinuteBuckets;
 use self::top_k::TopK;
 use self::web_vitals::WebVitals;
@@ -58,6 +60,14 @@ pub struct AggEvent {
     /// propagated so the aggregation snapshot can surface bot-vs-human
     /// pageview ratios. Default `false` is treated as a human request.
     pub is_bot: bool,
+    /// Server-observed end-to-end response latency in microseconds,
+    /// measured from the start of request handling to the end of the
+    /// response body on the Pingora side. Used by
+    /// [`DomainMetrics::ingest_log`] to bucket the request into the
+    /// fixed [`latency_histogram::BucketHistogram`]. The microsecond
+    /// unit matches [`dwaar_log::RequestLog::response_time_us`] so the
+    /// proxy site can pass the same value into both without conversion.
+    pub response_latency_us: u64,
 }
 const TOP_PAGES_K: usize = 100;
 const TOP_REFERRERS_N: usize = 50;
@@ -148,6 +158,14 @@ pub struct DomainMetrics {
     /// separate time-windowed structure.
     pub bot_views: u64,
     pub human_views: u64,
+    /// Fixed ten-bucket histogram of server-observed response latency.
+    /// Edges: `[10, 50, 100, 250, 500, 1000, 2500, 5000, 10000, +Inf]`
+    /// (milliseconds). Cardinality is bounded at construction time so
+    /// the per-domain memory footprint is 80 B regardless of traffic.
+    /// Surfaced on every snapshot as `response_latency_buckets:
+    /// Vec<(le, count)>` — see [`latency_histogram::BucketHistogram`]
+    /// for the bucketing rationale.
+    pub response_latency_buckets: BucketHistogram,
 }
 
 impl DomainMetrics {
@@ -169,6 +187,7 @@ impl DomainMetrics {
             web_vitals: WebVitals::new(),
             bot_views: 0,
             human_views: 0,
+            response_latency_buckets: BucketHistogram::new(),
         }
     }
 
@@ -185,6 +204,13 @@ impl DomainMetrics {
         self.top_pages.insert(event.path.to_string());
         self.status_codes[status_bucket(event.status)] += 1;
         self.bytes_sent += event.bytes_sent;
+        // Convert microseconds (the unit carried on `AggEvent` and
+        // `RequestLog`) to milliseconds for the latency histogram.
+        // Integer division floors — sub-millisecond responses land in
+        // the `10` bucket alongside true sub-10ms observations, which
+        // matches the Prometheus convention for the smallest `le`.
+        self.response_latency_buckets
+            .record(event.response_latency_us / 1000);
         // Split bot vs human counters from the bot-detect classification.
         if event.is_bot {
             self.bot_views += 1;
@@ -498,6 +524,7 @@ mod tests {
             referer: None,
             user_agent: None,
             is_bot: false,
+            response_latency_us: 0,
         };
         // Should not panic — drops silently when full
         for _ in 0..10_000 {
@@ -554,6 +581,7 @@ mod tests {
                 "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Mobile/15E148".into(),
             ),
             is_bot: false,
+            response_latency_us: 0,
         };
         dm.ingest_log(&event);
 
@@ -630,6 +658,7 @@ mod tests {
             referer: None,
             user_agent: None,
             is_bot: false,
+            response_latency_us: 0,
         };
         dm.ingest_log(&event);
         assert_eq!(dm.devices.top()[0].0, "unknown");
@@ -808,6 +837,7 @@ mod tests {
             referer: None,
             user_agent: None,
             is_bot: false,
+            response_latency_us: 0,
         };
         dm.ingest_log(&event);
         assert_eq!(dm.utm_sources.top()[0].0, "google");
@@ -831,6 +861,7 @@ mod tests {
             referer: None,
             user_agent: None,
             is_bot: false,
+            response_latency_us: 0,
         };
         dm.ingest_log(&event);
         assert!(dm.utm_sources.is_empty());
@@ -838,5 +869,38 @@ mod tests {
         assert!(dm.utm_campaigns.is_empty());
         assert!(dm.utm_terms.is_empty());
         assert!(dm.utm_contents.is_empty());
+    }
+
+    #[test]
+    fn ingest_log_buckets_response_latency() {
+        // Three requests landing in three distinct latency buckets so
+        // we can assert the histogram surfaces the distribution end-to-end
+        // via `ingest_log` (the production path) rather than only via
+        // the unit tests on `BucketHistogram` in isolation.
+        let mut dm = DomainMetrics::new();
+        let latencies_us = [5_000u64, 80_000, 3_000_000]; // 5ms, 80ms, 3 s
+        for (i, latency) in latencies_us.iter().enumerate() {
+            dm.ingest_log(&AggEvent {
+                host: "example.com".into(),
+                path: "/api".into(),
+                query: None,
+                status: 200,
+                bytes_sent: 128,
+                client_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, i as u8 + 1)),
+                country: None,
+                referer: None,
+                user_agent: None,
+                is_bot: false,
+                response_latency_us: *latency,
+            });
+        }
+
+        // 5 ms → bucket 0 (le=10), 80 ms → bucket 2 (le=100),
+        // 3 s → bucket 7 (le=5000).
+        let counts = dm.response_latency_buckets.counts();
+        assert_eq!(counts[0], 1, "5ms observation in 10ms bucket");
+        assert_eq!(counts[2], 1, "80ms observation in 100ms bucket");
+        assert_eq!(counts[7], 1, "3s observation in 5000ms bucket");
+        assert_eq!(dm.response_latency_buckets.total(), 3);
     }
 }

--- a/crates/dwaar-analytics/src/aggregation/service.rs
+++ b/crates/dwaar-analytics/src/aggregation/service.rs
@@ -155,6 +155,14 @@ impl<RT: RouteValidator> AggregationService<RT> {
             metrics.bytes_sent = 0;
             metrics.bot_views = 0;
             metrics.human_views = 0;
+            // Same per-window semantics as the other cumulative counters:
+            // the flush snapshot reports the delta for this window, so
+            // we zero the histogram after serialising it. Without this,
+            // every flush would report a lifetime total while the status
+            // counters next to it would show a window delta — operators
+            // would read the two side-by-side and get conflicting stories.
+            metrics.response_latency_buckets =
+                super::latency_histogram::BucketHistogram::new();
         }
         if let Err(e) = handle.flush() {
             warn!(error = %e, "failed to flush stdout");
@@ -260,6 +268,13 @@ struct FlushSnapshot {
     /// HTTP status classes (1xx..5xx) emitted in order with zero counts
     /// included. Sibling of [`crate::sink::DomainMetricsSnapshot::status_classes`].
     status_classes: Vec<StatusClassCount>,
+    /// Server-observed response-latency histogram across ten fixed
+    /// buckets (edges `[10, 50, 100, 250, 500, 1000, 2500, 5000, 10000,
+    /// +Inf]` milliseconds). Sibling of
+    /// [`crate::sink::DomainMetricsSnapshot::response_latency_buckets`]
+    /// — same data, different wire format (stdout-legacy JSON vs socket
+    /// sink). Always emitted in order with zero counts included.
+    response_latency_buckets: Vec<LatencyBucketCount>,
     status_codes: StatusCodes,
     bytes_sent: u64,
     web_vitals: VitalsSnapshot,
@@ -303,6 +318,16 @@ struct UtmCount {
 #[derive(Debug, Serialize)]
 struct StatusClassCount {
     class: String,
+    count: u64,
+}
+
+/// One response-latency histogram bucket entry for the stdout-legacy
+/// flush. `le` is the bucket upper-bound label (`"10"` … `"10000"` or
+/// `"+Inf"`). Structure mirrors the socket-sink wire format so
+/// consumers can parse both paths with the same shape.
+#[derive(Debug, Serialize)]
+struct LatencyBucketCount {
+    le: String,
     count: u64,
 }
 
@@ -403,6 +428,12 @@ impl FlushSnapshot {
                 .into_iter()
                 .map(|(class, count)| StatusClassCount { class, count })
                 .collect(),
+            response_latency_buckets: m
+                .response_latency_buckets
+                .snapshot()
+                .into_iter()
+                .map(|(le, count)| LatencyBucketCount { le, count })
+                .collect(),
             status_codes: StatusCodes {
                 s1xx: m.status_codes[0],
                 s2xx: m.status_codes[1],
@@ -453,6 +484,7 @@ mod tests {
                     .into(),
             ),
             is_bot: false,
+            response_latency_us: 0,
         }
     }
 
@@ -604,6 +636,51 @@ mod tests {
 
         shutdown_tx.send(true).expect("shutdown send");
         tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    #[test]
+    fn flush_resets_response_latency_buckets() {
+        // Per-window semantics: the flush snapshot reports the delta
+        // for this window, so the histogram must zero out after the
+        // flush just like status_codes and bytes_sent already do.
+        let domains: HashSet<String> = ["lat.test".into()].into();
+        let (_beacon_tx, beacon_rx) = mpsc::channel(1);
+        let (_log_tx, log_rx) = mpsc::channel(1);
+        let metrics = Arc::new(DashMap::new());
+        let svc = AggregationService::new(
+            Arc::clone(&metrics),
+            TestValidator(domains),
+            beacon_rx,
+            AggReceiver { rx: log_rx },
+        );
+
+        // Ingest two requests with distinct latencies so the histogram
+        // is populated before the flush.
+        let mut ev1 = test_event("lat.test", "/", 200);
+        ev1.response_latency_us = 25_000; // 25ms → bucket 1 (le=50)
+        svc.ingest_log(&ev1);
+        let mut ev2 = test_event("lat.test", "/", 200);
+        ev2.response_latency_us = 750_000; // 750ms → bucket 5 (le=1000)
+        svc.ingest_log(&ev2);
+
+        {
+            let entry = metrics.get("lat.test").expect("domain");
+            assert_eq!(entry.response_latency_buckets.total(), 2);
+        }
+
+        svc.flush();
+
+        {
+            let entry = metrics.get("lat.test").expect("domain");
+            assert_eq!(
+                entry.response_latency_buckets.total(),
+                0,
+                "flush must zero the histogram so next window reports a delta"
+            );
+            for count in entry.response_latency_buckets.counts() {
+                assert_eq!(*count, 0);
+            }
+        }
     }
 
     #[test]

--- a/crates/dwaar-analytics/src/aggregation/service.rs
+++ b/crates/dwaar-analytics/src/aggregation/service.rs
@@ -161,8 +161,7 @@ impl<RT: RouteValidator> AggregationService<RT> {
             // every flush would report a lifetime total while the status
             // counters next to it would show a window delta — operators
             // would read the two side-by-side and get conflicting stories.
-            metrics.response_latency_buckets =
-                super::latency_histogram::BucketHistogram::new();
+            metrics.response_latency_buckets = super::latency_histogram::BucketHistogram::new();
         }
         if let Err(e) = handle.flush() {
             warn!(error = %e, "failed to flush stdout");

--- a/crates/dwaar-analytics/src/aggregation/snapshot.rs
+++ b/crates/dwaar-analytics/src/aggregation/snapshot.rs
@@ -67,6 +67,17 @@ pub struct UtmEntry {
     pub count: u64,
 }
 
+/// One response-latency histogram bucket entry for the Admin API. `le`
+/// is the bucket upper-bound label (`"10"` … `"10000"` or `"+Inf"`);
+/// `count` is the non-cumulative observation count that landed in
+/// `(previous_edge, le]`. Always emitted in order across all ten
+/// buckets so downstream heatmaps key on a stable axis.
+#[derive(Debug, Serialize)]
+pub struct LatencyBucketEntry {
+    pub le: String,
+    pub count: u64,
+}
+
 /// Percentile snapshot for LCP, CLS, and INP Web Vitals.
 ///
 /// Read via `peek_*_percentiles` — intentionally does not flush the
@@ -118,6 +129,14 @@ pub struct AnalyticsSnapshot {
     pub utm_campaigns: Vec<UtmEntry>,
     pub utm_terms: Vec<UtmEntry>,
     pub utm_contents: Vec<UtmEntry>,
+    /// Server-observed response-latency histogram across ten fixed
+    /// buckets (edges `[10, 50, 100, 250, 500, 1000, 2500, 5000, 10000,
+    /// +Inf]` milliseconds). Always emitted in order with zero counts
+    /// included so the Admin API heatmap renders a stable axis without
+    /// gap-filling. Cardinality is bounded at ten labels by
+    /// construction — see
+    /// [`crate::aggregation::latency_histogram::BucketHistogram`].
+    pub response_latency_buckets: Vec<LatencyBucketEntry>,
     pub bytes_sent: u64,
     pub web_vitals: VitalsSnapshot,
     /// Bot vs human pageview split. Cumulative since the last 60s
@@ -205,6 +224,12 @@ impl AnalyticsSnapshot {
             .into_iter()
             .map(|(value, count)| UtmEntry { value, count })
             .collect();
+        let response_latency_buckets = m
+            .response_latency_buckets
+            .snapshot()
+            .into_iter()
+            .map(|(le, count)| LatencyBucketEntry { le, count })
+            .collect();
 
         let web_vitals = VitalsSnapshot {
             lcp: m.web_vitals.peek_lcp_percentiles(),
@@ -234,6 +259,7 @@ impl AnalyticsSnapshot {
             utm_campaigns,
             utm_terms,
             utm_contents,
+            response_latency_buckets,
             bytes_sent: m.bytes_sent,
             web_vitals,
             bot_views: m.bot_views,
@@ -266,6 +292,7 @@ mod tests {
                     .into(),
             ),
             is_bot: false,
+            response_latency_us: 0,
         }
     }
 

--- a/crates/dwaar-analytics/src/sink.rs
+++ b/crates/dwaar-analytics/src/sink.rs
@@ -66,6 +66,13 @@ pub struct DomainMetricsSnapshot {
     /// have to synthesize missing buckets. Sourced from the first five
     /// indices of [`crate::aggregation::DomainMetrics::status_codes`].
     pub status_classes: Vec<(String, u64)>,
+    /// Server-observed response-latency histogram across ten fixed
+    /// buckets (edges `[10, 50, 100, 250, 500, 1000, 2500, 5000, 10000,
+    /// +Inf]` milliseconds). Emitted as `(le_label, count)` pairs in
+    /// order with zero counts included so the downstream heatmap keys
+    /// on a stable axis. Cardinality is fixed at ten by construction —
+    /// see [`crate::aggregation::latency_histogram::BucketHistogram`].
+    pub response_latency_buckets: Vec<(String, u64)>,
     pub status_codes: [u64; 6],
     pub bytes_sent: u64,
     pub lcp: Percentiles,
@@ -91,6 +98,7 @@ impl DomainMetricsSnapshot {
             utm_terms: m.utm_terms.top(),
             utm_contents: m.utm_contents.top(),
             status_classes: crate::aggregation::status_class_snapshot(&m.status_codes),
+            response_latency_buckets: m.response_latency_buckets.snapshot(),
             status_codes: m.status_codes,
             bytes_sent: m.bytes_sent,
             lcp: m.web_vitals.peek_lcp_percentiles(),
@@ -304,6 +312,7 @@ mod tests {
                 referer: Some("https://news.ycombinator.com/".into()),
                 user_agent: Some((*ua).into()),
                 is_bot: false,
+                response_latency_us: 0,
             });
         }
 
@@ -363,6 +372,7 @@ mod tests {
                 referer: None,
                 user_agent: None,
                 is_bot: false,
+                response_latency_us: 0,
             });
         }
 
@@ -414,6 +424,62 @@ mod tests {
         assert!(snap.utm_campaigns.is_empty());
         assert!(snap.utm_terms.is_empty());
         assert!(snap.utm_contents.is_empty());
+    }
+
+    #[test]
+    fn snapshot_surfaces_response_latency_buckets() {
+        use crate::aggregation::AggEvent;
+        use std::net::{IpAddr, Ipv4Addr};
+
+        // Ingest three observations spanning three buckets so the
+        // surfaced snapshot exposes the histogram shape end-to-end
+        // (not just that the field exists on the wire).
+        let mut dm = DomainMetrics::new();
+        let latencies_us = [5_000u64, 80_000, 3_000_000];
+        for (i, latency) in latencies_us.iter().enumerate() {
+            dm.ingest_log(&AggEvent {
+                host: "test.example.com".into(),
+                path: "/".into(),
+                query: None,
+                status: 200,
+                bytes_sent: 0,
+                client_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, i as u8 + 1)),
+                country: None,
+                referer: None,
+                user_agent: None,
+                is_bot: false,
+                response_latency_us: *latency,
+            });
+        }
+
+        let snap = DomainMetricsSnapshot::from_metrics("test.example.com", &dm);
+        // All ten buckets always present, in order, with zero counts
+        // included so the frontend heatmap renders a stable axis.
+        assert_eq!(snap.response_latency_buckets.len(), 10);
+        let labels: Vec<_> = snap
+            .response_latency_buckets
+            .iter()
+            .map(|(l, _)| l.as_str())
+            .collect();
+        assert_eq!(
+            labels,
+            vec!["10", "50", "100", "250", "500", "1000", "2500", "5000", "10000", "+Inf"]
+        );
+        let counts: std::collections::HashMap<_, _> =
+            snap.response_latency_buckets.iter().cloned().collect();
+        assert_eq!(counts.get("10").copied(), Some(1));   // 5 ms
+        assert_eq!(counts.get("100").copied(), Some(1));  // 80 ms
+        assert_eq!(counts.get("5000").copied(), Some(1)); // 3 s
+        assert_eq!(counts.get("+Inf").copied(), Some(0));
+    }
+
+    #[test]
+    fn empty_metrics_emit_zero_response_latency_buckets() {
+        let snap = test_snapshot();
+        assert_eq!(snap.response_latency_buckets.len(), 10);
+        for (_, count) in &snap.response_latency_buckets {
+            assert_eq!(*count, 0);
+        }
     }
 
     #[test]

--- a/crates/dwaar-analytics/src/sink.rs
+++ b/crates/dwaar-analytics/src/sink.rs
@@ -463,12 +463,14 @@ mod tests {
             .collect();
         assert_eq!(
             labels,
-            vec!["10", "50", "100", "250", "500", "1000", "2500", "5000", "10000", "+Inf"]
+            vec![
+                "10", "50", "100", "250", "500", "1000", "2500", "5000", "10000", "+Inf"
+            ]
         );
         let counts: std::collections::HashMap<_, _> =
             snap.response_latency_buckets.iter().cloned().collect();
-        assert_eq!(counts.get("10").copied(), Some(1));   // 5 ms
-        assert_eq!(counts.get("100").copied(), Some(1));  // 80 ms
+        assert_eq!(counts.get("10").copied(), Some(1)); // 5 ms
+        assert_eq!(counts.get("100").copied(), Some(1)); // 80 ms
         assert_eq!(counts.get("5000").copied(), Some(1)); // 3 s
         assert_eq!(counts.get("+Inf").copied(), Some(0));
     }

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.3.5"
+version = "0.3.6"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -2312,6 +2312,11 @@ impl ProxyHttp for DwaarProxy {
                 // bot-detect plugin classifies the request on PluginCtx;
                 // the aggregator splits bot vs human counters in DomainMetrics.
                 is_bot: ctx.plugin_ctx.is_bot,
+                // Same value stored on `RequestLog::response_time_us` below —
+                // read once above and propagated to both paths so the log
+                // stream and the analytics histogram can never disagree on
+                // the per-request latency.
+                response_latency_us: response_time_us,
             };
             agg.send(event);
         }


### PR DESCRIPTION
## Summary

Dwaar half of the latency-histogram end-to-end. Per-request server-observed
response latency is now recorded into a fixed ten-bucket histogram on
\`DomainMetrics\` and surfaced on every snapshot as
\`response_latency_buckets: Vec<(le, count)>\`.

- Bucket edges (milliseconds): \`[10, 50, 100, 250, 500, 1000, 2500, 5000, 10000, +Inf]\`
- Cardinality is fixed at ten labels by construction — no top-N sampling,
  no adversarial cardinality growth path.
- \`AggEvent\` gains \`response_latency_us: u64\` so the proxy hot path can
  propagate the already-measured \`response_time_us\` without a second
  clock read.
- Window-delta semantics — the histogram is zeroed by \`flush()\` after
  serialisation, matching the existing \`status_codes\` / \`bytes_sent\` /
  bot-vs-human per-window discipline.
- Version bump \`0.3.5 → 0.3.6\` per the Dwaar version-bump policy; the
  auto-updater in the installer picks this up.

## Sibling PRs

- Deploy backend (metric emitter): permanu/Deploy#466
- permanu-svelte (consumer): permanu/permanu-svelte#21

## Test plan

- [x] \`cargo test -p dwaar-analytics\` (new \`latency_histogram\` tests
      + ingest path + sink/flush + snapshot coverage)
- [ ] \`cargo fmt --check && cargo clippy --all-targets -- -D warnings\` (CI)
- [ ] \`cargo test --workspace\` (CI; sandbox here blocks cargo)