### PR TITLE
perf(dwaar-analytics): offload /proc reads via spawn_blocking (#156)

### DIFF
--- a/crates/dwaar-admin/src/service.rs
+++ b/crates/dwaar-admin/src/service.rs
@@ -401,7 +401,7 @@ impl AdminService {
                 }
             }
             ("GET", "/metrics") => match &self.prometheus {
-                Some(prom) => prometheus_response(&prom.render()),
+                Some(prom) => prometheus_response(&prom.render().await),
                 None => json_response(
                     404,
                     r#"{"error":"metrics not enabled — start with --no-metrics=false"}"#,

--- a/crates/dwaar-analytics/Cargo.toml
+++ b/crates/dwaar-analytics/Cargo.toml
@@ -34,7 +34,7 @@ libc = { workspace = true }
 parking_lot = { workspace = true }
 pingora-core = { workspace = true }
 sonic-rs = { workspace = true }
-tokio = { workspace = true, features = ["sync", "time", "net", "io-util"] }
+tokio = { workspace = true, features = ["sync", "time", "net", "io-util", "rt"] }
 
 [dev-dependencies]
 chrono = { workspace = true }
@@ -42,6 +42,7 @@ compact_str = { workspace = true }
 criterion = { workspace = true }
 hyperloglog = { workspace = true }
 tempfile = { workspace = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 
 [[bench]]
 name = "aggregation"

--- a/crates/dwaar-analytics/src/process_metrics.rs
+++ b/crates/dwaar-analytics/src/process_metrics.rs
@@ -34,7 +34,7 @@ fn warn_once_on_proc_failure(path: &str, err: &std::io::Error) {
     });
 }
 
-/// Synchronous /proc read used only at startup (process_start_time_secs init).
+/// Synchronous /proc read used only at startup (`process_start_time_secs` init).
 ///
 /// The async `read_proc` variant below must be used for all per-scrape reads.
 /// Startup happens before the server accepts traffic, so a blocking read here
@@ -50,7 +50,7 @@ fn read_proc_sync(path: &str) -> Option<String> {
     }
 }
 
-/// Offloads a /proc file read onto a blocking thread via spawn_blocking.
+/// Offloads a /proc file read onto a blocking thread via `spawn_blocking`.
 ///
 /// Procfs reads are normally fast, but under disk pressure the kernel can
 /// stall the page-fault path for tens to hundreds of milliseconds. Doing
@@ -71,10 +71,10 @@ async fn read_proc(path: &'static str) -> Option<String> {
     .flatten()
 }
 
-/// Offloads a /proc directory read onto a blocking thread via spawn_blocking.
+/// Offloads a /proc directory read onto a blocking thread via `spawn_blocking`.
 ///
 /// Counting entries in /proc/self/fd requires a readdir syscall, which can
-/// block under I/O pressure. We collect the count inside spawn_blocking to
+/// block under I/O pressure. We collect the count inside `spawn_blocking` to
 /// avoid holding the async worker hostage.
 /// See issue #156.
 #[cfg(target_os = "linux")]
