### PR TITLE
perf(dwaar-core): pre-allocate FastCGI request body buffer up to 64KB

### DIFF
--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -1318,7 +1318,14 @@ impl ProxyHttp for DwaarProxy {
             let host = ctx.plugin_ctx.host.as_deref().unwrap_or("localhost");
 
             // Read request body for POST — reject with 413 if it exceeds the limit.
-            let mut body_buf = Vec::new();
+            // Pre-size the buffer so the typical small POST (forms, JSON
+            // payloads <16 KiB) lands in a single allocation. Cap at 64 KiB
+            // so we don't speculatively allocate megabytes for unlikely large
+            // bodies — the loop below grows the Vec naturally beyond the
+            // pre-alloc when needed.
+            let body_prealloc =
+                usize::try_from(ctx.request_body_max_size.min(64 * 1024)).unwrap_or(usize::MAX);
+            let mut body_buf = Vec::with_capacity(body_prealloc);
             while let Ok(Some(chunk)) = session.downstream_session.read_request_body().await {
                 body_buf.extend_from_slice(&chunk);
                 if body_buf.len() as u64 > ctx.request_body_max_size {


### PR DESCRIPTION
## Summary

`proxy.rs:1321` — the FastCGI POST body buffer now pre-allocates `min(body_max, 64 KiB)` instead of starting from zero capacity. Eliminates realloc cascade for typical form/JSON POST bodies into PHP/FastCGI upstreams.

(Internal note: this was originally tracked as "forward_auth body" in our perf audit; verification on-branch showed the line is actually in the FastCGI execution path, not the forward_auth plugin path. The fix and rationale are unchanged — pre-allocate the body buffer — only the label was off. A separate ticket should follow for the forward_auth body buffer if it has the same anti-pattern.)

No bench in isolation — exercised end-to-end by FastCGI integration paths. The change is a pre-allocation hint only; semantics are unchanged.

## Test plan
- [x] `cargo build -p dwaar-core`
- [x] `cargo test -p dwaar-core` (all tests pass)
- [x] `cargo clippy -p dwaar-core --all-targets -- -D warnings`