### PR TITLE
feat(release): cosign keyless signing + verification in install.sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,14 @@ jobs:
   build:
     name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    # id-token: write is required for cosign keyless OIDC signing.
+    # Without it cosign cannot exchange an OIDC token with Fulcio to get a
+    # short-lived signing certificate — the step will fail with a clear error
+    # rather than silently skip.  contents:write is needed so the upload
+    # artifact action can stage assets for the release job.
+    permissions:
+      id-token: write
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -76,6 +84,30 @@ jobs:
           cd dist
           sha256sum ${{ matrix.artifact }} > ${{ matrix.artifact }}.sha256
 
+      # Install cosign for keyless OIDC signing.
+      # Pinned to SHA for supply-chain safety — this digest corresponds to
+      # sigstore/cosign-installer@v3.8.2 (2025-04-16). Update by checking
+      # https://github.com/sigstore/cosign-installer/releases and verifying
+      # the commit SHA from the release tag.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
+
+      # Sign the binary with cosign keyless OIDC.
+      # The GitHub Actions OIDC token (provided by id-token: write above) is
+      # exchanged with Fulcio to obtain a short-lived signing certificate that
+      # encodes this workflow's identity:
+      #   https://github.com/permanu/Dwaar/.github/workflows/release.yml@refs/tags/<tag>
+      # No keys are stored — verification uses the cert chain back to Fulcio.
+      # --yes suppresses the interactive consent prompt in CI.
+      - name: Sign binary with cosign (keyless OIDC)
+        run: |
+          cosign sign-blob \
+            --yes \
+            --bundle "dist/${{ matrix.artifact }}.bundle" \
+            --output-signature "dist/${{ matrix.artifact }}.sig" \
+            --output-certificate "dist/${{ matrix.artifact }}.cert" \
+            "dist/${{ matrix.artifact }}"
+
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
@@ -117,11 +149,23 @@ jobs:
           echo "$NOTES" >> $GITHUB_OUTPUT
           echo "EOFNOTES" >> $GITHUB_OUTPUT
 
