### PR TITLE
refactor(dwaar-cli): extract shared fetch_latest_version helper (#176)

### DIFF
--- a/crates/dwaar-cli/src/auto_update.rs
+++ b/crates/dwaar-cli/src/auto_update.rs
@@ -15,7 +15,6 @@
 use std::process::Command;
 use std::time::Duration;
 
-use anyhow::Context as _;
 use async_trait::async_trait;
 use dwaar_config::model::{AutoUpdateAction, AutoUpdateConfig};
 use pingora_core::server::ShutdownWatch;
@@ -75,19 +74,20 @@ impl BackgroundService for AutoUpdateService {
 
 impl AutoUpdateService {
     async fn check_and_apply(&self) {
-        // Fetch latest version — runs reqwest blocking client so we don't
-        // stall the tokio executor.
-        let latest = match tokio::task::spawn_blocking(fetch_latest_version).await {
-            Ok(Ok(v)) => v,
-            Ok(Err(e)) => {
-                warn!(error = %e, "auto-update: failed to check latest version");
-                return;
-            }
-            Err(e) => {
-                warn!(error = %e, "auto-update: spawn_blocking panicked");
-                return;
-            }
-        };
+        // Fetch latest version — runs the shared blocking client so we don't
+        // stall the tokio executor. Delegates to version_check (#176).
+        let latest =
+            match tokio::task::spawn_blocking(crate::version_check::fetch_latest_version).await {
+                Ok(Ok(v)) => v,
+                Ok(Err(e)) => {
+                    warn!(error = %e, "auto-update: failed to check latest version");
+                    return;
+                }
+                Err(e) => {
+                    warn!(error = %e, "auto-update: spawn_blocking panicked");
+                    return;
+                }
+            };
 
         let latest_version = latest.strip_prefix('v').unwrap_or(&latest);
         let current = env!("CARGO_PKG_VERSION");
@@ -154,33 +154,6 @@ impl AutoUpdateService {
             }
         }
     }
-}
-
-/// Fetch latest version tag from GitHub Releases (blocking).
-///
-/// Follows the `/releases/latest` redirect in-process via reqwest and
-/// extracts the version tag from the final URL — equivalent to the previous
-/// `curl -w %{url_effective}` trick but without curl in the trust path.
-/// Issue #147: a compromised curl could have silently substituted a tag.
-fn fetch_latest_version() -> anyhow::Result<String> {
-    // Reuse the blocking client from self_update to share TLS config.
-    let client = reqwest::blocking::Client::builder()
-        .user_agent(concat!("dwaar-auto-update/", env!("CARGO_PKG_VERSION")))
-        .timeout(Duration::from_secs(30))
-        .build()
-        .context("failed to build HTTP client")?;
-
-    let resp = client
-        .get("https://github.com/permanu/Dwaar/releases/latest")
-        .send()
-        .context("GitHub redirect request failed")?;
-
-    resp.url()
-        .path_segments()
-        .and_then(|mut segs| segs.next_back())
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .ok_or_else(|| anyhow::anyhow!("could not extract tag from GitHub redirect URL"))
 }
 
 /// Check if current UTC time is within the maintenance window.

--- a/crates/dwaar-cli/src/main.rs
+++ b/crates/dwaar-cli/src/main.rs
@@ -33,6 +33,7 @@ mod auto_update;
 mod cli;
 mod readiness;
 mod self_update;
+mod version_check;
 
 use std::fs::Permissions;
 use std::os::unix::fs::PermissionsExt;

--- a/crates/dwaar-cli/src/self_update.rs
+++ b/crates/dwaar-cli/src/self_update.rs
@@ -9,11 +9,13 @@
 //! All HTTP is done in-process via `reqwest` with `rustls` — curl is no
 //! longer in the trust path, so a compromised `curl` binary cannot intercept
 //! the download or inject a malicious binary. Closes issue #147.
+//!
+//! Version resolution is delegated to `version_check::fetch_latest_version`
+//! (issue #176) so that `auto_update` uses the same JSON-then-redirect logic.
 
 use std::fmt::Write as FmtWrite;
 use std::fs;
 use std::path::Path;
-use std::time::Duration;
 
 use anyhow::{Context, bail};
 use subtle::ConstantTimeEq;
@@ -26,26 +28,13 @@ use subtle::ConstantTimeEq;
 /// and the R2 bucket can be decommissioned.
 const BASE_URL: &str = "https://github.com/permanu/Dwaar/releases/download";
 
-/// GitHub API endpoint to resolve the latest release tag.
-const LATEST_API: &str = "https://api.github.com/repos/permanu/Dwaar/releases/latest";
-
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
-
-/// Minimal GitHub Release object for deserialization.
-///
-/// The GitHub API returns many fields; we only care about `tag_name`.
-/// `serde_json` ignores extra fields by default, so this struct remains
-/// robust to API changes.
-#[derive(serde::Deserialize)]
-struct GhRelease {
-    tag_name: String,
-}
 
 /// Run the self-update flow. Returns a human-readable status message.
 // Self-update is an interactive CLI subcommand; println! is correct here.
 #[allow(clippy::disallowed_macros, clippy::print_stdout)]
 pub(crate) fn run(force: bool) -> anyhow::Result<()> {
-    let latest_tag = fetch_latest_version()?;
+    let latest_tag = crate::version_check::fetch_latest_version()?;
     let latest_version = latest_tag.strip_prefix('v').unwrap_or(&latest_tag);
 
     println!("Current version: {CURRENT_VERSION}");
@@ -111,64 +100,6 @@ pub(crate) fn run(force: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Build the shared HTTP client used by self-update operations.
-///
-/// Reusing a single client across calls is idiomatic reqwest and avoids
-/// redundant TLS handshakes. The 30-second timeout guards against hung
-/// connections during background provisioning (Guardrail #29).
-fn build_client() -> anyhow::Result<reqwest::blocking::Client> {
-    reqwest::blocking::Client::builder()
-        .user_agent(concat!("dwaar-self-update/", env!("CARGO_PKG_VERSION")))
-        .timeout(Duration::from_secs(30))
-        .build()
-        .context("failed to build HTTP client")
-}
-
-/// Fetch the latest release tag from the GitHub API.
-///
-/// Primary path: calls the GitHub Releases JSON API and parses `tag_name`.
-/// Fallback: follows the `/releases/latest` redirect and extracts the tag from
-/// the final URL — this mirrors what curl's `%{url_effective}` trick did, but
-/// entirely in-process via reqwest so curl is not in the trust path (#147).
-fn fetch_latest_version() -> anyhow::Result<String> {
-    let client = build_client()?;
-
-    // Primary: GitHub REST API returns JSON with `tag_name`.
-    let resp = client
-        .get(LATEST_API)
-        .header("Accept", "application/vnd.github+json")
-        .header("X-GitHub-Api-Version", "2022-11-28")
-        .send()
-        .context("GitHub API request failed")?;
-
-    if resp.status().is_success() {
-        let body = resp.text().context("GitHub API response is not UTF-8")?;
-        if let Ok(release) = serde_json::from_str::<GhRelease>(&body)
-            && !release.tag_name.is_empty()
-        {
-            return Ok(release.tag_name);
-        }
-    }
-
-    // Fallback: follow the /releases/latest redirect; reqwest follows redirects
-    // by default and exposes the final URL via `response.url()`.
-    // GitHub redirects /releases/latest → /releases/tag/vX.Y.Z.
-    let resp = client
-        .get("https://github.com/permanu/Dwaar/releases/latest")
-        .send()
-        .context("failed to resolve latest release via redirect")?;
-
-    let tag = resp
-        .url()
-        .path_segments()
-        .and_then(|mut segs| segs.next_back())
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .context("could not extract tag from GitHub redirect URL")?;
-
-    Ok(tag)
-}
-
 /// Download a URL to a local file in-process via reqwest.
 ///
 /// Replaces the previous `curl -fSL -o <dest> <url>` shell-out (#147).
@@ -176,7 +107,7 @@ fn fetch_latest_version() -> anyhow::Result<String> {
 /// directly to the destination file avoids buffering the entire binary in
 /// memory, which matters for large release artifacts.
 fn curl_download(url: &str, dest: &Path) -> anyhow::Result<()> {
-    let client = build_client()?;
+    let client = crate::version_check::build_http_client()?;
     let mut resp = client
         .get(url)
         .send()
@@ -381,28 +312,11 @@ mod tests {
     }
 
     #[test]
-    fn parse_release_tag_from_json() {
-        let json = r#"{"tag_name":"v0.3.10","name":"v0.3.10","draft":false}"#;
-        let parsed: GhRelease = serde_json::from_str(json).expect("valid JSON");
-        assert_eq!(parsed.tag_name, "v0.3.10");
-    }
-
-    #[test]
-    fn parse_release_tag_ignores_extra_fields() {
-        let json = r#"{"tag_name":"v1.2.3","html_url":"https://...","assets":[]}"#;
-        let parsed: GhRelease = serde_json::from_str(json).expect("valid JSON");
-        assert_eq!(parsed.tag_name, "v1.2.3");
-    }
-
-    #[test]
     fn http_client_builds() {
-        // Smoke: the migrated reqwest client builder constructs without
-        // panicking. No network calls are made here — integration tests
-        // cover wire-level behavior. Issue #147: curl shell-out replaced.
-        let client = reqwest::blocking::Client::builder()
-            .user_agent(concat!("dwaar-self-update/", env!("CARGO_PKG_VERSION")))
-            .timeout(std::time::Duration::from_secs(30))
-            .build();
-        assert!(client.is_ok(), "blocking HTTP client failed to build");
+        // Smoke: delegates to the shared client builder in version_check.
+        // No network calls are made here — integration tests cover
+        // wire-level behaviour. Issue #147: curl shell-out replaced.
+        // Issue #176: builder is now shared across self_update and auto_update.
+        crate::version_check::build_http_client().expect("blocking HTTP client should build");
     }
 }

--- a/crates/dwaar-cli/src/version_check.rs
+++ b/crates/dwaar-cli/src/version_check.rs
@@ -1,0 +1,132 @@
+// Copyright (C) 2026 Permanu
+// SPDX-License-Identifier: BSL-1.1
+//
+// This file is part of Dwaar — https://dwaar.dev
+// Licensed under the Business Source License 1.1
+
+//! Shared GitHub Releases version check helper.
+//!
+//! Both `self_update` and `auto_update` need to resolve the latest release tag.
+//! Rather than maintaining two separate implementations that can drift apart
+//! (as happened before issue #176), this module provides the single canonical
+//! function that both callers delegate to.
+//!
+//! The implementation prefers the GitHub REST API (JSON response with a
+//! `tag_name` field) over the older redirect trick. The redirect fallback is
+//! retained so that a transient API outage does not block updates entirely.
+
+use std::time::Duration;
+
+use anyhow::Context;
+
+/// GitHub REST API endpoint for the latest release.
+const LATEST_API: &str = "https://api.github.com/repos/permanu/Dwaar/releases/latest";
+
+/// GitHub HTML releases page — following the redirect reveals the tag in the URL.
+const LATEST_HTML: &str = "https://github.com/permanu/Dwaar/releases/latest";
+
+/// Minimal GitHub Release object for deserialization.
+///
+/// The GitHub API returns many fields; we only care about `tag_name`.
+/// `serde_json` ignores extra fields by default, so this struct stays robust
+/// to API changes without any maintenance burden.
+#[derive(serde::Deserialize)]
+pub(crate) struct GhRelease {
+    pub(crate) tag_name: String,
+}
+
+/// Build a reusable blocking HTTP client for GitHub requests.
+///
+/// Centralised here so both the version check and the download path share the
+/// same TLS and timeout configuration. The 30-second timeout guards against
+/// hung connections during background provisioning (Guardrail #29).
+pub(crate) fn build_http_client() -> anyhow::Result<reqwest::blocking::Client> {
+    reqwest::blocking::Client::builder()
+        .user_agent(concat!("dwaar/", env!("CARGO_PKG_VERSION")))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .context("failed to build HTTP client")
+}
+
+/// Fetch the latest release tag from GitHub.
+///
+/// Primary path: calls the GitHub Releases JSON API and parses `tag_name`.
+/// Fallback: follows the `/releases/latest` redirect and extracts the tag from
+/// the final URL — equivalent to curl's `%{url_effective}` trick, but entirely
+/// in-process via reqwest so curl is not in the trust path (issue #147).
+///
+/// Returns the raw tag string (e.g. `"v0.3.7"`). Callers that want a semver
+/// without the leading `v` should strip it themselves.
+pub(crate) fn fetch_latest_version() -> anyhow::Result<String> {
+    let client = build_http_client()?;
+
+    // Primary: GitHub REST API returns JSON with `tag_name`.
+    let resp = client
+        .get(LATEST_API)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .send()
+        .context("GitHub API request failed")?;
+
+    if resp.status().is_success() {
+        let body = resp.text().context("GitHub API response is not UTF-8")?;
+        if let Ok(release) = serde_json::from_str::<GhRelease>(&body)
+            && !release.tag_name.is_empty()
+        {
+            return Ok(release.tag_name);
+        }
+    }
+
+    // Fallback: follow the /releases/latest redirect; reqwest follows redirects
+    // by default and exposes the final URL via `response.url()`.
+    // GitHub redirects /releases/latest → /releases/tag/vX.Y.Z.
+    let resp = client
+        .get(LATEST_HTML)
+        .send()
+        .context("failed to resolve latest release via redirect")?;
+
+    let tag = resp
+        .url()
+        .path_segments()
+        .and_then(|mut segs| segs.next_back())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .context("could not extract tag from GitHub redirect URL")?;
+
+    Ok(tag)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_release_tag_from_json() {
+        let json = r#"{"tag_name":"v0.3.10","name":"v0.3.10","draft":false}"#;
+        let parsed: GhRelease = serde_json::from_str(json).expect("valid JSON");
+        assert_eq!(parsed.tag_name, "v0.3.10");
+    }
+
+    #[test]
+    fn parse_release_tag_ignores_extra_fields() {
+        let json = r#"{"tag_name":"v1.2.3","html_url":"https://...","assets":[]}"#;
+        let parsed: GhRelease = serde_json::from_str(json).expect("valid JSON");
+        assert_eq!(parsed.tag_name, "v1.2.3");
+    }
+
+    #[test]
+    fn http_client_builds_in_canonical_helper() {
+        // Smoke test: the canonical client builder constructs without panicking.
+        // No network calls — integration tests cover wire-level behaviour.
+        build_http_client().expect("HTTP client should build");
+    }
+
+    /// Live network test — skipped by default; run with
+    /// `cargo test -p dwaar-cli -- --ignored fetch_latest_version_network`.
+    #[test]
+    #[ignore = "requires live network; run with --ignored"]
+    fn fetch_latest_version_network() {
+        let tag = fetch_latest_version().expect("should return a version tag");
+        assert!(tag.starts_with('v'), "tag should start with 'v': {tag}");
+    }
+}


### PR DESCRIPTION
## Summary

- New `crates/dwaar-cli/src/version_check.rs` hosts the canonical `fetch_latest_version` (JSON API → redirect fallback) and `build_http_client` shared by both callers.
- `self_update.rs` and `auto_update.rs` delegate to `version_check::fetch_latest_version` — the duplicated bodies are gone.
- `GhRelease` struct and tag-parsing tests (`parse_release_tag_from_json`, `parse_release_tag_ignores_extra_fields`) relocated to `version_check.rs` so coverage travels with the implementation.
- `auto_update` gains the richer JSON-first path it was previously missing (it only did redirect fallback before this PR).

## Test plan

- [x] `cargo test -p dwaar-cli --bin dwaar` — 57 passed, 1 ignored (network test)
- [x] `cargo build -p dwaar-cli` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Closes #176