### PR TITLE
fix(dwaar-core): guard round-robin against empty backend pool (#170)

### DIFF
--- a/crates/dwaar-core/src/l4.rs
+++ b/crates/dwaar-core/src/l4.rs
@@ -1762,6 +1762,24 @@ mod tests {
         );
     }
 
+    #[test]
+    fn round_robin_empty_pool_returns_none() {
+        // Regression for issue #170: select_upstream() computed `counter % n`
+        // where n = upstreams.len(). An empty pool made n == 0, which panics.
+        // The guard was added so callers see None rather than a worker crash.
+        let upstreams: Vec<SocketAddr> = vec![];
+        let health: Vec<Arc<L4UpstreamHealth>> = vec![];
+        let rr_counter = Arc::new(AtomicU64::new(0));
+        let result = select_upstream(
+            &upstreams,
+            &health,
+            L4LoadBalancePolicy::RoundRobin,
+            &rr_counter,
+            peer(9000),
+        );
+        assert!(result.is_none(), "empty pool must return None, not panic");
+    }
+
     // -- Passive health tracking --
 
     #[test]

--- a/crates/dwaar-core/src/upstream.rs
+++ b/crates/dwaar-core/src/upstream.rs
@@ -273,6 +273,13 @@ impl UpstreamPool {
     /// without changing the distribution for the common all-healthy case.
     fn select_round_robin(&self) -> Option<SocketAddr> {
         let n = self.backends.len();
+        // Guard against empty pool — `% n` panics on n == 0. The public
+        // `select()` already returns None before reaching here, but this inner
+        // guard makes the function independently safe if the call path changes.
+        // See #170.
+        if n == 0 {
+            return None;
+        }
         let start = self.counter.fetch_add(1, Ordering::Relaxed) as usize % n;
         self.find_available_from(start)
     }
@@ -1404,5 +1411,19 @@ mod tests {
         });
         assert!(pool.retry_config().is_enabled());
         assert_eq!(pool.retry_config().max_retries, 3);
+    }
+
+    // ── regression: issue #170 ───────────────────────────────────────────────
+
+    #[test]
+    fn round_robin_empty_pool_returns_none() {
+        // Regression for issue #170: select_round_robin() previously computed
+        // `counter % backends.len()` without checking len > 0, causing a
+        // division-by-zero panic on an empty pool. The guard in select() caught
+        // this for callers going through the public API, but select_round_robin()
+        // itself was unguarded — reachable if the call path ever changes.
+        let pool = UpstreamPool::new(vec![], LbPolicy::RoundRobin, None, None);
+        // Call the inner method directly to verify it is independently safe.
+        assert!(pool.select_round_robin().is_none());
     }
 }


### PR DESCRIPTION
## Summary
- `upstream.rs` `select_round_robin()` now early-returns `None` when the backend pool is empty, preventing a division-by-zero panic on `counter % backends.len()`.
- `l4.rs` `select_upstream()` already had this guard; a regression test is added to make the coverage explicit.
- Adds two regression tests (`round_robin_empty_pool_returns_none`) — the `upstream.rs` test was verified red (panic) before the fix and green after.

## Test plan
- [x] `cargo test -p dwaar-core --lib` — 314 tests pass including both new regression tests
- [x] `cargo clippy -p dwaar-core --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Closes #170