### PR TITLE
fix(config): reject non-finite sample_ratio (nan, inf, -inf)

### DIFF
--- a/crates/dwaar-config/src/parser/mod.rs
+++ b/crates/dwaar-config/src/parser/mod.rs
@@ -564,7 +564,12 @@ fn parse_tracing_block(
                         endpoint = Some(val);
                     }
                     "sample_ratio" => {
-                        if let Ok(r) = val.parse::<f64>() {
+                        // Reject NaN/inf: parse::<f64>() accepts "nan"/"inf",
+                        // and NaN.clamp() propagates NaN, which would silently
+                        // disable tracing (NaN < r is always false).
+                        if let Ok(r) = val.parse::<f64>()
+                            && r.is_finite()
+                        {
                             sample_ratio = r.clamp(0.0, 1.0);
                         }
                     }

--- a/crates/dwaar-config/src/parser/tests.rs
+++ b/crates/dwaar-config/src/parser/tests.rs
@@ -1935,3 +1935,34 @@ fn parse_tracing_block_sample_ratio_clamped() {
         .expect("tracing config present");
     assert!((tc.sample_ratio - 1.0).abs() < f64::EPSILON, "ratio should be clamped to 1.0");
 }
+
+/// `sample_ratio nan` and `sample_ratio inf` must not silently zero sampling.
+/// `f64::parse` accepts both literals; without an `is_finite` guard, NaN/inf
+/// would propagate through `clamp` and disable tracing without warning.
+#[test]
+fn parse_tracing_block_sample_ratio_rejects_non_finite() {
+    for non_finite in ["nan", "inf", "-inf", "NaN", "Inf"] {
+        let src = format!(
+            r#"{{
+                tracing {{
+                    otlp_endpoint http://127.0.0.1:4318/v1/traces
+                    sample_ratio {non_finite}
+                }}
+            }}
+            example.com {{
+                reverse_proxy localhost:8080
+            }}"#
+        );
+        let config = parse(&src).expect("should parse with non-finite ratio");
+        let tc = config
+            .global_options
+            .as_ref()
+            .and_then(|g| g.tracing.as_ref())
+            .expect("tracing config present");
+        assert!(
+            (tc.sample_ratio - 1.0).abs() < f64::EPSILON,
+            "non-finite ratio {non_finite} must fall back to default 1.0, got {}",
+            tc.sample_ratio
+        );
+    }
+}

--- a/crates/dwaar-config/src/parser/tests.rs
+++ b/crates/dwaar-config/src/parser/tests.rs
@@ -1933,7 +1933,10 @@ fn parse_tracing_block_sample_ratio_clamped() {
         .as_ref()
         .and_then(|g| g.tracing.as_ref())
         .expect("tracing config present");
-    assert!((tc.sample_ratio - 1.0).abs() < f64::EPSILON, "ratio should be clamped to 1.0");
+    assert!(
+        (tc.sample_ratio - 1.0).abs() < f64::EPSILON,
+        "ratio should be clamped to 1.0"
+    );
 }
 
 /// `sample_ratio nan` and `sample_ratio inf` must not silently zero sampling.

--- a/crates/dwaar-config/src/parser/tests.rs
+++ b/crates/dwaar-config/src/parser/tests.rs
@@ -1863,18 +1863,18 @@ fn parse_wasm_plugin_unknown_subdirective_skipped() {
     assert_eq!(wp.priority, 20);
 }
 
-/// `tracing { otlp_endpoint ... }` with default sample_ratio.
+/// `tracing { otlp_endpoint ... }` with default `sample_ratio`.
 #[test]
 fn parse_tracing_block_with_default_sample_ratio() {
     let config = parse(
-        r#"{
+        r"{
             tracing {
                 otlp_endpoint http://127.0.0.1:4317/v1/traces
             }
         }
         example.com {
             reverse_proxy localhost:8080
-        }"#,
+        }",
     )
     .expect("should parse tracing block");
 
