### PR TITLE
ci: optimize workflows — drop macOS test, dev-profile build, prebuilt cargo-deny/audit, concurrency

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -19,16 +19,22 @@ permissions:
   contents: read
 
 jobs:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
   audit:
     name: Dependency Audit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      # Use latest stable Rust for cargo-audit (not our pinned toolchain)
-      # cargo-audit inspects Cargo.lock, doesn't compile our code
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+      # Install cargo-audit from prebuilt binaries (~5s) instead of
+      # compiling from source (~2-3min). cargo-audit only inspects
+      # Cargo.lock — it doesn't need the Rust toolchain.
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
       - name: Run audit
         run: >-
           cargo audit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,7 +18,6 @@ on:
 permissions:
   contents: read
 
-jobs:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: read
 
+# Cancel in-flight runs for the same branch when a new commit lands.
+# Prevents queued-run pile-up during active feature work.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -22,6 +28,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
+      - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all --check
 
   clippy:
@@ -39,12 +46,12 @@ jobs:
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   test:
+    # Linux-only — Dwaar ships as a Linux server binary; macOS coverage adds
+    # 10× runner cost (macos minutes are billed at 10× linux) for negligible
+    # signal. Cross-platform validation happens at release tag time via
+    # release.yml's matrix (linux-amd64, linux-arm64, darwin-arm64).
     name: Test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -62,6 +69,11 @@ jobs:
         timeout-minutes: 15
 
   build:
+    # Dev-profile build only — the test job already compiles the workspace
+    # in dev. Release-profile compilation runs at tag time in release.yml,
+    # where lto=fat + codegen-units=1 actually matter. Doing it here added
+    # 5–10 min per PR for zero practical signal beyond what `cargo test`
+    # already provides.
     name: Build
     runs-on: ubuntu-latest
     steps:
@@ -71,7 +83,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build --workspace --release
+      - run: cargo build --workspace
 
   license-headers:
     name: License Headers
@@ -101,8 +113,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install cargo-deny
-        run: cargo install cargo-deny --locked
-      - name: Run cargo-deny
-        run: cargo deny check
+      # Install cargo-deny from prebuilt binaries (~5s) instead of
+      # compiling from source (~2-3min on cold runner). Doesn't need
+      # the Rust toolchain at all.
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+      - run: cargo deny check


### PR DESCRIPTION
## Summary

Concrete optimizations from the CI audit. ~50% reduction in test runner minutes, ~5min off every PR's wall time.

| Change | File(s) | Savings |
|---|---|---|
| Add \`concurrency.cancel-in-progress\` | ci.yml, audit.yml | Eliminates queued-run pile-up on rapid pushes |
| Drop \`macos-latest\` from test matrix | ci.yml test job | ~50% of test minutes (macOS billed 10× linux) |
| \`cargo build\` (dev) instead of \`--release\` in CI | ci.yml build job | 5–10 min/PR (lto=fat is release-only, doesn't belong on the PR gate) |
| Add \`Swatinem/rust-cache\` to fmt job | ci.yml fmt | 30–60s/PR (proc-macros + toolchain reuse) |
| \`taiki-e/install-action@v2\` for cargo-deny | ci.yml deny | ~2-3min/PR (prebuilt binary vs source compile) |
| \`taiki-e/install-action@v2\` for cargo-audit | audit.yml | ~2-3min/PR (same) |

## Things deliberately kept

- \`audit.yml\` path filter (\`Cargo.{toml,lock}\`) + daily schedule — load-bearing for security posture.
- \`Swatinem/rust-cache\` in clippy/test/build — already present and correctly keyed.
- \`license-headers\` job — fast (no Rust compile), enforces BSL-1.1 header presence.
- \`release.yml\` cross-compile matrix (linux-amd64/arm64, darwin-arm64) — those are real ship targets, leave alone.

## Future follow-ups (not in this PR)

- Composite \`.github/actions/setup-rust\` — centralize checkout + toolchain + protoc + rust-cache. Eliminates the protoc fragmentation that caused PR #212.
- Cache Playwright in site.yml (~1-2min/build).
- Pre-existing \`cargo-deny\` duplicate warnings + RUSTSEC-2026-0104 advisory — separate PR (tracked in task queue).