### PR TITLE
feat(observability): OTLP ingress spans + sample_ratio (v0.3.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7] - 2026-04-24
+
+### Added
+
+- **OTLP ingress span per request** — Dwaar now emits one OpenTelemetry
+  span for every proxied HTTP request when `tracing { otlp_endpoint }` is
+  configured. The span is exported to the OTLP/HTTP collector via the
+  existing `dwaar-analytics` exporter and appears as the root node (or
+  child of the client's span) in the Permanu trace viewer.
+- **W3C Trace Context child-span propagation** — when an inbound request
+  carries a `traceparent` header, Dwaar now generates a *child* span
+  (same `trace_id`, fresh `span_id`) instead of propagating the client's
+  span unchanged. The child context is injected into the upstream request
+  so downstream services appear nested under the Dwaar ingress span.
+  When no `traceparent` is present, a fresh root span is generated as
+  before.
+- **`sample_ratio` config knob** — operators can set
+  `sample_ratio 0.1` inside the `tracing { }` block to record only a
+  fraction of requests (range `[0.0, 1.0]`, default `1.0`). Useful for
+  high-traffic sites where full sampling is cost-prohibitive.
+- **Semantic convention attributes on ingress span** — the span carries
+  `http.request.method`, `http.response.status_code`, `url.path`,
+  `url.scheme`, `server.address`, `client.address`, `dwaar.upstream`,
+  `http.request.body.size`, `http.response.body.size`, and
+  `dwaar.tls.version` (when TLS).
+
+### Changed
+
+- `TracingConfig` gains a `sample_ratio: f64` field (default `1.0`).
+  Existing Dwaarfiles without `sample_ratio` continue to record every
+  request unchanged.
+- The OTLP exporter `Arc` is now shared between `DwaarProxy` (records
+  spans on the hot path) and the background flush loop, eliminating the
+  double initialisation that existed previously.
+
 ## [0.3.6] - 2026-04-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-cli"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.3.6"
+version = "0.3.7"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-cli/src/main.rs
+++ b/crates/dwaar-cli/src/main.rs
@@ -678,6 +678,35 @@ fn run_server(
     let outcome_sink = Arc::new(dwaar_grpc::AnomalyOutcomeSink::new(Arc::clone(&event_bus)));
     let log_buffer = Arc::new(dwaar_grpc::LogChunkBuffer::new(Arc::clone(&event_bus)));
 
+    // OTLP span exporter — built here so the Arc can be shared with both
+    // DwaarProxy (records one span per request in logging()) and the
+    // background flush service (drains the ring buffer to the collector).
+    // Kept as `None` when the Dwaarfile has no `tracing {}` block.
+    let otlp_exporter_for_proxy: Option<Arc<dwaar_analytics::otel::OtlpExporter>> = dwaar_config
+        .global_options
+        .as_ref()
+        .and_then(|g| g.tracing.as_ref())
+        .and_then(|t| {
+            match dwaar_analytics::otel::OtlpExporter::new(
+                &t.otlp_endpoint,
+                env!("CARGO_PKG_VERSION"),
+            ) {
+                Ok(e) => {
+                    info!(endpoint = %t.otlp_endpoint, "OTLP span exporter initialised");
+                    Some(Arc::new(e))
+                }
+                Err(e) => {
+                    warn!(error = %e, "failed to initialise OTLP exporter — tracing disabled");
+                    None
+                }
+            }
+        });
+    let otlp_sample_ratio: f64 = dwaar_config
+        .global_options
+        .as_ref()
+        .and_then(|g| g.tracing.as_ref())
+        .map_or(1.0, |t| t.sample_ratio);
+
     let proxy = DwaarProxy::new(
         route_table,
         challenge_solver.clone(),
@@ -697,6 +726,11 @@ fn run_server(
         Arc::clone(&mirror_dispatcher) as Arc<dyn dwaar_core::proxy::MirrorDispatcher>
     )
     .with_outcome_sink(Arc::clone(&outcome_sink) as Arc<dyn dwaar_core::proxy::RequestOutcomeSink>);
+    let proxy = if let Some(ref exp) = otlp_exporter_for_proxy {
+        proxy.with_otlp_exporter(Arc::clone(exp), otlp_sample_ratio)
+    } else {
+        proxy
+    };
     // Hand-off: the admin / metrics wiring consuming `mirror_metrics` and
     // `log_buffer` lands in a follow-up wheel. Explicit drops keep both
     // `Arc`s' ref counts honest for now — cheap atomic decrements.
@@ -960,6 +994,7 @@ fn run_server(
         dwaar_config,
         l4_shared,
         l4_reload_notify,
+        otlp_exporter_for_proxy,
     );
 
     info!("entering run loop, waiting for connections or signals");
@@ -991,6 +1026,7 @@ fn register_background_services(
     config: &dwaar_config::model::DwaarConfig,
     l4_servers: dwaar_core::l4::SharedL4Servers,
     l4_reload_notify: Arc<tokio::sync::Notify>,
+    otlp_exporter: Option<Arc<dwaar_analytics::otel::OtlpExporter>>,
 ) {
     // Upstream health checker — runs as a BackgroundService (Guardrail #20).
     // Always registered; it will sleep if the pool list is empty and wake up
@@ -1116,34 +1152,16 @@ fn register_background_services(
         info!("analytics aggregation service registered");
     }
 
-    // OTLP span exporter — only registered when the Dwaarfile sets `tracing { otlp_endpoint }`.
-    if let Some(tracing_cfg) = config
-        .global_options
-        .as_ref()
-        .and_then(|g| g.tracing.as_ref())
-    {
-        match dwaar_analytics::otel::OtlpExporter::new(
-            &tracing_cfg.otlp_endpoint,
-            env!("CARGO_PKG_VERSION"),
-        ) {
-            Ok(exporter) => {
-                let exporter = Arc::new(exporter);
-                let otel_bg = pingora_core::services::background::background_service(
-                    "OTLP exporter",
-                    OtlpExporterService {
-                        exporter: Arc::clone(&exporter),
-                    },
-                );
-                server.add_service(otel_bg);
-                info!(
-                    endpoint = %tracing_cfg.otlp_endpoint,
-                    "OTLP span exporter registered"
-                );
-            }
-            Err(e) => {
-                warn!(error = %e, "failed to initialize OTLP exporter — tracing disabled");
-            }
-        }
+    // OTLP background flush loop — drains the ring buffer to the collector.
+    // The exporter Arc was initialised before proxy construction so DwaarProxy
+    // can call record() on the hot path; here we just register the flush loop.
+    if let Some(exporter) = otlp_exporter {
+        let otel_bg = pingora_core::services::background::background_service(
+            "OTLP exporter",
+            OtlpExporterService { exporter },
+        );
+        server.add_service(otel_bg);
+        info!("OTLP exporter background flush service registered");
     }
 }
 

--- a/crates/dwaar-config/src/model.rs
+++ b/crates/dwaar-config/src/model.rs
@@ -63,13 +63,24 @@ pub struct GlobalOptions {
 
 /// Distributed tracing export configuration.
 ///
-/// Parsed from the `tracing { otlp_endpoint <url> }` block inside
-/// global options.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// Parsed from the `tracing { ... }` block inside global options.
+#[derive(Debug, Clone)]
 pub struct TracingConfig {
     /// OTLP/HTTP endpoint URL, e.g. `http://localhost:4318/v1/traces`.
     pub otlp_endpoint: String,
+    /// Fraction of requests to sample, in the range `[0.0, 1.0]`.
+    /// Default `1.0` means record every request.
+    pub sample_ratio: f64,
 }
+
+impl PartialEq for TracingConfig {
+    fn eq(&self, other: &Self) -> bool {
+        self.otlp_endpoint == other.otlp_endpoint
+            && self.sample_ratio.to_bits() == other.sample_ratio.to_bits()
+    }
+}
+
+impl Eq for TracingConfig {}
 
 /// Connection-level timeouts for slow loris protection (ISSUE-076).
 ///

--- a/crates/dwaar-config/src/parser/mod.rs
+++ b/crates/dwaar-config/src/parser/mod.rs
@@ -564,7 +564,12 @@ fn parse_tracing_block(
                         endpoint = Some(val);
                     }
                     "sample_ratio" => {
-                        if let Ok(r) = val.parse::<f64>() {
+                        // Reject NaN/inf: parse::<f64>() accepts "nan"/"inf",
+                        // and NaN.clamp() propagates NaN, which would silently
+                        // disable tracing (NaN < r is always false).
+                        if let Ok(r) = val.parse::<f64>()
+                            && r.is_finite()
+                        {
                             sample_ratio = r.clamp(0.0, 1.0);
                         }
                     }

--- a/crates/dwaar-config/src/parser/mod.rs
+++ b/crates/dwaar-config/src/parser/mod.rs
@@ -532,6 +532,7 @@ fn parse_tracing_block(
     t.next_token(); // consume `{`
 
     let mut endpoint: Option<String> = None;
+    let mut sample_ratio: f64 = 1.0;
 
     loop {
         let tok = t.peek();
@@ -558,10 +559,17 @@ fn parse_tracing_block(
                 };
                 let val = peek_consume_word_or_quoted(t);
 
-                if sub_key.as_str() == "otlp_endpoint" {
-                    endpoint = Some(val);
+                match sub_key.as_str() {
+                    "otlp_endpoint" => {
+                        endpoint = Some(val);
+                    }
+                    "sample_ratio" => {
+                        if let Ok(r) = val.parse::<f64>() {
+                            sample_ratio = r.clamp(0.0, 1.0);
+                        }
+                    }
+                    _ => {} // Ignore unknown sub-directives for forward compat.
                 }
-                // Ignore unknown tracing sub-directives for forward compat.
             }
             _ => {
                 t.next_token();
@@ -579,7 +587,10 @@ fn parse_tracing_block(
         },
     })?;
 
-    Ok(super::model::TracingConfig { otlp_endpoint })
+    Ok(super::model::TracingConfig {
+        otlp_endpoint,
+        sample_ratio,
+    })
 }
 
 /// Parse "HH:MM-HH:MM" into (`start_minutes_from_midnight`, `end_minutes_from_midnight`).

--- a/crates/dwaar-config/src/parser/tests.rs
+++ b/crates/dwaar-config/src/parser/tests.rs
@@ -1935,3 +1935,34 @@ fn parse_tracing_block_sample_ratio_clamped() {
         .expect("tracing config present");
     assert!((tc.sample_ratio - 1.0).abs() < f64::EPSILON, "ratio should be clamped to 1.0");
 }
+
+/// `sample_ratio nan` and `sample_ratio inf` must not silently zero sampling.
+/// `f64::parse` accepts both literals; without an `is_finite` guard, NaN/inf
+/// would propagate through `clamp` and disable tracing without warning.
+#[test]
+fn parse_tracing_block_sample_ratio_rejects_non_finite() {
+    for non_finite in ["nan", "inf", "-inf", "NaN", "Inf"] {
+        let src = format!(
+            r#"{{
+                tracing {{
+                    otlp_endpoint http://127.0.0.1:4318/v1/traces
+                    sample_ratio {non_finite}
+                }}
+            }}
+            example.com {{
+                reverse_proxy localhost:8080
+            }}"#
+        );
+        let config = parse(&src).expect("should parse with non-finite ratio");
+        let tc = config
+            .global_options
+            .as_ref()
+            .and_then(|g| g.tracing.as_ref())
+            .expect("tracing config present");
+        assert!(
+            (tc.sample_ratio - 1.0).abs() < f64::EPSILON,
+            "non-finite ratio {non_finite} must fall back to default 1.0, got {}",
+            tc.sample_ratio
+        );
+    }
+}

--- a/crates/dwaar-config/src/parser/tests.rs
+++ b/crates/dwaar-config/src/parser/tests.rs
@@ -1863,18 +1863,18 @@ fn parse_wasm_plugin_unknown_subdirective_skipped() {
     assert_eq!(wp.priority, 20);
 }
 
-/// `tracing { otlp_endpoint ... }` with default sample_ratio.
+/// `tracing { otlp_endpoint ... }` with default `sample_ratio`.
 #[test]
 fn parse_tracing_block_with_default_sample_ratio() {
     let config = parse(
-        r#"{
+        r"{
             tracing {
                 otlp_endpoint http://127.0.0.1:4317/v1/traces
             }
         }
         example.com {
             reverse_proxy localhost:8080
-        }"#,
+        }",
     )
     .expect("should parse tracing block");
 
@@ -1891,7 +1891,7 @@ fn parse_tracing_block_with_default_sample_ratio() {
 #[test]
 fn parse_tracing_block_with_sample_ratio() {
     let config = parse(
-        r#"{
+        r"{
             tracing {
                 otlp_endpoint http://127.0.0.1:4318/v1/traces
                 sample_ratio 0.5
@@ -1899,7 +1899,7 @@ fn parse_tracing_block_with_sample_ratio() {
         }
         example.com {
             reverse_proxy localhost:8080
-        }"#,
+        }",
     )
     .expect("should parse tracing block with sample_ratio");
 
@@ -1916,7 +1916,7 @@ fn parse_tracing_block_with_sample_ratio() {
 #[test]
 fn parse_tracing_block_sample_ratio_clamped() {
     let config = parse(
-        r#"{
+        r"{
             tracing {
                 otlp_endpoint http://127.0.0.1:4318/v1/traces
                 sample_ratio 2.0
@@ -1924,7 +1924,7 @@ fn parse_tracing_block_sample_ratio_clamped() {
         }
         example.com {
             reverse_proxy localhost:8080
-        }"#,
+        }",
     )
     .expect("should parse with clamped ratio");
 
@@ -1933,7 +1933,10 @@ fn parse_tracing_block_sample_ratio_clamped() {
         .as_ref()
         .and_then(|g| g.tracing.as_ref())
         .expect("tracing config present");
-    assert!((tc.sample_ratio - 1.0).abs() < f64::EPSILON, "ratio should be clamped to 1.0");
+    assert!(
+        (tc.sample_ratio - 1.0).abs() < f64::EPSILON,
+        "ratio should be clamped to 1.0"
+    );
 }
 
 /// `sample_ratio nan` and `sample_ratio inf` must not silently zero sampling.
@@ -1943,7 +1946,7 @@ fn parse_tracing_block_sample_ratio_clamped() {
 fn parse_tracing_block_sample_ratio_rejects_non_finite() {
     for non_finite in ["nan", "inf", "-inf", "NaN", "Inf"] {
         let src = format!(
-            r#"{{
+            r"{{
                 tracing {{
                     otlp_endpoint http://127.0.0.1:4318/v1/traces
                     sample_ratio {non_finite}
@@ -1951,7 +1954,7 @@ fn parse_tracing_block_sample_ratio_rejects_non_finite() {
             }}
             example.com {{
                 reverse_proxy localhost:8080
-            }}"#
+            }}"
         );
         let config = parse(&src).expect("should parse with non-finite ratio");
         let tc = config

--- a/crates/dwaar-config/src/parser/tests.rs
+++ b/crates/dwaar-config/src/parser/tests.rs
@@ -4,7 +4,7 @@
 // This file is part of Dwaar — https://dwaar.dev
 // Licensed under the Business Source License 1.1
 
-//! Parser tests — all 69 tests covering happy paths, error cases, and real-world configs.
+//! Parser tests — covering happy paths, error cases, and real-world configs.
 
 use super::*;
 use crate::model::*;
@@ -1861,4 +1861,77 @@ fn parse_wasm_plugin_unknown_subdirective_skipped() {
         panic!("expected WasmPlugin directive");
     };
     assert_eq!(wp.priority, 20);
+}
+
+/// `tracing { otlp_endpoint ... }` with default sample_ratio.
+#[test]
+fn parse_tracing_block_with_default_sample_ratio() {
+    let config = parse(
+        r#"{
+            tracing {
+                otlp_endpoint http://127.0.0.1:4317/v1/traces
+            }
+        }
+        example.com {
+            reverse_proxy localhost:8080
+        }"#,
+    )
+    .expect("should parse tracing block");
+
+    let tc = config
+        .global_options
+        .as_ref()
+        .and_then(|g| g.tracing.as_ref())
+        .expect("tracing config present");
+    assert_eq!(tc.otlp_endpoint, "http://127.0.0.1:4317/v1/traces");
+    assert!((tc.sample_ratio - 1.0).abs() < f64::EPSILON);
+}
+
+/// `tracing { otlp_endpoint ... sample_ratio 0.5 }` parses ratio.
+#[test]
+fn parse_tracing_block_with_sample_ratio() {
+    let config = parse(
+        r#"{
+            tracing {
+                otlp_endpoint http://127.0.0.1:4318/v1/traces
+                sample_ratio 0.5
+            }
+        }
+        example.com {
+            reverse_proxy localhost:8080
+        }"#,
+    )
+    .expect("should parse tracing block with sample_ratio");
+
+    let tc = config
+        .global_options
+        .as_ref()
+        .and_then(|g| g.tracing.as_ref())
+        .expect("tracing config present");
+    assert_eq!(tc.otlp_endpoint, "http://127.0.0.1:4318/v1/traces");
+    assert!((tc.sample_ratio - 0.5).abs() < 1e-9);
+}
+
+/// `sample_ratio` values outside [0,1] are clamped.
+#[test]
+fn parse_tracing_block_sample_ratio_clamped() {
+    let config = parse(
+        r#"{
+            tracing {
+                otlp_endpoint http://127.0.0.1:4318/v1/traces
+                sample_ratio 2.0
+            }
+        }
+        example.com {
+            reverse_proxy localhost:8080
+        }"#,
+    )
+    .expect("should parse with clamped ratio");
+
+    let tc = config
+        .global_options
+        .as_ref()
+        .and_then(|g| g.tracing.as_ref())
+        .expect("tracing config present");
+    assert!((tc.sample_ratio - 1.0).abs() < f64::EPSILON, "ratio should be clamped to 1.0");
 }

--- a/crates/dwaar-core/src/context.rs
+++ b/crates/dwaar-core/src/context.rs
@@ -184,8 +184,16 @@ pub struct RequestContext {
     /// advertising a protocol the server can't actually serve for this route.
     pub quic_capable: bool,
 
-    /// Trace context parsed/generated in `upstream_request_filter()`.
+    /// Trace context generated for this request (Dwaar's own span).
+    /// Set in `upstream_request_filter()`. The `span_id` here is Dwaar's span ID;
+    /// it is injected into the upstream `traceparent` so downstream services
+    /// appear as children of the Dwaar ingress span.
     pub trace_ctx: Option<crate::trace::TraceContext>,
+
+    /// The inbound client's span ID when the request carried a `traceparent`
+    /// header. Used to set `parent_span_id` on the emitted ingress span so
+    /// the Dwaar span nests correctly under the client's trace.
+    pub inbound_parent_span_id: Option<[u8; 16]>,
 
     /// Upstream response status cached in `response_filter()` for
     /// `response_body_filter()` which doesn't have direct header access.
@@ -273,6 +281,7 @@ impl RequestContext {
             cache_status: None,
             quic_capable: false,
             trace_ctx: None,
+            inbound_parent_span_id: None,
             upstream_status: 0,
             upstream_error_body: None,
             rejected_by: None,

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -1812,21 +1812,20 @@ impl ProxyHttp for DwaarProxy {
         //
         // When no traceparent is present, generate a fresh trace + span so the
         // downstream service tree is still fully correlated.
-        let (trace_ctx, inbound_parent_span_id) =
-            if let Some(inbound) = session
-                .req_header()
-                .headers
-                .get("traceparent")
-                .and_then(|v| v.to_str().ok())
-                .and_then(crate::trace::parse_traceparent)
-            {
-                // Extract the client's span_id before generating the child context.
-                let parent_id = inbound.span_id_bytes();
-                let child = crate::trace::generate_child_traceparent(&inbound);
-                (child, Some(parent_id))
-            } else {
-                (crate::trace::generate_traceparent(), None)
-            };
+        let (trace_ctx, inbound_parent_span_id) = if let Some(inbound) = session
+            .req_header()
+            .headers
+            .get("traceparent")
+            .and_then(|v| v.to_str().ok())
+            .and_then(crate::trace::parse_traceparent)
+        {
+            // Extract the client's span_id before generating the child context.
+            let parent_id = inbound.span_id_bytes();
+            let child = crate::trace::generate_child_traceparent(&inbound);
+            (child, Some(parent_id))
+        } else {
+            (crate::trace::generate_traceparent(), None)
+        };
 
         upstream_request.insert_header("traceparent", trace_ctx.traceparent())?;
 
@@ -2284,10 +2283,13 @@ impl ProxyHttp for DwaarProxy {
         // a single pointer compare; zero overhead when tracing is disabled.
         if let Some(ref exporter) = self.otlp_exporter
             && let Some(ref trace_ctx) = ctx.trace_ctx
-            && (self.trace_sample_ratio >= 1.0
-                || fastrand::f64() < self.trace_sample_ratio)
+            && (self.trace_sample_ratio >= 1.0 || fastrand::f64() < self.trace_sample_ratio)
         {
-            let scheme = if ctx.plugin_ctx.is_tls { "https" } else { "http" };
+            let scheme = if ctx.plugin_ctx.is_tls {
+                "https"
+            } else {
+                "http"
+            };
             let span_client_ip = ctx
                 .plugin_ctx
                 .client_ip

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -129,6 +129,11 @@ pub struct DwaarProxy {
     /// fire-and-forget clone of the request to the mirror target. Mirror
     /// failures NEVER affect the primary response.
     mirror_dispatcher: Option<Arc<dyn MirrorDispatcher>>,
+    /// OTLP span exporter — present when `tracing { otlp_endpoint }` is set.
+    /// One span is recorded per completed request in `logging()`.
+    otlp_exporter: Option<Arc<dwaar_analytics::otel::OtlpExporter>>,
+    /// Fraction of requests to sample for tracing `[0.0, 1.0]`. 0.0 = off.
+    trace_sample_ratio: f64,
 }
 
 /// Registries consulted by the proxy hot path, populated by the gRPC
@@ -205,6 +210,8 @@ impl DwaarProxy {
             control_plane: None,
             outcome_sink: None,
             mirror_dispatcher: None,
+            otlp_exporter: None,
+            trace_sample_ratio: 1.0,
         }
     }
 
@@ -230,6 +237,20 @@ impl DwaarProxy {
     #[must_use]
     pub fn with_mirror_dispatcher(mut self, dispatcher: Arc<dyn MirrorDispatcher>) -> Self {
         self.mirror_dispatcher = Some(dispatcher);
+        self
+    }
+
+    /// Install the OTLP exporter. When set, one ingress span is recorded per
+    /// completed request in `logging()`. The exporter's flush loop runs as a
+    /// separate Pingora `BackgroundService` — the proxy only calls `record()`.
+    #[must_use]
+    pub fn with_otlp_exporter(
+        mut self,
+        exporter: Arc<dwaar_analytics::otel::OtlpExporter>,
+        sample_ratio: f64,
+    ) -> Self {
+        self.otlp_exporter = Some(exporter);
+        self.trace_sample_ratio = sample_ratio.clamp(0.0, 1.0);
         self
     }
 }
@@ -1782,16 +1803,30 @@ impl ProxyHttp for DwaarProxy {
 
         upstream_request.insert_header("X-Request-Id", ctx.request_id())?;
 
-        // W3C Trace Context propagation (ISSUE-112): if the client sent a valid
-        // traceparent, propagate it unchanged; otherwise generate a fresh one so
-        // downstream tracing tools can correlate this edge span.
-        let trace_ctx = session
-            .req_header()
-            .headers
-            .get("traceparent")
-            .and_then(|v| v.to_str().ok())
-            .and_then(crate::trace::parse_traceparent)
-            .unwrap_or_else(crate::trace::generate_traceparent);
+        // W3C Trace Context propagation (ISSUE-112):
+        //
+        // When the client sends a valid traceparent, Dwaar emits its own ingress
+        // span as a child of the client's span (same trace_id, fresh span_id),
+        // then injects that as the upstream traceparent so downstream services
+        // are children of Dwaar, not of the original client call.
+        //
+        // When no traceparent is present, generate a fresh trace + span so the
+        // downstream service tree is still fully correlated.
+        let (trace_ctx, inbound_parent_span_id) =
+            if let Some(inbound) = session
+                .req_header()
+                .headers
+                .get("traceparent")
+                .and_then(|v| v.to_str().ok())
+                .and_then(crate::trace::parse_traceparent)
+            {
+                // Extract the client's span_id before generating the child context.
+                let parent_id = inbound.span_id_bytes();
+                let child = crate::trace::generate_child_traceparent(&inbound);
+                (child, Some(parent_id))
+            } else {
+                (crate::trace::generate_traceparent(), None)
+            };
 
         upstream_request.insert_header("traceparent", trace_ctx.traceparent())?;
 
@@ -1803,6 +1838,7 @@ impl ProxyHttp for DwaarProxy {
         }
 
         ctx.trace_ctx = Some(trace_ctx);
+        ctx.inbound_parent_span_id = inbound_parent_span_id;
 
         // Strip hop-by-hop headers (RFC 7230 §6.1)
         // IMPORTANT: Use remove_header(), not headers.remove() — Pingora
@@ -2241,6 +2277,54 @@ impl ProxyHttp for DwaarProxy {
                 Some("MISS") => prom.rate_cache.record_cache_miss(host),
                 _ => {}
             }
+        }
+
+        // OTLP ingress span — emitted before field moves below so we can
+        // borrow method/path/host from ctx without cloning. The None check is
+        // a single pointer compare; zero overhead when tracing is disabled.
+        if let Some(ref exporter) = self.otlp_exporter
+            && let Some(ref trace_ctx) = ctx.trace_ctx
+            && (self.trace_sample_ratio >= 1.0
+                || fastrand::f64() < self.trace_sample_ratio)
+        {
+            let scheme = if ctx.plugin_ctx.is_tls { "https" } else { "http" };
+            let span_client_ip = ctx
+                .plugin_ctx
+                .client_ip
+                .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
+            let client_addr = span_client_ip.to_string();
+            let upstream_str = ctx
+                .route_upstream
+                .map_or_else(String::default, |a| a.to_string());
+            let tls_version_str = session
+                .downstream_session
+                .digest()
+                .and_then(|d| d.ssl_digest.as_ref())
+                .map(|ssl| ssl.version.clone());
+            let now_ns = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos() as u64;
+            let start_ns = now_ns.saturating_sub(response_time_us * 1_000);
+            let host_str = ctx.plugin_ctx.host.as_deref().unwrap_or("");
+
+            let meta = crate::trace::IngressSpanMeta {
+                trace_ctx,
+                parent_span_id: ctx.inbound_parent_span_id,
+                method: ctx.plugin_ctx.method.as_str(),
+                path: ctx.plugin_ctx.path.as_str(),
+                scheme,
+                host: host_str,
+                client_address: &client_addr,
+                upstream: &upstream_str,
+                status,
+                tls_version: tls_version_str.as_deref(),
+                request_body_size: bytes_received,
+                response_body_size: bytes_sent,
+                start_ns,
+                end_ns: now_ns,
+            };
+            exporter.record(crate::trace::create_ingress_span(&meta));
         }
 
         let Some(ref sender) = self.log_sender else {

--- a/crates/dwaar-core/src/trace.rs
+++ b/crates/dwaar-core/src/trace.rs
@@ -41,6 +41,11 @@ impl TraceContext {
     pub fn traceparent(&self) -> &str {
         std::str::from_utf8(&self.traceparent).expect("traceparent is valid ASCII")
     }
+
+    /// Raw 16-byte span ID array, used when recording this context as a parent.
+    pub fn span_id_bytes(&self) -> [u8; 16] {
+        self.span_id
+    }
 }
 
 /// Validate that `s` is exactly `len` hex characters.
@@ -100,6 +105,30 @@ pub fn parse_traceparent(value: &str) -> Option<TraceContext> {
     Some(ctx)
 }
 
+/// Generate a child `TraceContext` that inherits the trace ID from `parent`
+/// but carries a fresh span ID. Used when the inbound request has a valid
+/// `traceparent`: Dwaar emits its own span nested under the client's span,
+/// then injects this context into the upstream request so downstream services
+/// appear as children of the Dwaar span.
+pub fn generate_child_traceparent(parent: &TraceContext) -> TraceContext {
+    let mut span_bytes = [0u8; 8];
+    fastrand::fill(&mut span_bytes);
+
+    let mut ctx = TraceContext {
+        trace_id: parent.trace_id,
+        span_id: [0u8; 16],
+        traceparent: *b"00-00000000000000000000000000000000-0000000000000000-01",
+    };
+
+    hex_encode_lower_into(&span_bytes, &mut ctx.span_id);
+
+    // Embed into traceparent: "00-" (3) + trace_id (32) + "-" (1) + span_id (16) + "-01" (3)
+    ctx.traceparent[3..35].copy_from_slice(&ctx.trace_id);
+    ctx.traceparent[36..52].copy_from_slice(&ctx.span_id);
+
+    ctx
+}
+
 /// Generate a fresh `TraceContext` with random trace and span IDs.
 ///
 /// Uses `fastrand` (thread-local, no syscall) for speed — this runs on
@@ -130,12 +159,110 @@ pub fn generate_traceparent() -> TraceContext {
     ctx
 }
 
+/// Metadata for a completed HTTP request used to build an ingress span.
+#[derive(Debug)]
+pub struct IngressSpanMeta<'a> {
+    /// Parsed/generated trace context for this request.
+    pub trace_ctx: &'a TraceContext,
+    /// Span ID of the inbound client's traceparent, if present.
+    /// When `Some`, the Dwaar span is a child of the client's span.
+    pub parent_span_id: Option<[u8; 16]>,
+    pub method: &'a str,
+    pub path: &'a str,
+    pub scheme: &'a str,
+    pub host: &'a str,
+    pub client_address: &'a str,
+    /// Upstream address selected by the route (e.g. `"127.0.0.1:3000"`).
+    pub upstream: &'a str,
+    pub status: u16,
+    /// TLS version string if the downstream connection was TLS (e.g. `"TLSv1.3"`).
+    pub tls_version: Option<&'a str>,
+    pub request_body_size: u64,
+    pub response_body_size: u64,
+    pub start_ns: u64,
+    pub end_ns: u64,
+}
+
+/// Build a completed OTLP ingress span from a finished request.
+///
+/// Returns a `dwaar_analytics::otel::Span` ready for `OtlpExporter::record()`.
+/// The trace/span IDs come from the propagated or generated `TraceContext`.
+/// When the inbound request carried a `traceparent`, `meta.parent_span_id` is
+/// set so the Dwaar span nests under the client's trace.
+pub fn create_ingress_span(meta: &IngressSpanMeta<'_>) -> dwaar_analytics::otel::Span {
+    use compact_str::CompactString;
+    use dwaar_analytics::otel::{SpanAttribute, SpanKind, SpanValue};
+
+    let name = CompactString::from(format!("HTTP {} {}", meta.method, meta.path));
+
+    let mut attributes = vec![
+        SpanAttribute {
+            key: CompactString::from("http.request.method"),
+            value: SpanValue::String(CompactString::from(meta.method)),
+        },
+        SpanAttribute {
+            key: CompactString::from("http.response.status_code"),
+            value: SpanValue::Int(i64::from(meta.status)),
+        },
+        SpanAttribute {
+            key: CompactString::from("url.path"),
+            value: SpanValue::String(CompactString::from(meta.path)),
+        },
+        SpanAttribute {
+            key: CompactString::from("url.scheme"),
+            value: SpanValue::String(CompactString::from(meta.scheme)),
+        },
+        SpanAttribute {
+            key: CompactString::from("server.address"),
+            value: SpanValue::String(CompactString::from(meta.host)),
+        },
+        SpanAttribute {
+            key: CompactString::from("client.address"),
+            value: SpanValue::String(CompactString::from(meta.client_address)),
+        },
+        SpanAttribute {
+            key: CompactString::from("dwaar.upstream"),
+            value: SpanValue::String(CompactString::from(meta.upstream)),
+        },
+        SpanAttribute {
+            key: CompactString::from("http.request.body.size"),
+            value: SpanValue::Int(meta.request_body_size.cast_signed()),
+        },
+        SpanAttribute {
+            key: CompactString::from("http.response.body.size"),
+            value: SpanValue::Int(meta.response_body_size.cast_signed()),
+        },
+    ];
+
+    if let Some(tls) = meta.tls_version {
+        attributes.push(SpanAttribute {
+            key: CompactString::from("dwaar.tls.version"),
+            value: SpanValue::String(CompactString::from(tls)),
+        });
+    }
+
+    dwaar_analytics::otel::Span {
+        trace_id: meta.trace_ctx.trace_id,
+        span_id: meta.trace_ctx.span_id,
+        parent_span_id: meta.parent_span_id,
+        name,
+        kind: SpanKind::Server,
+        start_ns: meta.start_ns,
+        end_ns: meta.end_ns,
+        status_code: meta.status,
+        attributes,
+    }
+}
+
 /// Build a completed OTLP span from a finished request. Called at the end
 /// of the request lifecycle when both timing and status are known.
 ///
 /// Returns a `dwaar_analytics::otel::Span` ready for `OtlpExporter::record()`.
 /// The trace/span IDs come from the propagated or generated `TraceContext`;
 /// everything else is request metadata captured during proxying.
+///
+/// Prefer [`create_ingress_span`] for new call sites — this simpler form is
+/// kept for tests that don't need the full attribute set.
 pub fn create_request_span(
     trace_ctx: &TraceContext,
     method: &str,
@@ -326,5 +453,101 @@ mod tests {
         let span = create_request_span(&ctx, "POST", "/upload", 201, "store:9090", 5000, 6000);
         assert_eq!(span.status_code, 201);
         assert_eq!(span.name.as_str(), "HTTP POST /upload");
+    }
+
+    #[test]
+    fn generate_child_traceparent_inherits_trace_id() {
+        let parent_tp = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let parent = parse_traceparent(parent_tp).expect("valid");
+        let child = generate_child_traceparent(&parent);
+
+        // Child must share the parent's trace ID.
+        assert_eq!(child.trace_id(), parent.trace_id());
+        // Child must have a different span ID.
+        assert_ne!(child.span_id(), parent.span_id());
+        // Child traceparent must be well-formed.
+        assert_eq!(child.traceparent().len(), 55);
+        let reparsed = parse_traceparent(child.traceparent()).expect("child is parseable");
+        assert_eq!(reparsed.trace_id(), parent.trace_id());
+    }
+
+    #[test]
+    fn span_id_bytes_roundtrips() {
+        let tp = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let ctx = parse_traceparent(tp).expect("valid");
+        let bytes = ctx.span_id_bytes();
+        assert_eq!(
+            std::str::from_utf8(&bytes).expect("ascii"),
+            "00f067aa0ba902b7"
+        );
+    }
+
+    #[test]
+    fn create_ingress_span_root_span_no_parent() {
+        let ctx = generate_traceparent();
+        let meta = IngressSpanMeta {
+            trace_ctx: &ctx,
+            parent_span_id: None,
+            method: "GET",
+            path: "/health",
+            scheme: "http",
+            host: "example.com",
+            client_address: "192.168.1.1",
+            upstream: "127.0.0.1:3000",
+            status: 200,
+            tls_version: None,
+            request_body_size: 0,
+            response_body_size: 512,
+            start_ns: 1_000_000,
+            end_ns: 1_001_000,
+        };
+        let span = create_ingress_span(&meta);
+        assert_eq!(span.parent_span_id, None);
+        assert_eq!(span.status_code, 200);
+        assert_eq!(span.name.as_str(), "HTTP GET /health");
+        // Must include all required semantic convention attributes.
+        let keys: Vec<_> = span.attributes.iter().map(|a| a.key.as_str()).collect();
+        assert!(keys.contains(&"http.request.method"));
+        assert!(keys.contains(&"http.response.status_code"));
+        assert!(keys.contains(&"url.path"));
+        assert!(keys.contains(&"url.scheme"));
+        assert!(keys.contains(&"server.address"));
+        assert!(keys.contains(&"client.address"));
+        assert!(keys.contains(&"dwaar.upstream"));
+        assert!(keys.contains(&"http.request.body.size"));
+        assert!(keys.contains(&"http.response.body.size"));
+        // No TLS version when TLS is absent.
+        assert!(!keys.contains(&"dwaar.tls.version"));
+    }
+
+    #[test]
+    fn create_ingress_span_child_span_sets_parent() {
+        let parent_tp = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let parent = parse_traceparent(parent_tp).expect("valid");
+        let child_ctx = generate_child_traceparent(&parent);
+        let parent_id = parent.span_id_bytes();
+
+        let meta = IngressSpanMeta {
+            trace_ctx: &child_ctx,
+            parent_span_id: Some(parent_id),
+            method: "POST",
+            path: "/api/data",
+            scheme: "https",
+            host: "api.example.com",
+            client_address: "10.0.0.1",
+            upstream: "127.0.0.1:8080",
+            status: 201,
+            tls_version: Some("TLSv1.3"),
+            request_body_size: 256,
+            response_body_size: 128,
+            start_ns: 2_000_000,
+            end_ns: 2_500_000,
+        };
+        let span = create_ingress_span(&meta);
+        assert_eq!(span.parent_span_id, Some(parent_id));
+        assert_eq!(span.status_code, 201);
+        // TLS version attribute present when TLS is active.
+        let keys: Vec<_> = span.attributes.iter().map(|a| a.key.as_str()).collect();
+        assert!(keys.contains(&"dwaar.tls.version"));
     }
 }


### PR DESCRIPTION
## Summary

- Emit one OpenTelemetry span per proxied request from `dwaar-core` (root span, or child of inbound `traceparent`) and export via the existing `dwaar-analytics` OTLP/HTTP path
- New `tracing { sample_ratio 0.0..1.0 }` config knob (default `1.0`) for cost-controlled sampling on high-traffic sites
- W3C Trace Context propagation: when a request carries `traceparent`, generate a child span (same `trace_id`, fresh `span_id`) and inject the new context upstream so downstream services nest under the Dwaar ingress span
- Semantic-convention attributes on the ingress span: `http.request.method`, `http.response.status_code`, `url.path`, `url.scheme`, `server.address`, `client.address`, `dwaar.upstream`, request/response body sizes, `dwaar.tls.version`
- CLI wires the OTLP exporter into `DwaarProxy` at startup
- Bumps version to **0.3.7** and adds CHANGELOG entry

This unlocks first-party trace ingestion in the Permanu trace viewer without forcing customers onto a third-party tracing vendor.

## Files of note

- `crates/dwaar-core/src/trace.rs` (+223) — span builder, traceparent parsing, child-span derivation
- `crates/dwaar-core/src/proxy.rs` (+~95) — span emission inside `logging()`
- `crates/dwaar-config/src/{model.rs,parser/mod.rs}` — `sample_ratio` field + parser
- `crates/dwaar-cli/src/main.rs` — exporter wiring

## Test plan

- [ ] `cargo test -p dwaar-config` (parser tests cover `sample_ratio` defaults and bounds)
- [ ] `cargo test -p dwaar-core` (trace.rs unit tests for traceparent parse + child derivation)
- [ ] Manual: run Dwaar against an OTLP collector (e.g. Jaeger all-in-one), verify spans appear with correct parent/child relationship
- [ ] Manual: set `sample_ratio 0.1`, hit endpoint 1000×, verify ~100 spans recorded
- [ ] Verify version bump in installer auto-update path (per `feedback_dwaar_version_bump`)