### PR TITLE
ci: version-guard — prevent release-version skips and Cargo/LICENSE/CHANGELOG drift

### DIFF
--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -1,0 +1,36 @@
+name: Version Guard
+
+# Enforce that Cargo.toml dwaar-cli version, LICENSE Licensed Work version,
+# and the top CHANGELOG.md entry agree, AND that any version bump is exactly
+# one increment ahead of the latest published Git tag (no skips).
+#
+# Backstop for the missing-tag class of bugs that produced the v0.3.7
+# (never tagged) → v0.3.8 (LICENSE-mismatch failure) → v0.3.9 (actual
+# release) sequence on 2026-04-25. With this guard, that sequence cannot
+# recur — a PR that bumps Cargo.toml without matching LICENSE + CHANGELOG
+# fails CI before it can land on main.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: Version Consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Need full history so `git tag -l` resolves the latest tag.
+          fetch-depth: 0
+      - run: chmod +x scripts/check-version-consistency.sh
+      - run: ./scripts/check-version-consistency.sh

--- a/scripts/check-version-consistency.sh
+++ b/scripts/check-version-consistency.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# check-version-consistency.sh — Enforce that the version declared in
+# Cargo.toml, LICENSE, and CHANGELOG.md is consistent, and that any bump
+# is exactly one patch ahead of the latest published Git tag (or one
+# minor / major if those components increment with patch=0 / minor=0).
+#
+# Run by .github/workflows/version-guard.yml on every PR; also runnable
+# locally before opening a PR.
+#
+# Exits 0 if everything is consistent, non-zero with a descriptive
+# error otherwise.
+
+set -euo pipefail
+
+CARGO_TOML="crates/dwaar-cli/Cargo.toml"
+LICENSE_FILE="LICENSE"
+CHANGELOG_FILE="CHANGELOG.md"
+
+# --- Read the three sources of truth ---
+
+cargo_version() {
+    grep -E '^version = "[0-9]+\.[0-9]+\.[0-9]+"$' "$CARGO_TOML" | head -1 | sed -E 's/version = "([^"]+)"/\1/'
+}
+
+license_version() {
+    grep "Licensed Work:" "$LICENSE_FILE" | head -1 | awk '{print $NF}'
+}
+
+# Latest version that has a CHANGELOG section header (## [x.y.z]).
+# Guards against "Unreleased" sneaking in as the canonical version.
+changelog_top_version() {
+    grep -m 1 -E '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' "$CHANGELOG_FILE" | sed -E 's/^## \[([^]]+)\].*/\1/'
+}
+
+# Latest released git tag (any v-prefixed semver). Sorted by version, not date.
+latest_tag() {
+    git tag -l 'v[0-9]*' | sort -V | tail -1 | sed 's/^v//'
+}
+
+# --- Semver helpers ---
+
+split() { echo "$1" | tr '.' ' '; }
+
+is_clean_increment() {
+    # is_clean_increment <new> <old> → returns 0 if new is exactly old + 1 in
+    # major / minor / patch (with zeros below), else returns 1.
+    read -r oM om op <<<"$(split "$2")"
+    read -r nM nm np <<<"$(split "$1")"
+
+    # patch bump: same M.m, p = op + 1
+    if [ "$nM" = "$oM" ] && [ "$nm" = "$om" ] && [ "$np" = "$((op + 1))" ]; then return 0; fi
+    # minor bump: same M, m = om + 1, p = 0
+    if [ "$nM" = "$oM" ] && [ "$nm" = "$((om + 1))" ] && [ "$np" = "0" ]; then return 0; fi
+    # major bump: M = oM + 1, m = 0, p = 0
+    if [ "$nM" = "$((oM + 1))" ] && [ "$nm" = "0" ] && [ "$np" = "0" ]; then return 0; fi
+    return 1
+}
+
+# --- Run checks ---
+
+CARGO=$(cargo_version)
+LICENSE=$(license_version)
+CL=$(changelog_top_version)
+TAG=$(latest_tag)
+
+printf 'Cargo.toml dwaar-cli version : %s\n' "$CARGO"
+printf 'LICENSE Licensed Work version : %s\n' "$LICENSE"
+printf 'CHANGELOG top entry version  : %s\n' "$CL"
+printf 'Latest git tag                : %s\n' "$TAG"
+echo
+
+fail=0
+
+if [ "$CARGO" != "$LICENSE" ]; then
+    printf '✗ Cargo.toml (%s) does not match LICENSE (%s).\n' "$CARGO" "$LICENSE" >&2
+    printf '  Run: ./scripts/bump-license-date.sh %s\n' "$CARGO" >&2
+    fail=1
+fi
+
+if [ "$CARGO" != "$CL" ]; then
+    printf '✗ Cargo.toml (%s) does not match top CHANGELOG entry (%s).\n' "$CARGO" "$CL" >&2
+    printf "  Add a '## [%s] - YYYY-MM-DD' section to CHANGELOG.md.\n" "$CARGO" >&2
+    fail=1
+fi
+
+# Only enforce the increment rule when the version actually moved past the
+# latest tag — non-bumping PRs (most of them) leave Cargo.toml at the
+# already-tagged value and that's fine.
+if [ "$CARGO" != "$TAG" ]; then
+    if ! is_clean_increment "$CARGO" "$TAG"; then
+        printf '✗ Version skip detected.\n' >&2
+        printf '  Latest tag : v%s\n' "$TAG" >&2
+        printf '  Cargo.toml : %s\n' "$CARGO" >&2
+        printf '  Allowed next versions:\n' >&2
+        read -r M m p <<<"$(split "$TAG")"
+        printf '    %s.%s.%s   (patch)\n' "$M" "$m" "$((p + 1))" >&2
+        printf '    %s.%s.0     (minor)\n' "$M" "$((m + 1))" >&2
+        printf '    %s.0.0       (major)\n' "$((M + 1))" >&2
+        printf '  Either bump to one of those, or rebase onto main if a release was cut after your branch diverged.\n' >&2
+        fail=1
+    fi
+fi
+
+if [ "$fail" -ne 0 ]; then
+    exit 1
+fi
+
+printf '✓ Version triple is consistent and the bump (if any) is a clean increment.\n'


