### PR TITLE
chore(release): v0.3.9 — bump LICENSE Licensed Work + retag (v0.3.8 release-yml LICENSE check failed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.8] - 2026-04-25
+## [0.3.9] - 2026-04-25
 
 First tagged release covering the v0.3.7 OTLP/sample_ratio work, which
 was internally version-bumped in main (#218) but never had a tag or
-GitHub release cut for it. v0.3.8 supersedes v0.3.7 and ships the
+GitHub release cut for it. v0.3.9 supersedes both (the v0.3.8 tag failed to publish — LICENSE version mismatch in CI). Ships the
 following on top of v0.3.6:
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-cli"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.3.6
+Licensed Work:        Dwaar 0.3.9
                       The Licensed Work is
                       (c) 2026 Permanu
 
@@ -65,7 +65,7 @@ Additional Use Grant: You may use, copy, modify, create derivative works of,
                         of the Licensed Work as part of a commercial
                         infrastructure or platform product.
 
-Change Date:          2036-04-18
+Change Date:          2036-04-25
 
 Change License:       GNU Affero General Public License v3.0
 

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.3.8"
+version = "0.3.9"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false


### PR DESCRIPTION
## What happened

v0.3.8 tag was cut and release.yml ran. All three binary builds (linux-amd64, linux-arm64, darwin-arm64) and the Docker image succeeded. **The Create Release job failed at the \`Verify license date matches tag\` step** because \`LICENSE\` still said \`Licensed Work: Dwaar 0.3.6\`. No GitHub Release was published.

The check is correct — BSL Licensed Work line must track the released version so the Change Date (10-year auto-Apache-2.0 timer) is accurate per release.

## Fix

Bump to **v0.3.9** (skipping the broken v0.3.8 tag which produced no artifacts) via \`./scripts/bump-license-date.sh 0.3.9\`. Updates:
- \`LICENSE\` → Licensed Work: Dwaar 0.3.9, Change Date 2036-04-25
- \`crates/dwaar-cli/Cargo.toml\` → 0.3.9
- \`Cargo.lock\` → 0.3.9
- \`CHANGELOG.md\` → 0.3.8 entry retitled to 0.3.9 (same body, security CVEs + tracing fixes + CI optimisation)

## Plan after merge

1. Tag \`v0.3.9\` from the merge commit
2. release.yml fires (LICENSE check now passes)
3. Three binaries + Docker image + GitHub Release auto-create
4. Done

## Why skip v0.3.8 instead of retagging

Retagging would require force-deleting the existing v0.3.8 tag from the remote — destructive operation that disrupts anyone (or any tool) that may have already pinned to that ref. v0.3.9 is additive, no destruction.