+      # Aggregate all per-artifact sha256 files into a single SHASUMS.txt.
+      # install.sh and the auto-update agent both consume this file.
+      - name: Aggregate SHASUMS.txt
+        run: |
+          cd artifacts
+          cat *.sha256 > SHASUMS.txt
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           body: ${{ steps.changelog.outputs.notes }}
-          files: artifacts/*
+          # Include binaries, per-file sha256, cosign bundles (.bundle),
+          # detached signatures (.sig), signing certificates (.cert), and
+          # the aggregated SHASUMS.txt.
+          files: |
+            artifacts/dwaar-*
+            artifacts/SHASUMS.txt
           generate_release_notes: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Release binaries are now signed with cosign (keyless OIDC). `install.sh` verifies the signature when cosign is installed. Verification command: `cosign verify-blob --certificate-identity-regexp "^https://github.com/permanu/Dwaar/\\.github/workflows/release\\.yml@.*" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --certificate <binary>.cert --signature <binary>.sig <binary>`. Permanu's auto-update agent verifies the same way before swapping any binary.
+
 ## [0.3.8] - 2026-04-25
 
 First tagged release covering the v0.3.7 OTLP/sample_ratio work, which

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -433,6 +433,11 @@ main() {
     BINARY_TMP="${TMPDIR_DWAAR}/${ARTIFACT}"
     SHA256_TMP="${TMPDIR_DWAAR}/${ARTIFACT}.sha256"
 
+    SIG_URL="${BINARY_URL}.sig"
+    CERT_URL="${BINARY_URL}.cert"
+    SIG_TMP="${TMPDIR_DWAAR}/${ARTIFACT}.sig"
+    CERT_TMP="${TMPDIR_DWAAR}/${ARTIFACT}.cert"
+
     # 4. Download binary
     info "Downloading ${ARTIFACT}..."
     download "${BINARY_URL}" "${BINARY_TMP}"
@@ -442,6 +447,43 @@ main() {
     download "${SHA256_URL}" "${SHA256_TMP}"
     verify_sha256 "${BINARY_TMP}" "${SHA256_TMP}"
     success "SHA256 checksum verified."
+
+    # 5a. Cosign signature verification (keyless OIDC).
+    # The .sig and .cert files are published alongside every release binary.
+    # If cosign is installed, we verify the cryptographic signature — the cert
+    # chains to Fulcio with the GitHub Actions OIDC issuer and pins the exact
+    # workflow path that produced this binary.  This is a stronger guarantee
+    # than sha256 alone (sha256 only proves download integrity; cosign proves
+    # build provenance).
+    #
+    # If cosign is NOT installed we fall back to sha256-only and print a loud
+    # warning — we never silently bypass signature verification.
+    info "Verifying cosign signature..."
+    download "${SIG_URL}"  "${SIG_TMP}"
+    download "${CERT_URL}" "${CERT_TMP}"
+    if command -v cosign >/dev/null 2>&1; then
+        cosign verify-blob \
+            --certificate "${CERT_TMP}" \
+            --signature "${SIG_TMP}" \
+            --certificate-identity-regexp "^https://github\.com/permanu/Dwaar/\.github/workflows/release\.yml@.*" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            "${BINARY_TMP}"
+        success "Cosign signature verified."
+    else
+        printf "%bWarning: cosign not installed, skipping signature verification (sha256 still checked).%b\n" \
+            "${YELLOW}" "${RESET}" >&2
+        printf "%b         Install cosign from https://github.com/sigstore/cosign/releases%b\n" \
+            "${YELLOW}" "${RESET}" >&2
+        printf "%b         then verify manually:%b\n" "${YELLOW}" "${RESET}" >&2
+        printf "%b         cosign verify-blob \\%b\n" "${YELLOW}" "${RESET}" >&2
+        printf "%b           --certificate %s.cert \\%b\n" "${YELLOW}" "${ARTIFACT}" "${RESET}" >&2
+        printf "%b           --signature %s.sig \\%b\n" "${YELLOW}" "${ARTIFACT}" "${RESET}" >&2
+        printf '%b           --certificate-identity-regexp "^https://github\\.com/permanu/Dwaar/\\.github/workflows/release\\.yml@.*" \\%b\n' \
+            "${YELLOW}" "${RESET}" >&2
+        printf '%b           --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \\%b\n' \
+            "${YELLOW}" "${RESET}" >&2
+        printf "%b           %s%b\n" "${YELLOW}" "${ARTIFACT}" "${RESET}" >&2
+    fi
 
     # 6. Install the binary (sets INSTALL_PATH)
     info "Installing to ${SYSTEM_BIN}..."

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -50,6 +50,8 @@ fi
 
 DOWNLOAD_URL="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/${ARTIFACT}"
 CHECKSUM_URL="${DOWNLOAD_URL}.sha256"
+SIG_URL="${DOWNLOAD_URL}.sig"
+CERT_URL="${DOWNLOAD_URL}.cert"
 
 printf "Installing dwaar %s (%s/%s)\n" "$VERSION" "$os" "$arch"
 
@@ -59,6 +61,8 @@ trap 'rm -rf "$TMP"' EXIT
 
 curl -fSL --progress-bar -o "${TMP}/${ARTIFACT}" "$DOWNLOAD_URL"
 curl -fsSL -o "${TMP}/${ARTIFACT}.sha256" "$CHECKSUM_URL"
+curl -fsSL -o "${TMP}/${ARTIFACT}.sig"    "$SIG_URL"
+curl -fsSL -o "${TMP}/${ARTIFACT}.cert"   "$CERT_URL"
 
 # --- Verify checksum ---
 cd "$TMP"
@@ -68,6 +72,32 @@ elif command -v shasum >/dev/null 2>&1; then
   shasum -a 256 -c "${ARTIFACT}.sha256"
 else
   printf "Warning: no sha256 tool found, skipping checksum verification\n" >&2
+fi
+
+# --- Verify cosign signature (keyless OIDC) ---
+# The .sig and .cert files are published alongside every release binary.
+# Verification pins the GitHub Actions workflow identity — no pre-shared keys.
+# If cosign is not installed we fall back to sha256-only and print a loud
+# warning. We never silently bypass signature verification.
+if command -v cosign >/dev/null 2>&1; then
+  printf "Verifying cosign signature...\n"
+  cosign verify-blob \
+    --certificate "${TMP}/${ARTIFACT}.cert" \
+    --signature   "${TMP}/${ARTIFACT}.sig" \
+    --certificate-identity-regexp "^https://github\.com/permanu/Dwaar/\.github/workflows/release\.yml@.*" \
+    --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+    "${TMP}/${ARTIFACT}"
+  printf "Cosign signature verified.\n"
+else
+  printf "Warning: cosign not installed, skipping signature verification (sha256 still checked).\n" >&2
+  printf "         Install cosign: https://github.com/sigstore/cosign/releases\n" >&2
+  printf "         Then verify manually:\n" >&2
+  printf "           cosign verify-blob \\\\\n" >&2
+  printf "             --certificate %s.cert \\\\\n" "$ARTIFACT" >&2
+  printf "             --signature %s.sig \\\\\n" "$ARTIFACT" >&2
+  printf '             --certificate-identity-regexp "^https://github\\.com/permanu/Dwaar/\\.github/workflows/release\\.yml@.*" \\\\\n' >&2
+  printf '             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \\\\\n' >&2
+  printf "             %s\n" "$ARTIFACT" >&2
 fi
 
 # --- Install ---

--- a/site/src/content/docs/security/release-signing.md
+++ b/site/src/content/docs/security/release-signing.md
@@ -1,0 +1,109 @@
+---
+title: Release Signing
+description: How Dwaar release binaries are signed and how to verify them
+---
+
+# Release Signing
+
+Every Dwaar release binary is cryptographically signed using [cosign](https://github.com/sigstore/cosign) keyless OIDC signing. No pre-shared keys are required — verification relies on the public Sigstore infrastructure (Fulcio CA + Rekor transparency log).
+
+## Trust chain
+
+```
+GitHub Actions OIDC token
+        ↓
+Fulcio (Sigstore CA) exchanges it for a short-lived signing certificate
+        ↓
+Certificate encodes the exact workflow identity:
+  https://github.com/permanu/Dwaar/.github/workflows/release.yml@refs/tags/<tag>
+        ↓
+Binary is signed; signature + certificate recorded in Rekor (public transparency log)
+        ↓
+.sig and .cert artifacts attached to the GitHub Release
+```
+
+The certificate's Subject Alternative Name (SAN) is the workflow URI above. Verification checks that the cert chains back to Fulcio **and** that the workflow path matches the expected pattern — so a binary signed by any other workflow or repository will not verify.
+
+## Artifacts published per release
+
+For each platform binary (e.g. `dwaar-linux-amd64`) the following files are attached to the GitHub Release:
+
+| File | Contents |
+|------|----------|
+| `dwaar-<os>-<arch>` | The binary |
+| `dwaar-<os>-<arch>.sha256` | SHA256 checksum |
+| `dwaar-<os>-<arch>.sig` | Detached cosign signature |
+| `dwaar-<os>-<arch>.cert` | Short-lived signing certificate (PEM) |
+| `dwaar-<os>-<arch>.bundle` | Cosign bundle (sig + cert + Rekor metadata) |
+| `SHASUMS.txt` | Aggregated SHA256 for all binaries |
+
+## Verifying a binary
+
+### Automatic (via install.sh)
+
+`install.sh` verifies the cosign signature automatically if `cosign` is installed on the system. If cosign is not present it falls back to SHA256 verification and prints a prominent warning.
+
+### Manual verification
+
+Download the binary and its `.sig` / `.cert` siblings, then run:
+
+```sh
+cosign verify-blob \
+  --certificate dwaar-linux-amd64.cert \
+  --signature   dwaar-linux-amd64.sig \
+  --certificate-identity-regexp "^https://github\.com/permanu/Dwaar/\.github/workflows/release\.yml@.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  dwaar-linux-amd64
+```
+
+Replace `dwaar-linux-amd64` with your platform artifact name (`dwaar-linux-arm64`, `dwaar-darwin-arm64`).
+
+A successful verification prints:
+
+```
+Verified OK
+```
+
+### Installing cosign
+
+```sh
+# macOS
+brew install cosign
+
+# Linux (direct download)
+curl -Lo cosign https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64
+chmod +x cosign && sudo mv cosign /usr/local/bin/
+```
+
+See the [cosign releases page](https://github.com/sigstore/cosign/releases) for all platforms.
+
+## How to confirm the workflow identity
+
+The `--certificate-identity-regexp` you verify against is:
+
+```
+^https://github\.com/permanu/Dwaar/\.github/workflows/release\.yml@.*
+```
+
+This anchors to the `permanu/Dwaar` repository and the `release.yml` workflow file. The `@.*` suffix matches any git ref (tag, branch) so the same command works for any release version.
+
+To additionally pin to a specific tag:
+
+```sh
+--certificate-identity "https://github.com/permanu/Dwaar/.github/workflows/release.yml@refs/tags/v0.3.8"
+```
+
+## Agent-side verification (Permanu auto-update)
+
+The Permanu auto-update agent verifies cosign before swapping any binary:
+
+```sh
+cosign verify-blob \
+  --certificate <download_dir>/dwaar-<os>-<arch>.cert \
+  --signature   <download_dir>/dwaar-<os>-<arch>.sig \
+  --certificate-identity-regexp "^https://github\.com/permanu/Dwaar/\.github/workflows/release\.yml@.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  <download_dir>/dwaar-<os>-<arch>
+```
+
+The agent will refuse to apply an update if cosign verification fails. There is no bypass.


### PR DESCRIPTION
## Summary

- **release.yml**: adds `id-token: write` permission to the `build` job, installs `sigstore/cosign-installer@v3.8.2` (pinned to SHA `3454372f43399081ed03b604cb2d021dabca52bb`), and runs `cosign sign-blob` after each `cargo build --release`. The `.sig`, `.cert`, and `.bundle` artifacts are uploaded alongside the binary. The `release` job now also aggregates a `SHASUMS.txt` from all per-artifact `.sha256` files.
- **scripts/install.sh + site/public/install.sh**: after SHA256 verification, downloads `.sig` and `.cert` siblings; if `cosign` is installed runs `cosign verify-blob` with the pinned identity regexp and OIDC issuer; if not, prints a **loud warning** (never silent) and continues with sha256-only.
- **CHANGELOG.md**: `[Unreleased]` Security entry with the verbatim verify command.
- **site/src/content/docs/security/release-signing.md**: new doc — trust chain explanation, manual verification steps, agent-side note.

## Verification command (for Mission B to copy verbatim)

```sh
cosign verify-blob \
  --certificate <binary>.cert \
  --signature   <binary>.sig \
  --certificate-identity-regexp "^https://github\.com/permanu/Dwaar/\.github/workflows/release\.yml@.*" \
  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
  <binary>
```

The `--certificate-identity-regexp` is:
```
^https://github\.com/permanu/Dwaar/\.github/workflows/release\.yml@.*
```

## This unblocks agent-side auto-update verification

Mission B's agent can now verify every binary before swapping using the command above. Verification failure aborts the swap — there is no bypass path.

## Test plan

- [ ] `actionlint .github/workflows/release.yml` — clean (verified locally)
- [ ] `shellcheck site/public/install.sh` — clean (verified locally)
- [ ] `shellcheck scripts/install.sh` — pre-existing SC2016/SC2088 warnings only, none introduced by this PR
- [ ] On next tag push: confirm `.sig`, `.cert`, `.bundle`, `SHASUMS.txt` appear in the GitHub Release assets
- [ ] On a machine with cosign installed: run the verify command against a downloaded binary and cert/sig pair