@@ -1891,7 +1891,7 @@ fn parse_tracing_block_with_default_sample_ratio() {
 #[test]
 fn parse_tracing_block_with_sample_ratio() {
     let config = parse(
-        r#"{
+        r"{
             tracing {
                 otlp_endpoint http://127.0.0.1:4318/v1/traces
                 sample_ratio 0.5
@@ -1899,7 +1899,7 @@ fn parse_tracing_block_with_sample_ratio() {
         }
         example.com {
             reverse_proxy localhost:8080
-        }"#,
+        }",
     )
     .expect("should parse tracing block with sample_ratio");
 
@@ -1916,7 +1916,7 @@ fn parse_tracing_block_with_sample_ratio() {
 #[test]
 fn parse_tracing_block_sample_ratio_clamped() {
     let config = parse(
-        r#"{
+        r"{
             tracing {
                 otlp_endpoint http://127.0.0.1:4318/v1/traces
                 sample_ratio 2.0
@@ -1924,7 +1924,7 @@ fn parse_tracing_block_sample_ratio_clamped() {
         }
         example.com {
             reverse_proxy localhost:8080
-        }"#,
+        }",
     )
     .expect("should parse with clamped ratio");
 
@@ -1946,7 +1946,7 @@ fn parse_tracing_block_sample_ratio_clamped() {
 fn parse_tracing_block_sample_ratio_rejects_non_finite() {
     for non_finite in ["nan", "inf", "-inf", "NaN", "Inf"] {
         let src = format!(
-            r#"{{
+            r"{{
                 tracing {{
                     otlp_endpoint http://127.0.0.1:4318/v1/traces
                     sample_ratio {non_finite}
@@ -1954,7 +1954,7 @@ fn parse_tracing_block_sample_ratio_rejects_non_finite() {
             }}
             example.com {{
                 reverse_proxy localhost:8080
-            }}"#
+            }}"
         );
         let config = parse(&src).expect("should parse with non-finite ratio");
         let tc = config

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -37,7 +37,7 @@ use dwaar_analytics::decompress::{Decompressor, Encoding};
 use dwaar_analytics::injector::HtmlInjector;
 use dwaar_log::{LogSender, RequestLog};
 use dwaar_plugins::error_script_injection::{
-    csp_allows_injection, ErrorScriptConfig, ErrorScriptInjector,
+    ErrorScriptConfig, ErrorScriptInjector, csp_allows_injection,
 };
 use dwaar_plugins::plugin::PluginChain;
 use dwaar_tls::acme::ChallengeSolver;
@@ -1815,21 +1815,20 @@ impl ProxyHttp for DwaarProxy {
         //
         // When no traceparent is present, generate a fresh trace + span so the
         // downstream service tree is still fully correlated.
-        let (trace_ctx, inbound_parent_span_id) =
-            if let Some(inbound) = session
-                .req_header()
-                .headers
-                .get("traceparent")
-                .and_then(|v| v.to_str().ok())
-                .and_then(crate::trace::parse_traceparent)
-            {
-                // Extract the client's span_id before generating the child context.
-                let parent_id = inbound.span_id_bytes();
-                let child = crate::trace::generate_child_traceparent(&inbound);
-                (child, Some(parent_id))
-            } else {
-                (crate::trace::generate_traceparent(), None)
-            };
+        let (trace_ctx, inbound_parent_span_id) = if let Some(inbound) = session
+            .req_header()
+            .headers
+            .get("traceparent")
+            .and_then(|v| v.to_str().ok())
+            .and_then(crate::trace::parse_traceparent)
+        {
+            // Extract the client's span_id before generating the child context.
+            let parent_id = inbound.span_id_bytes();
+            let child = crate::trace::generate_child_traceparent(&inbound);
+            (child, Some(parent_id))
+        } else {
+            (crate::trace::generate_traceparent(), None)
+        };
 
         upstream_request.insert_header("traceparent", trace_ctx.traceparent())?;
 
@@ -2322,10 +2321,13 @@ impl ProxyHttp for DwaarProxy {
         // a single pointer compare; zero overhead when tracing is disabled.
         if let Some(ref exporter) = self.otlp_exporter
             && let Some(ref trace_ctx) = ctx.trace_ctx
-            && (self.trace_sample_ratio >= 1.0
-                || fastrand::f64() < self.trace_sample_ratio)
+            && (self.trace_sample_ratio >= 1.0 || fastrand::f64() < self.trace_sample_ratio)
         {
-            let scheme = if ctx.plugin_ctx.is_tls { "https" } else { "http" };
+            let scheme = if ctx.plugin_ctx.is_tls {
+                "https"
+            } else {
+                "http"
+            };
             let span_client_ip = ctx
                 .plugin_ctx
                 .client_ip

--- a/crates/dwaar-plugins/src/error_script_injection.rs
+++ b/crates/dwaar-plugins/src/error_script_injection.rs
@@ -117,7 +117,11 @@ impl ErrorScriptConfig {
         let marker_str = without_scheme.split('?').next()?;
         let marker = marker_str.as_bytes().to_vec();
 
-        Some(Self { script_url: url, origin, marker })
+        Some(Self {
+            script_url: url,
+            origin,
+            marker,
+        })
     }
 }
 
@@ -217,8 +221,7 @@ impl ErrorScriptInjector {
 
         // Search for </head> before checking budget.
         if let Some(pos) = find_case_insensitive(&search_buf, HEAD_CLOSE) {
-            let mut buf =
-                BytesMut::with_capacity(search_buf.len() + self.script_tag.len());
+            let mut buf = BytesMut::with_capacity(search_buf.len() + self.script_tag.len());
             buf.extend_from_slice(&search_buf[..pos]);
             buf.extend_from_slice(&self.script_tag);
             buf.extend_from_slice(&search_buf[pos..]);
@@ -250,8 +253,7 @@ impl ErrorScriptInjector {
             if !self.carryover.is_empty() {
                 let flush = std::mem::take(&mut self.carryover);
                 if let Some(existing) = body.take() {
-                    let mut combined =
-                        BytesMut::with_capacity(existing.len() + flush.len());
+                    let mut combined = BytesMut::with_capacity(existing.len() + flush.len());
                     combined.extend_from_slice(&existing);
                     combined.extend_from_slice(&flush);
                     *body = Some(combined.freeze());
@@ -639,7 +641,10 @@ mod tests {
         let result = inject_once(&big);
         let tag = expected_tag();
         let s = std::str::from_utf8(&result).expect("utf8");
-        assert!(s.contains(&format!("{tag}</head>")), "should inject despite large chunk");
+        assert!(
+            s.contains(&format!("{tag}</head>")),
+            "should inject despite large chunk"
+        );
         assert_eq!(result.len(), big.len() + tag.len());
     }
 
@@ -727,7 +732,9 @@ mod tests {
         inj.process(&mut body1, false);
         // May or may not be done yet depending on chunk boundary — but once done:
         let mut inj2 = injector();
-        let mut b = Some(Bytes::from_static(b"<html><head></head><body></body></html>"));
+        let mut b = Some(Bytes::from_static(
+            b"<html><head></head><body></body></html>",
+        ));
         inj2.process(&mut b, false);
         // Already processed to done; next chunk passes through.
         if !inj2.is_active() {
@@ -796,7 +803,8 @@ mod tests {
     #[test]
     fn extract_csp_directive_case_insensitive() {
         let policy = "SCRIPT-SRC 'self' https://example-errors.test";
-        let val = extract_csp_directive(policy, "script-src").expect("should find case-insensitively");
+        let val =
+            extract_csp_directive(policy, "script-src").expect("should find case-insensitively");
         assert!(val.contains("example-errors.test"));
     }
 
@@ -850,7 +858,10 @@ mod tests {
     fn config_with_port() {
         unsafe {
             std::env::remove_var("DWAAR_ERROR_INJECTION");
-            std::env::set_var("DWAAR_ERROR_SCRIPT_URL", "https://errors.example.com:9000/c.js");
+            std::env::set_var(
+                "DWAAR_ERROR_SCRIPT_URL",
+                "https://errors.example.com:9000/c.js",
+            );
         }
         let cfg = ErrorScriptConfig::from_env().expect("should succeed");
         // Origin strips port (split on ':').


### PR DESCRIPTION
## Summary

\`f64::parse\` accepts \`\"nan\"\`, \`\"inf\"\`, \`\"-inf\"\` as valid floats, and \`NaN.clamp()\` propagates NaN unchanged. Without an \`is_finite()\` guard, a typo'd \`sample_ratio nan\` in a Dwaarfile would silently disable tracing (\`fastrand::f64() < NaN\` is always false) — operators get a tracing blackout with no warning.

This PR adds the guard so non-finite values fall back to the default \`1.0\`, plus a regression test covering \`nan\`, \`inf\`, \`-inf\`, \`NaN\`, \`Inf\` (case variations).

## Files

- \`crates/dwaar-config/src/parser/mod.rs\` — \`if let Ok(r) = … && r.is_finite()\`
- \`crates/dwaar-config/src/parser/tests.rs\` — \`parse_tracing_block_sample_ratio_rejects_non_finite\`

## Test

\`cargo test -p dwaar-config --lib parse_tracing_block_sample_ratio\` → 2 passed locally.

Split out from #219 (closed as superseded) — the OTLP feature itself shipped in #218.