### PR TITLE
refactor(dwaar-plugins): PluginResponse header values use Cow<'static, str>

### DIFF
--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -509,7 +509,7 @@ impl DwaarProxy {
     ) -> Result<bool> {
         let mut resp = ResponseHeader::build(plugin_resp.status, Some(plugin_resp.headers.len()))?;
         for (name, value) in &plugin_resp.headers {
-            resp.insert_header(*name, value.as_str()).map_err(|e| {
+            resp.insert_header(*name, value.as_ref()).map_err(|e| {
                 Error::explain(
                     HTTPStatus(plugin_resp.status),
                     format!("plugin response header error: {e}"),

--- a/crates/dwaar-core/src/quic/handler.rs
+++ b/crates/dwaar-core/src/quic/handler.rs
@@ -759,7 +759,7 @@ async fn send_plugin_response<S, B>(
     };
 
     for (name, value) in &plugin_resp.headers {
-        let _ = pingora_resp.insert_header(*name, value.as_str());
+        let _ = pingora_resp.insert_header(*name, value.as_ref());
     }
 
     plugin_chain.run_response(&mut pingora_resp, ctx);

--- a/crates/dwaar-plugins/src/ip_filter.rs
+++ b/crates/dwaar-plugins/src/ip_filter.rs
@@ -218,7 +218,7 @@ impl DwaarPlugin for IpFilterPlugin {
         } else {
             PluginAction::Respond(PluginResponse {
                 status: 403,
-                headers: vec![("Content-Length", "0".to_string())],
+                headers: vec![("Content-Length", std::borrow::Cow::Borrowed("0"))],
                 body: Bytes::new(),
             })
         }

--- a/crates/dwaar-plugins/src/plugin.rs
+++ b/crates/dwaar-plugins/src/plugin.rs
@@ -79,7 +79,12 @@ pub struct PluginCtx {
 #[derive(Debug, Clone)]
 pub struct PluginResponse {
     pub status: u16,
-    pub headers: Vec<(&'static str, String)>,
+    /// Response headers. Value is `Cow<'static, str>` so static literals
+    /// (Content-Length: "0", Retry-After: "1") are zero-alloc Borrowed,
+    /// while runtime-built values (cookie strings, dynamic Content-Length)
+    /// use Owned. Avoids per-rejected-request heap allocations on the
+    /// rate-limit and ip-filter short-circuit paths.
+    pub headers: Vec<(&'static str, std::borrow::Cow<'static, str>)>,
     pub body: Bytes,
 }
 
@@ -310,7 +315,7 @@ mod tests {
                 request_action: || {
                     PluginAction::Respond(PluginResponse {
                         status: 429,
-                        headers: vec![("Retry-After", "1".to_string())],
+                        headers: vec![("Retry-After", std::borrow::Cow::Borrowed("1"))],
                         body: Bytes::new(),
                     })
                 },
@@ -452,5 +457,18 @@ mod tests {
         })]);
         let debug = format!("{chain:?}");
         assert!(debug.contains("test-plugin"));
+    }
+
+    #[test]
+    fn plugin_response_borrows_static_header_value() {
+        // After the Cow refactor, a literal value should be a Borrowed
+        // variant — the whole point of the change is no per-request alloc
+        // for short-circuit responses (rate-limit 429, ip-filter 403).
+        let r = PluginResponse {
+            status: 200,
+            headers: vec![("Content-Length", std::borrow::Cow::Borrowed("0"))],
+            body: bytes::Bytes::new(),
+        };
+        assert!(matches!(r.headers[0].1, std::borrow::Cow::Borrowed(_)));
     }
 }

--- a/crates/dwaar-plugins/src/rate_limit.rs
+++ b/crates/dwaar-plugins/src/rate_limit.rs
@@ -143,8 +143,8 @@ impl DwaarPlugin for RateLimitPlugin {
         PluginAction::Respond(PluginResponse {
             status: 429,
             headers: vec![
-                ("Retry-After", "1".to_string()),
-                ("Content-Length", "0".to_string()),
+                ("Retry-After", std::borrow::Cow::Borrowed("1")),
+                ("Content-Length", std::borrow::Cow::Borrowed("0")),
             ],
             body: Bytes::new(),
         })

--- a/crates/dwaar-plugins/src/under_attack.rs
+++ b/crates/dwaar-plugins/src/under_attack.rs
@@ -348,10 +348,10 @@ impl DwaarPlugin for UnderAttackPlugin {
                 return PluginAction::Respond(PluginResponse {
                     status: 302,
                     headers: vec![
-                        ("Set-Cookie", cookie_header),
-                        ("Location", clean_path),
-                        ("Content-Length", "0".to_string()),
-                        ("Cache-Control", "no-store".to_string()),
+                        ("Set-Cookie", std::borrow::Cow::Owned(cookie_header)),
+                        ("Location", std::borrow::Cow::Owned(clean_path)),
+                        ("Content-Length", std::borrow::Cow::Borrowed("0")),
+                        ("Cache-Control", std::borrow::Cow::Borrowed("no-store")),
                     ],
                     body: Bytes::new(),
                 });
@@ -365,9 +365,15 @@ impl DwaarPlugin for UnderAttackPlugin {
         PluginAction::Respond(PluginResponse {
             status: 200,
             headers: vec![
-                ("Content-Type", "text/html; charset=utf-8".to_string()),
-                ("Content-Length", body.len().to_string()),
-                ("Cache-Control", "no-store".to_string()),
+                (
+                    "Content-Type",
+                    std::borrow::Cow::Borrowed("text/html; charset=utf-8"),
+                ),
+                (
+                    "Content-Length",
+                    std::borrow::Cow::Owned(body.len().to_string()),
+                ),
+                ("Cache-Control", std::borrow::Cow::Borrowed("no-store")),
             ],
             body,
         })

--- a/crates/dwaar-plugins/src/wasm/bindings.rs
+++ b/crates/dwaar-plugins/src/wasm/bindings.rs
@@ -83,7 +83,10 @@ pub fn wit_action_to_native(action: wit_types::PluginAction) -> PluginAction {
         wit_types::PluginAction::Continue => PluginAction::Continue,
         wit_types::PluginAction::Respond => PluginAction::Respond(crate::plugin::PluginResponse {
             status: 503,
-            headers: vec![("content-type", "text/plain".to_string())],
+            headers: vec![(
+                "content-type",
+                std::borrow::Cow::Owned("text/plain".to_string()),
+            )],
             body: bytes::Bytes::from_static(b"plugin short-circuit"),
         }),
         wit_types::PluginAction::Skip => PluginAction::Skip,

--- a/crates/dwaar-plugins/src/wasm/bindings.rs
+++ b/crates/dwaar-plugins/src/wasm/bindings.rs
@@ -83,10 +83,7 @@ pub fn wit_action_to_native(action: wit_types::PluginAction) -> PluginAction {
         wit_types::PluginAction::Continue => PluginAction::Continue,
         wit_types::PluginAction::Respond => PluginAction::Respond(crate::plugin::PluginResponse {
             status: 503,
-            headers: vec![(
-                "content-type",
-                std::borrow::Cow::Owned("text/plain".to_string()),
-            )],
+            headers: vec![("content-type", std::borrow::Cow::Borrowed("text/plain"))],
             body: bytes::Bytes::from_static(b"plugin short-circuit"),
         }),
         wit_types::PluginAction::Skip => PluginAction::Skip,


### PR DESCRIPTION
## Summary

`PluginResponse.headers` value type: `String` → `Cow<'static, str>`.

- Eliminates per-rejected-request heap allocations in ip_filter (403) and rate_limit (429) hot paths.
- All internal construction sites updated (5 in dwaar-plugins, 1 WASM bridge).
- Consumer fix in dwaar-core/proxy.rs and quic/handler.rs: `.as_str()` is stable on `String` but resolves to the unstable `str_as_str` path on `Cow<str>`; switched to `.as_ref()` which is fully stable and equivalent.

## Callsite breakdown (Borrowed/Owned split)

| Site | Header | Variant |
|------|--------|---------|
| ip_filter.rs | Content-Length "0" | Borrowed |
| rate_limit.rs | Retry-After "1" | Borrowed |
| rate_limit.rs | Content-Length "0" | Borrowed |
| under_attack.rs (302) | Set-Cookie (format!) | Owned |
| under_attack.rs (302) | Location (runtime) | Owned |
| under_attack.rs (302) | Content-Length "0" | Borrowed |
| under_attack.rs (302) | Cache-Control "no-store" | Borrowed |
| under_attack.rs (200) | Content-Type (literal) | Borrowed |
| under_attack.rs (200) | Content-Length (body.len()) | Owned |
| under_attack.rs (200) | Cache-Control "no-store" | Borrowed |
| plugin.rs test helper | Retry-After "1" | Borrowed |
| wasm/bindings.rs | content-type (WIT stub) | Owned |

## Test plan
- [x] `cargo test -p dwaar-plugins` (includes new `plugin_response_borrows_static_header_value` test — red first, then green)
- [x] `cargo build -p dwaar-core` (both consumers at proxy.rs:512 and quic/handler.rs:762)
- [x] `cargo clippy -p dwaar-plugins -p dwaar-core --all-targets -- -D warnings`
- [x] `cargo fmt --check`