### PR TITLE
chore(release): v0.3.10 — auto-update production pipeline ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.10] - 2026-04-25
+
+First release of the production auto-update pipeline. After this lands
+on a customer VPS, Permanu's control plane can stage canary rollouts
+to the entire Dwaar fleet with cosign-verified binaries and
+zero-downtime socket handoff.
+
 ### Added
 
 - **`auto_update { enabled / drain_timeout_secs / health_check_url / rollback_on_health_fail }` knobs** —

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-cli"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.3.9
+Licensed Work:        Dwaar 0.3.10
                       The Licensed Work is
                       (c) 2026 Permanu
 

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.3.9"
+version = "0.3.10"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false


### PR DESCRIPTION
## Summary

First release of the production auto-update pipeline. After this lands on a customer VPS, Permanu's control plane can stage canary rollouts to the entire Dwaar fleet with cosign-verified binaries and zero-downtime socket handoff.

### What's in this release

#### Added
- **\`auto_update { ... }\` Dwaarfile directive** with knobs: \`enabled\`, \`drain_timeout_secs\`, \`health_check_url\`, \`rollback_on_health_fail\`
- **Pingora \`upgrade_sock\` graceful binary swap** — SIGUSR2 handler spawns child via FD-passing; parent drains in-flight connections and exits when done
- **Admin endpoints** \`GET /healthz\` (drain-aware: 503 during shutdown) and \`GET /version\` (returns version + pid + started_at)
- **\`DWAAR_UPGRADE_SOCK\` / \`DWAAR_UPGRADE_FROM\` / \`DWAAR_UPGRADE_BINARY\`** env knobs for the upgrade orchestrator

#### Security
- **Cosign keyless signing** on all release binaries. \`install.sh\` verifies the signature when cosign is installed; the permanu-agent verifies the same way before any swap. Verification cmd:
  ```
  cosign verify-blob \
    --certificate-identity-regexp "^https://github.com/permanu/Dwaar/\\.github/workflows/release\\.yml@.*" \
    --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
    --certificate <binary>.cert --signature <binary>.sig <binary>
  ```

### Plan after merge

1. Tag \`v0.3.10\`
2. release.yml fires → 3 cross-compile builds (linux-amd64, linux-arm64, darwin-arm64) → cosign signs each → GitHub Release auto-created with \`.sig\`, \`.cert\`, \`.bundle\` artifacts
3. End-to-end auto-update is live: Mission B's \`permanu-agent\` (already on customer VPSes) will pick up v0.3.10 instructions from Mission C's backend rollout state machine.

### Verified

- Local \`./scripts/check-version-consistency.sh\` → ✓ clean increment from v0.3.9
- LICENSE \"Licensed Work: Dwaar 0.3.10\" + Change Date 2036-04-25
- CHANGELOG \[0.3.10\] section pulled forward from [Unreleased]