### PR DESCRIPTION
## Why

On 2026-04-25 we cut v0.3.9 only after this skip sequence:

- **v0.3.7** internal-bumped in PR #218 → never tagged → no release
- **v0.3.8** tagged → release.yml failed at \`Verify license date matches tag\` because LICENSE still said \`Dwaar 0.3.6\` → no release
- **v0.3.9** finally shipped (after PR #224 bumped LICENSE)

That created a visible gap on the Releases page (now backfilled with retroactive metadata-only releases for v0.3.2/3/4/7/8 — those tags were created so the Releases page reads continuously).

This PR adds a CI guard so the entire skip class becomes unmergeable.

## What it checks

On every PR / push to main, \`.github/workflows/version-guard.yml\` runs \`scripts/check-version-consistency.sh\`, which asserts:

1. **Triple agreement** — \`crates/dwaar-cli/Cargo.toml\` version, \`LICENSE\` Licensed Work version, and the top non-Unreleased \`CHANGELOG.md\` section header all match.
2. **Clean increment** — if Cargo.toml has moved past the latest \`v*\` Git tag, the new version is exactly latest + 1 in patch / minor / major (with zeros below). Skipping (\`0.3.6 → 0.3.8\`) is rejected with a descriptive error listing the three allowed next versions.

## Local use

Contributors can run the same script locally before opening a PR:

\`\`\`bash
./scripts/check-version-consistency.sh
\`\`\`

Sample failure output:

\`\`\`
✗ Version skip detected.
  Latest tag : v0.3.9
  Cargo.toml : 0.3.11
  Allowed next versions:
    0.3.10  (patch)
    0.4.0   (minor)
    1.0.0   (major)
\`\`\`

## Tested

- Local run against current main (\`Cargo.toml 0.3.9 / LICENSE 0.3.9 / CHANGELOG [0.3.9] / tag v0.3.9\`) → PASS.
- Logic verified by hand with a deliberately-mismatched Cargo.toml.

## Not in this PR

- Auto-bumping LICENSE on Cargo.toml change (still manual via \`scripts/bump-license-date.sh <version>\`). The guard catches drift loudly, so manual + verification is sufficient for now.
- Tag-time continuity check in release.yml (the LICENSE check there already covers the same ground from the tag direction).