@@ -342,7 +342,7 @@ fn cpu_seconds_total_impl() -> f64 {
 
 #[cfg(target_os = "linux")]
 async fn resident_memory_bytes_impl() -> u64 {
-    // /proc/self/status VmRSS is in kB. The read is offloaded via spawn_blocking
+    // /proc/self/status VmRSS is in kB. The read is offloaded via `spawn_blocking`
     // because procfs can stall on disk pressure (issue #156).
     read_proc("/proc/self/status")
         .await
@@ -424,7 +424,7 @@ fn max_fds_impl() -> u64 {
 
 #[cfg(target_os = "linux")]
 async fn threads_impl() -> u64 {
-    // Threads: field in /proc/self/status. Offloaded via spawn_blocking
+    // Threads: field in /proc/self/status. Offloaded via `spawn_blocking`
     // for the same reason as resident_memory_bytes_impl (issue #156).
     read_proc("/proc/self/status")
         .await

--- a/crates/dwaar-analytics/src/process_metrics.rs
+++ b/crates/dwaar-analytics/src/process_metrics.rs
@@ -34,9 +34,13 @@ fn warn_once_on_proc_failure(path: &str, err: &std::io::Error) {
     });
 }
 
-/// Reads a /proc file, logging a one-shot warning if the read fails.
+/// Synchronous /proc read used only at startup (process_start_time_secs init).
+///
+/// The async `read_proc` variant below must be used for all per-scrape reads.
+/// Startup happens before the server accepts traffic, so a blocking read here
+/// does not stall any runtime workers.
 #[cfg(target_os = "linux")]
-fn read_proc(path: &str) -> Option<String> {
+fn read_proc_sync(path: &str) -> Option<String> {
     match std::fs::read_to_string(path) {
         Ok(s) => Some(s),
         Err(e) => {
@@ -46,16 +50,44 @@ fn read_proc(path: &str) -> Option<String> {
     }
 }
 
-/// Reads a /proc directory, logging a one-shot warning if the read fails.
+/// Offloads a /proc file read onto a blocking thread via spawn_blocking.
+///
+/// Procfs reads are normally fast, but under disk pressure the kernel can
+/// stall the page-fault path for tens to hundreds of milliseconds. Doing
+/// this on a runtime worker thread blocks all tasks on that thread. Moving
+/// the read onto a dedicated blocking thread keeps the async workers free.
+/// See issue #156.
 #[cfg(target_os = "linux")]
-fn read_proc_dir(path: &str) -> Option<std::fs::ReadDir> {
-    match std::fs::read_dir(path) {
-        Ok(entries) => Some(entries),
+async fn read_proc(path: &'static str) -> Option<String> {
+    tokio::task::spawn_blocking(move || match std::fs::read_to_string(path) {
+        Ok(s) => Some(s),
         Err(e) => {
             warn_once_on_proc_failure(path, &e);
             None
         }
-    }
+    })
+    .await
+    .ok()
+    .flatten()
+}
+
+/// Offloads a /proc directory read onto a blocking thread via spawn_blocking.
+///
+/// Counting entries in /proc/self/fd requires a readdir syscall, which can
+/// block under I/O pressure. We collect the count inside spawn_blocking to
+/// avoid holding the async worker hostage.
+/// See issue #156.
+#[cfg(target_os = "linux")]
+async fn read_proc_dir_count(path: &'static str) -> u64 {
+    tokio::task::spawn_blocking(move || match std::fs::read_dir(path) {
+        Ok(entries) => entries.count() as u64,
+        Err(e) => {
+            warn_once_on_proc_failure(path, &e);
+            0
+        }
+    })
+    .await
+    .unwrap_or(0)
 }
 
 /// Cached process start time in Unix seconds.
@@ -101,12 +133,14 @@ impl ProcessMetrics {
         cpu_seconds_total_impl()
     }
 
-    pub fn resident_memory_bytes(&self) -> u64 {
-        resident_memory_bytes_impl()
+    /// Async — offloads the /proc/self/status read onto a blocking thread.
+    pub async fn resident_memory_bytes(&self) -> u64 {
+        resident_memory_bytes_impl().await
     }
 
-    pub fn open_fds(&self) -> u64 {
-        open_fds_impl()
+    /// Async — offloads the /proc/self/fd readdir onto a blocking thread.
+    pub async fn open_fds(&self) -> u64 {
+        open_fds_impl().await
     }
 
     pub fn start_time_seconds(&self) -> f64 {
@@ -117,12 +151,17 @@ impl ProcessMetrics {
         max_fds_impl()
     }
 
-    pub fn threads(&self) -> u64 {
-        threads_impl()
+    /// Async — offloads the /proc/self/status thread-count read onto a blocking thread.
+    pub async fn threads(&self) -> u64 {
+        threads_impl().await
     }
 
     /// Render all 6 `process_*` metrics in Prometheus text exposition format.
-    pub fn render(&self, out: &mut String) {
+    ///
+    /// Async because the per-scrape /proc reads are offloaded via
+    /// `spawn_blocking` to avoid blocking the runtime worker on slow procfs
+    /// I/O (issue #156).
+    pub async fn render(&self, out: &mut String) {
         out.push_str(
             "# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.\n",
         );
@@ -138,12 +177,12 @@ impl ProcessMetrics {
         let _ = writeln!(
             out,
             "process_resident_memory_bytes {}",
-            self.resident_memory_bytes()
+            self.resident_memory_bytes().await
         );
 
         out.push_str("# HELP process_open_fds Number of open file descriptors.\n");
         out.push_str("# TYPE process_open_fds gauge\n");
-        let _ = writeln!(out, "process_open_fds {}", self.open_fds());
+        let _ = writeln!(out, "process_open_fds {}", self.open_fds().await);
 
         out.push_str("# HELP process_start_time_seconds Start time of the process since Unix epoch in seconds.\n");
         out.push_str("# TYPE process_start_time_seconds gauge\n");
@@ -159,7 +198,7 @@ impl ProcessMetrics {
 
         out.push_str("# HELP process_threads Number of OS threads in the process.\n");
         out.push_str("# TYPE process_threads gauge\n");
-        let _ = writeln!(out, "process_threads {}", self.threads());
+        let _ = writeln!(out, "process_threads {}", self.threads().await);
     }
 }
 
@@ -184,10 +223,15 @@ fn current_unix_secs() -> f64 {
 ///
 /// Every path returns a finite non-negative `f64` — callers never have to
 /// handle errors because the metric is a best-effort gauge.
+///
+/// Uses synchronous /proc reads deliberately: this runs exactly once at
+/// startup (cached by `PROCESS_START_TIME_SECS`), before the server accepts
+/// traffic, so blocking is acceptable here. Per-scrape reads use the async
+/// helpers instead.
 fn process_start_time_secs() -> f64 {
     #[cfg(target_os = "linux")]
     {
-        if let Some(secs) = linux_process_start_time_secs() {
+        if let Some(secs) = linux_process_start_time_secs_sync() {
             return secs;
         }
     }
@@ -200,11 +244,12 @@ fn process_start_time_secs() -> f64 {
     current_unix_secs()
 }
 
+/// Sync version of the Linux start-time lookup, used only at startup init.
 #[cfg(target_os = "linux")]
-fn linux_process_start_time_secs() -> Option<f64> {
+fn linux_process_start_time_secs_sync() -> Option<f64> {
     // /proc/self/stat: split on the LAST `)` to avoid desync from a
     // `comm` field that contains spaces or parens.
-    let stat = read_proc("/proc/self/stat")?;
+    let stat = read_proc_sync("/proc/self/stat")?;
     let rparen = stat.rfind(')')?;
     let after = stat.get(rparen + 1..)?.trim_start();
     // `starttime` is original field 22 → index 22-3 = 19 in `after`.
@@ -221,7 +266,7 @@ fn linux_process_start_time_secs() -> Option<f64> {
     #[allow(clippy::cast_precision_loss)]
     let seconds_since_boot = starttime_ticks as f64 / clk_tck;
 
-    let stat2 = read_proc("/proc/stat")?;
+    let stat2 = read_proc_sync("/proc/stat")?;
     let btime: u64 = stat2
         .lines()
         .find_map(|l| l.strip_prefix("btime "))?
@@ -296,9 +341,11 @@ fn cpu_seconds_total_impl() -> f64 {
 }
 
 #[cfg(target_os = "linux")]
-fn resident_memory_bytes_impl() -> u64 {
-    // /proc/self/status VmRSS is in kB.
+async fn resident_memory_bytes_impl() -> u64 {
+    // /proc/self/status VmRSS is in kB. The read is offloaded via spawn_blocking
+    // because procfs can stall on disk pressure (issue #156).
     read_proc("/proc/self/status")
+        .await
         .and_then(|s| {
             s.lines()
                 .find(|line| line.starts_with("VmRSS:"))
@@ -313,8 +360,10 @@ fn resident_memory_bytes_impl() -> u64 {
 }
 
 #[cfg(target_os = "macos")]
-#[allow(unsafe_code)]
-fn resident_memory_bytes_impl() -> u64 {
+#[allow(unsafe_code, clippy::unused_async)]
+// getrusage is a syscall with no blocking I/O, so spawn_blocking is not needed
+// here. The async signature is kept so callers are uniform across platforms.
+async fn resident_memory_bytes_impl() -> u64 {
     // ru_maxrss is in bytes on macOS (unlike Linux where it's KB).
     unsafe {
         let mut usage: libc::rusage = std::mem::zeroed();
@@ -327,25 +376,36 @@ fn resident_memory_bytes_impl() -> u64 {
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-fn resident_memory_bytes_impl() -> u64 {
+#[allow(clippy::unused_async)]
+// Stub for unsupported platforms; async signature kept for API uniformity.
+async fn resident_memory_bytes_impl() -> u64 {
     0
 }
 
 #[cfg(target_os = "linux")]
-fn open_fds_impl() -> u64 {
-    read_proc_dir("/proc/self/fd").map_or(0, |entries| entries.count() as u64)
+async fn open_fds_impl() -> u64 {
+    // Counting /proc/self/fd entries requires readdir, which can block under
+    // I/O pressure. Offload to a blocking thread (issue #156).
+    read_proc_dir_count("/proc/self/fd").await
 }
 
 #[cfg(target_os = "macos")]
-fn open_fds_impl() -> u64 {
-    // /dev/fd is macOS's equivalent of /proc/self/fd.
-    std::fs::read_dir("/dev/fd")
-        .map(|entries| entries.count() as u64)
-        .unwrap_or(0)
+async fn open_fds_impl() -> u64 {
+    // /dev/fd is macOS's equivalent of /proc/self/fd. readdir can block
+    // under I/O pressure; offload to a blocking thread (issue #156).
+    tokio::task::spawn_blocking(|| {
+        std::fs::read_dir("/dev/fd")
+            .map(|entries| entries.count() as u64)
+            .unwrap_or(0)
+    })
+    .await
+    .unwrap_or(0)
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-fn open_fds_impl() -> u64 {
+#[allow(clippy::unused_async)]
+// Stub for unsupported platforms; async signature kept for API uniformity.
+async fn open_fds_impl() -> u64 {
     0
 }
 
@@ -363,8 +423,11 @@ fn max_fds_impl() -> u64 {
 }
 
 #[cfg(target_os = "linux")]
-fn threads_impl() -> u64 {
+async fn threads_impl() -> u64 {
+    // Threads: field in /proc/self/status. Offloaded via spawn_blocking
+    // for the same reason as resident_memory_bytes_impl (issue #156).
     read_proc("/proc/self/status")
+        .await
         .and_then(|s| {
             s.lines()
                 .find(|line| line.starts_with("Threads:"))
@@ -375,7 +438,9 @@ fn threads_impl() -> u64 {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn threads_impl() -> u64 {
+#[allow(clippy::unused_async)]
+// Stub for non-Linux platforms; async signature kept for API uniformity.
+async fn threads_impl() -> u64 {
     // No portable way without platform-specific APIs.
     0
 }
@@ -395,19 +460,19 @@ mod tests {
         assert!(m.cpu_seconds_total() >= 0.0);
     }
 
-    #[test]
-    fn resident_memory_is_positive() {
+    #[tokio::test]
+    async fn resident_memory_is_positive() {
         let m = ProcessMetrics::new();
         assert!(
-            m.resident_memory_bytes() > 0,
+            m.resident_memory_bytes().await > 0,
             "process must use some memory"
         );
     }
 
-    #[test]
-    fn open_fds_positive() {
+    #[tokio::test]
+    async fn open_fds_positive() {
         let m = ProcessMetrics::new();
-        assert!(m.open_fds() > 0, "stdin/stdout/stderr at minimum");
+        assert!(m.open_fds().await > 0, "stdin/stdout/stderr at minimum");
     }
 
     #[test]
@@ -424,11 +489,11 @@ mod tests {
         assert!(m.max_fds() > 0);
     }
 
-    #[test]
-    fn render_contains_all_metrics() {
+    #[tokio::test]
+    async fn render_contains_all_metrics() {
         let m = ProcessMetrics::new();
         let mut out = String::new();
-        m.render(&mut out);
+        m.render(&mut out).await;
 
         assert!(out.contains("process_cpu_seconds_total"));
         assert!(out.contains("process_resident_memory_bytes"));
@@ -438,11 +503,11 @@ mod tests {
         assert!(out.contains("process_threads"));
     }
 
-    #[test]
-    fn render_has_help_and_type_lines() {
+    #[tokio::test]
+    async fn render_has_help_and_type_lines() {
         let m = ProcessMetrics::new();
         let mut out = String::new();
-        m.render(&mut out);
+        m.render(&mut out).await;
 
         let help_count = out.matches("# HELP").count();
         let type_count = out.matches("# TYPE").count();
@@ -467,5 +532,24 @@ mod tests {
         warn_once_on_proc_failure("/proc/self/synthetic", &err);
         warn_once_on_proc_failure("/proc/self/synthetic", &err);
         // Test passes if no panic.
+    }
+
+    /// Smoke test: the async read_proc helper returns Some for a real path.
+    /// This is a regression guard — if spawn_blocking is broken or the path
+    /// doesn't exist in the test environment, the scraper would silently
+    /// report zeros.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn read_proc_returns_some_for_existing_file() {
+        let r = read_proc("/proc/self/stat").await;
+        assert!(r.is_some(), "expected Some(_) for /proc/self/stat");
+    }
+
+    /// Smoke test: a missing path returns None without panicking.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn read_proc_returns_none_for_missing_file() {
+        let r = read_proc("/proc/self/this-file-does-not-exist").await;
+        assert!(r.is_none());
     }
 }

--- a/crates/dwaar-analytics/src/process_metrics.rs
+++ b/crates/dwaar-analytics/src/process_metrics.rs
@@ -534,8 +534,8 @@ mod tests {
         // Test passes if no panic.
     }
 
-    /// Smoke test: the async read_proc helper returns Some for a real path.
-    /// This is a regression guard — if spawn_blocking is broken or the path
+    /// Smoke test: the async `read_proc` helper returns Some for a real path.
+    /// This is a regression guard — if `spawn_blocking` is broken or the path
     /// doesn't exist in the test environment, the scraper would silently
     /// report zeros.
     #[cfg(target_os = "linux")]

--- a/crates/dwaar-analytics/src/prometheus.rs
+++ b/crates/dwaar-analytics/src/prometheus.rs
@@ -420,7 +420,11 @@ impl PrometheusMetrics {
     ///
     /// Called on `GET /metrics` — iterates `DashMap` entries and formats
     /// each metric with HELP, TYPE, and value lines.
-    pub fn render(&self) -> String {
+    ///
+    /// Async because `process.render()` offloads /proc reads via
+    /// `spawn_blocking` to avoid stalling runtime workers on slow procfs I/O
+    /// (issue #156).
+    pub async fn render(&self) -> String {
         // Pre-allocate generously — typical output for 10 domains is ~8 KB
         let mut out = String::with_capacity(8192);
 
@@ -432,7 +436,7 @@ impl PrometheusMetrics {
         self.render_upstream_health(&mut out);
         self.render_tls_handshake_duration(&mut out);
         self.render_config_reloads(&mut out);
-        self.process.render(&mut out);
+        self.process.render(&mut out).await;
         self.rate_cache.render(&mut out);
 
         out
@@ -746,10 +750,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn render_empty_registry() {
+    #[tokio::test]
+    async fn render_empty_registry() {
         let m = PrometheusMetrics::new();
-        let text = m.render();
+        let text = m.render().await;
         // Should still have HELP/TYPE lines but no data lines
         assert!(text.contains("# HELP dwaar_requests_total"));
         assert!(text.contains("# TYPE dwaar_requests_total counter"));
@@ -757,15 +761,15 @@ mod tests {
         assert!(!text.contains("domain="));
     }
 
-    #[test]
-    fn render_counter_values() {
+    #[tokio::test]
+    async fn render_counter_values() {
         let m = PrometheusMetrics::new();
         let domain = CompactString::from("app.example.com");
         m.record_request(&domain, "GET", 200, 1_000, 512, 64);
         m.record_request(&domain, "GET", 200, 2_000, 512, 64);
         m.record_request(&domain, "POST", 404, 3_000, 0, 128);
 
-        let text = m.render();
+        let text = m.render().await;
         assert!(text.contains(
             "dwaar_requests_total{domain=\"app.example.com\",method=\"GET\",status=\"2xx\"} 2"
         ));
@@ -775,13 +779,13 @@ mod tests {
         assert!(text.contains("dwaar_bytes_sent_total{domain=\"app.example.com\"} 1024"));
     }
 
-    #[test]
-    fn render_histogram_format() {
+    #[tokio::test]
+    async fn render_histogram_format() {
         let m = PrometheusMetrics::new();
         let domain = CompactString::from("h.test");
         m.record_request(&domain, "GET", 200, 3_000, 0, 0); // 3ms
 
-        let text = m.render();
+        let text = m.render().await;
         // Check bucket format
         assert!(
             text.contains(
@@ -795,31 +799,31 @@ mod tests {
         assert!(text.contains("dwaar_request_duration_seconds_count{domain=\"h.test\"} 1"));
     }
 
-    #[test]
-    fn render_config_reload_counters() {
+    #[tokio::test]
+    async fn render_config_reload_counters() {
         let m = PrometheusMetrics::new();
         m.config_reloads_success.fetch_add(3, Relaxed);
         m.config_reloads_failure.fetch_add(1, Relaxed);
 
-        let text = m.render();
+        let text = m.render().await;
         assert!(text.contains("dwaar_config_reload_total{result=\"success\"} 3"));
         assert!(text.contains("dwaar_config_reload_total{result=\"failure\"} 1"));
     }
 
-    #[test]
-    fn render_skips_zero_config_reloads() {
+    #[tokio::test]
+    async fn render_skips_zero_config_reloads() {
         let m = PrometheusMetrics::new();
-        let text = m.render();
+        let text = m.render().await;
         assert!(!text.contains("dwaar_config_reload_total"));
     }
 
-    #[test]
-    fn render_active_connections_gauge() {
+    #[tokio::test]
+    async fn render_active_connections_gauge() {
         let m = PrometheusMetrics::new();
         let domain = CompactString::from("gauge.test");
         m.connection_start(&domain);
 
-        let text = m.render();
+        let text = m.render().await;
         assert!(text.contains("dwaar_active_connections{domain=\"gauge.test\"} 1"));
     }
 }


### PR DESCRIPTION
## Summary

- `read_proc` / `read_proc_dir` now wrap `std::fs` calls in `tokio::task::spawn_blocking`, freeing the async runtime worker during slow procfs I/O (disk pressure can stall these reads for tens to hundreds of ms).
- All per-scrape Linux process metric helpers (`resident_memory_bytes_impl`, `open_fds_impl`, `threads_impl`) and their public callers on `ProcessMetrics` are now async.
- `ProcessMetrics::render()` and `PrometheusMetrics::render()` became async; the admin service `dispatch()` — already async — adds a single `.await`.
- macOS `open_fds_impl` (`/dev/fd` readdir) also wrapped via `spawn_blocking`.
- The one-time startup read for `process_start_time_secs` stays synchronous (runs at init before traffic, cached in `OnceLock`).
- Propagation depth: 2 layers. No architectural changes required.

## Test plan

- [x] `cargo test -p dwaar-analytics` — 207 tests pass (includes 2 new async regression-guard tests for `read_proc`)
- [x] `cargo test --workspace --exclude dwaar-cli` — all 1,299 non-integration tests pass
- [x] `cargo build --workspace` — clean build
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — zero warnings
- [x] `cargo fmt --all --check` — clean

Closes #156