### PR TITLE
perf(dwaar-analytics): pre-seed known domains to avoid DashMap stampede (#163)

### DIFF
--- a/crates/dwaar-analytics/src/aggregation/service.rs
+++ b/crates/dwaar-analytics/src/aggregation/service.rs
@@ -38,6 +38,20 @@ const FLUSH_INTERVAL: Duration = Duration::from_secs(60);
 /// `dwaar-core` (no circular dependency).
 pub trait RouteValidator: Send + Sync {
     fn is_known_host(&self, host: &str) -> bool;
+
+    /// Return the set of known hosts at the time of the call.
+    ///
+    /// Used by [`AggregationService::new`] to pre-seed the metrics map so
+    /// the first `entry().or_default()` for each domain is a contention-free
+    /// read of an existing entry rather than a write that competes with other
+    /// concurrent first-writes. See issue #163.
+    ///
+    /// The default returns an empty `Vec`, preserving backward compatibility
+    /// for implementations that cannot enumerate domains (pre-seeding
+    /// degrades gracefully to the lazy-allocation status quo).
+    fn known_hosts(&self) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 /// Aggregation background service.
@@ -70,6 +84,20 @@ impl<RT: RouteValidator> AggregationService<RT> {
         beacon_rx: mpsc::Receiver<BeaconEvent>,
         log_rx: AggReceiver,
     ) -> Self {
+        // Pre-seed the map with all currently known domains so the first
+        // event per domain hits an existing entry instead of racing to
+        // create one. Under high concurrency with many new domains appearing
+        // simultaneously, multiple workers could call entry().or_default()
+        // simultaneously, each racing to insert a short-lived DomainMetrics
+        // allocation — DashMap serialises those writes at the shard level,
+        // causing unnecessary contention. With the map pre-seeded, every
+        // ingest() call for a known domain is a contention-free shard read.
+        // Unknown hosts are still gated by is_known_host() before they ever
+        // reach the entry() call, so they never appear in the map. #163
+        for host in route_validator.known_hosts() {
+            metrics.entry(host).or_default();
+        }
+
         Self {
             metrics,
             route_validator,
@@ -466,6 +494,10 @@ mod tests {
         fn is_known_host(&self, host: &str) -> bool {
             self.0.contains(host)
         }
+
+        fn known_hosts(&self) -> Vec<String> {
+            self.0.iter().cloned().collect()
+        }
     }
 
     fn test_event(host: &str, path: &str, status: u16) -> AggEvent {
@@ -548,8 +580,14 @@ mod tests {
             beacon_rx,
             AggReceiver { rx: log_rx },
         );
+        // Pre-seeding adds example.com at construction; unknown hosts must
+        // never be inserted, so the map must not contain evil.com after
+        // this ingest. #163
         svc.ingest_log(&test_event("evil.com", "/hack", 200));
-        assert_eq!(metrics.len(), 0, "unknown host must not create entry");
+        assert!(
+            !metrics.contains_key("evil.com"),
+            "unknown host must not create entry"
+        );
     }
 
     #[test]
@@ -735,6 +773,38 @@ mod tests {
             assert_eq!(entry.bytes_sent, 1024, "only window 2 bytes");
             assert_eq!(entry.human_views, 1);
         }
+    }
+
+    #[test]
+    fn pre_seed_known_domains_no_stampede_on_first_ingest() {
+        // After construction the map already contains an entry for every
+        // known domain, so ingest_log()'s entry().or_default() becomes a
+        // contention-free read of an existing shard entry rather than a
+        // write that races against concurrent first-writes for other new
+        // domains. The map must not grow during the first ingest. #163
+        let known = ["a.example.com", "b.example.com", "c.example.com"];
+        let domain_set: HashSet<String> = known.iter().map(|&s| s.into()).collect();
+        let (_beacon_tx, beacon_rx) = mpsc::channel(1);
+        let (_log_tx, log_rx) = mpsc::channel(1);
+        let metrics = Arc::new(DashMap::new());
+        let _svc = AggregationService::new(
+            Arc::clone(&metrics),
+            TestValidator(domain_set),
+            beacon_rx,
+            AggReceiver { rx: log_rx },
+        );
+
+        // All three domains seeded at construction — no ingest needed.
+        assert_eq!(
+            metrics.len(),
+            3,
+            "all known domains pre-seeded at construction"
+        );
+
+        // First ingest for a known domain: entry already exists, map does not grow.
+        let entry = metrics.entry("a.example.com".to_string()).or_default();
+        drop(entry);
+        assert_eq!(metrics.len(), 3, "first ingest must not grow the map");
     }
 
     #[tokio::test]

--- a/crates/dwaar-cli/src/main.rs
+++ b/crates/dwaar-cli/src/main.rs
@@ -2089,6 +2089,16 @@ impl RouteValidator for LiveRouteValidator {
     fn is_known_host(&self, host: &str) -> bool {
         self.0.load().resolve(host).is_some()
     }
+
+    fn known_hosts(&self) -> Vec<String> {
+        // Snapshot the domain keys from the current route table so
+        // AggregationService can pre-seed the metrics map at construction.
+        // A snapshot is fine here — new domains that arrive via hot-reload
+        // will still be gated by is_known_host() and lazily inserted on
+        // their first event; the pre-seed only eliminates the stampede for
+        // the domains known at startup. #163
+        self.0.load().domain_keys().map(str::to_owned).collect()
+    }
 }
 
 /// Wraps `AggregationService` as a Pingora `BackgroundService`.


### PR DESCRIPTION
## Summary
- Adds `known_hosts() -> Vec<String>` to the `RouteValidator` trait (default impl returns empty `Vec` for backward compatibility).
- `AggregationService::new()` calls `known_hosts()` to pre-seed the DashMap with empty `DomainMetrics` for all known domains at construction. The first event per domain is now a contention-free shard read of an existing entry rather than a write racing against other concurrent first-writes.
- `LiveRouteValidator` (in `dwaar-cli`) implements `known_hosts()` by snapshotting `RouteTable::domain_keys()` at startup.
- Unknown hosts remain gated by `is_known_host()` before ever reaching `entry()` — they never appear in the map.

## Test plan
- [x] Added `pre_seed_known_domains_no_stampede_on_first_ingest` test: verifies all known domains are present after construction and that first ingest does not grow the map.
- [x] Updated `ingest_log_unknown_host_rejected` assertion: checks `evil.com` is absent (not that map is empty — pre-seeding legitimately populates the map with known domains at construction).
- [x] `cargo test -p dwaar-analytics` — 208 passed, 0 failed
- [x] `cargo build -p dwaar-analytics` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean

Closes #163