### PR TITLE
perf(dwaar-core): pre-build HttpPeer per single-backend route (#164)

### DIFF
--- a/crates/dwaar-config/src/compile.rs
+++ b/crates/dwaar-config/src/compile.rs
@@ -1306,10 +1306,14 @@ fn compile_reverse_proxy_handler(rp: &ReverseProxyDirective, location: &str) -> 
 
     if rp.upstreams.len() <= 1 && !is_block_form {
         // Common single-upstream case — zero overhead path.
+        // Build the HttpPeer once here so upstream_peer() can clone it on the
+        // hot path instead of constructing a new one per request.
         let addr = resolve_upstream(&rp.upstreams)?;
+        let pre_built_peer = Arc::new(dwaar_core::route::build_single_backend_peer(addr));
         return Some(Handler::ReverseProxy {
             upstream: addr,
             upstream_h2: rp.transport_h2,
+            pre_built_peer: Some(pre_built_peer),
         });
     }
 
@@ -2733,6 +2737,65 @@ mod tests {
 
     // Smoke test: compile_forward_auth must succeed (return Some) both with and
     // without allow_plaintext. When true, a tracing::warn! fires at config load
+    // ── Pre-built peer tests (#164) ──────────────────────────────────────────
+
+    #[test]
+    fn single_backend_route_has_pre_built_peer() {
+        // A single-backend route compiled by compile_routes should carry a
+        // pre-built HttpPeer so upstream_peer() can clone it instead of
+        // constructing one from scratch on every request.
+        let config = DwaarConfig {
+            global_options: None,
+            sites: vec![make_site("example.com", rp("127.0.0.1:8080"))],
+        };
+        let table = compile_routes(&config);
+        let route = table.resolve("example.com").expect("should resolve");
+        let block = route.handlers.first().expect("has handler block");
+        match &block.handler {
+            Handler::ReverseProxy {
+                pre_built_peer,
+                upstream,
+                ..
+            } => {
+                assert!(
+                    pre_built_peer.is_some(),
+                    "single-backend route must carry a pre-built HttpPeer"
+                );
+                // The pre-built peer must target the configured upstream address.
+                if let Some(peer) = pre_built_peer {
+                    assert_eq!(
+                        peer._address.to_string(),
+                        upstream.to_string(),
+                        "pre-built peer must target the same upstream as the route"
+                    );
+                }
+            }
+            other => panic!("expected ReverseProxy handler, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multi_backend_route_has_no_pre_built_peer() {
+        // Multi-backend routes go through pool selection per request; there is
+        // no single fixed peer to pre-build.
+        let config = DwaarConfig {
+            global_options: None,
+            sites: vec![make_site(
+                "example.com",
+                rp_multi(&["127.0.0.1:8080", "127.0.0.1:8081"]),
+            )],
+        };
+        let table = compile_routes(&config);
+        let route = table.resolve("example.com").expect("should resolve");
+        let block = route.handlers.first().expect("has handler block");
+        assert!(
+            matches!(&block.handler, Handler::ReverseProxyPool { .. }),
+            "multi-backend route must use ReverseProxyPool, not ReverseProxy"
+        );
+        // ReverseProxyPool has no pre_built_peer field — absence of the field
+        // is the contract for pool routes (peer chosen per request at runtime).
+    }
+
     // (verified manually in startup logs). See issue #150.
     #[test]
     fn forward_auth_allow_plaintext_does_not_break_compilation() {

--- a/crates/dwaar-core/src/context.rs
+++ b/crates/dwaar-core/src/context.rs
@@ -47,6 +47,7 @@ use uuid::Uuid;
 use crate::route::{CompiledCopyResponseHeaders, CompiledIntercept};
 use crate::template::VarSlots;
 use crate::upstream::UpstreamPool;
+use pingora_core::upstreams::peer::HttpPeer;
 
 /// Per-request state shared across all Pingora lifecycle hooks.
 ///
@@ -133,6 +134,15 @@ pub struct RequestContext {
     /// `None` for single-upstream routes — they use `route_upstream` directly,
     /// avoiding all pool overhead on the common case.
     pub upstream_pool: Option<Arc<UpstreamPool>>,
+
+    /// Pre-built `HttpPeer` for single-backend routes (#164).
+    ///
+    /// Built once at route-compile time and shared across requests via `Arc`.
+    /// `upstream_peer()` clones the inner peer into the `Box` Pingora requires —
+    /// cloning a pre-configured struct avoids `HttpPeer::new` + `PeerOptions`
+    /// setup on every request. `None` when the route uses a pool or when gRPC
+    /// ALPN override is needed (those paths build the peer inline).
+    pub pre_built_peer: Option<Arc<HttpPeer>>,
 
     /// WebSocket upgrade detected — preserves hop-by-hop headers and skips
     /// analytics injection so Pingora can establish the bidirectional tunnel.
@@ -280,6 +290,7 @@ impl RequestContext {
             intercept_body: None,
             copy_response_headers: None,
             upstream_pool: None,
+            pre_built_peer: None,
             is_websocket: false,
             is_grpc: false,
             grpc_web_mode: None,

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -894,9 +894,16 @@ impl ProxyHttp for DwaarProxy {
                         crate::route::Handler::FileServer { root, browse } => {
                             ctx.file_server = Some((root.clone(), *browse));
                         }
-                        crate::route::Handler::ReverseProxy { upstream, .. } => {
+                        crate::route::Handler::ReverseProxy {
+                            upstream,
+                            pre_built_peer,
+                            ..
+                        } => {
                             ctx.route_upstream = Some(*upstream);
                             ctx.quic_capable = true;
+                            // Cache the pre-built peer so upstream_peer() can
+                            // clone it instead of constructing one from scratch.
+                            ctx.pre_built_peer.clone_from(pre_built_peer);
                         }
                         crate::route::Handler::ReverseProxyPool { pool, .. } => {
                             ctx.quic_capable = true;
@@ -1654,10 +1661,38 @@ impl ProxyHttp for DwaarProxy {
             "route resolved"
         );
 
-        let mut peer = HttpPeer::new(upstream, use_tls, sni);
-        peer.options.connection_timeout = Some(std::time::Duration::from_secs(10));
-        peer.options.read_timeout = Some(std::time::Duration::from_secs(30));
-        peer.options.write_timeout = Some(std::time::Duration::from_secs(30));
+        // Fast path (#164): single-backend routes carry a pre-built peer so we
+        // skip HttpPeer::new + PeerOptions construction on every request.
+        // The Arc clone is cheap; Box::new(Clone) copies the struct — still
+        // one allocation, but cheaper than field-by-field setup from scratch.
+        //
+        // Conditions that bypass the fast path and build inline:
+        //   • Pool route (mTLS, custom CA, TLS SNI — all pool-only features)
+        //   • gRPC request (needs ALPN::H2 override)
+        let mut peer = if let Some(ref cached) = ctx.pre_built_peer
+            && !ctx.is_grpc
+            && client_cert_key.is_none()
+            && trusted_ca.is_none()
+        {
+            // Clone the pre-configured peer — all timeout/keepalive fields are
+            // already set; nothing to patch for standard HTTP/1.1 requests.
+            (**cached).clone()
+        } else {
+            // Build the peer from scratch for pool routes and gRPC requests.
+            let mut p = HttpPeer::new(upstream, use_tls, sni);
+            p.options.connection_timeout = Some(std::time::Duration::from_secs(10));
+            p.options.read_timeout = Some(std::time::Duration::from_secs(30));
+            p.options.write_timeout = Some(std::time::Duration::from_secs(30));
+            p.options.tcp_keepalive = Some(pingora_core::protocols::TcpKeepalive {
+                idle: std::time::Duration::from_secs(60),
+                interval: std::time::Duration::from_secs(10),
+                count: 3,
+                #[cfg(target_os = "linux")]
+                user_timeout: std::time::Duration::ZERO,
+            });
+            p.options.idle_timeout = Some(std::time::Duration::from_secs(60));
+            p
+        };
 
         // Wire mTLS client cert into the peer (ISSUE-077)
         if let Some(ck) = client_cert_key {
@@ -1667,22 +1702,6 @@ impl ProxyHttp for DwaarProxy {
         if let Some(ca) = trusted_ca {
             peer.options.ca = Some(ca);
         }
-
-        // Detect dead upstream connections via TCP keepalive probes instead of
-        // waiting for read_timeout (30s) on a silently broken connection.
-        // Probes start after 60s idle, retry every 10s, give up after 3 failures.
-        peer.options.tcp_keepalive = Some(pingora_core::protocols::TcpKeepalive {
-            idle: std::time::Duration::from_secs(60),
-            interval: std::time::Duration::from_secs(10),
-            count: 3,
-            #[cfg(target_os = "linux")]
-            user_timeout: std::time::Duration::ZERO,
-        });
-
-        // Evict idle connections from the pool before the upstream closes them.
-        // Set slightly below common upstream keepalive_timeout (nginx default: 75s)
-        // to avoid sending requests on connections the upstream is about to close.
-        peer.options.idle_timeout = Some(std::time::Duration::from_secs(60));
 
         // gRPC requires HTTP/2 end-to-end — force h2 ALPN negotiation
         if ctx.is_grpc {

--- a/crates/dwaar-core/src/quic/convert.rs
+++ b/crates/dwaar-core/src/quic/convert.rs
@@ -174,6 +174,7 @@ pub fn resolve_upstream_addr(
             Handler::ReverseProxy {
                 upstream,
                 upstream_h2,
+                ..
             } => {
                 return Ok((*upstream, *upstream_h2));
             }

--- a/crates/dwaar-core/src/route.rs
+++ b/crates/dwaar-core/src/route.rs
@@ -59,6 +59,7 @@ use compact_str::CompactString;
 
 use crate::template::{CompiledTemplate, TemplateContext, VarSlots};
 use crate::upstream::UpstreamPool;
+use pingora_core::upstreams::peer::HttpPeer;
 use regex::Regex;
 
 /// Validate that a string is a legal hostname or wildcard pattern.
@@ -125,11 +126,19 @@ pub enum Handler {
     /// Forward the request to a single upstream backend (zero-overhead common case).
     ///
     /// Used when the config has exactly one upstream and no block-form options.
-    /// Keeps `upstream_peer()` allocation-free: no `Arc` load, no pool scan.
+    /// `pre_built_peer` is constructed once at route-compile time so the hot
+    /// path skips `HttpPeer::new` and `PeerOptions` initialization on every
+    /// request. Pingora's trait requires `Box<HttpPeer>`, so the clone is
+    /// unavoidable, but cloning a pre-configured struct is cheaper than
+    /// constructing one from scratch (no `to_socket_addrs` call, no field-by-
+    /// field option setup).
     ReverseProxy {
         upstream: SocketAddr,
         /// Use HTTP/2 multiplexing for the upstream connection (H3 path only).
         upstream_h2: bool,
+        /// Pre-built peer for the common (non-gRPC) fast path. `None` only
+        /// during construction before `compile_routes` sets it.
+        pre_built_peer: Option<Arc<HttpPeer>>,
     },
     /// Forward the request through a load-balancing pool of backends.
     ///
@@ -500,6 +509,36 @@ pub enum CompiledMapPattern {
     Default,
 }
 
+// ── Pre-built peer helpers ────────────────────────────────────
+
+/// Build a plain HTTP/1.1 `HttpPeer` for a single-backend route with the
+/// standard Dwaar connection options pre-applied.
+///
+/// Called once at route-compile time per single-backend handler. The result is
+/// stored as `Arc<HttpPeer>` and cloned into the `Box` that Pingora's
+/// `upstream_peer` API requires — cloning a pre-configured struct is cheaper
+/// than constructing one from scratch on every request (no `to_socket_addrs`
+/// call, no field-by-field setup).
+///
+/// TLS is always `false` here — single-backend routes created via
+/// `Handler::ReverseProxy` are plain-HTTP. TLS upstreams go through
+/// `ReverseProxyPool` where the per-backend `tls` flag drives the peer.
+pub fn build_single_backend_peer(upstream: SocketAddr) -> HttpPeer {
+    let mut peer = HttpPeer::new(upstream, false, String::new());
+    peer.options.connection_timeout = Some(std::time::Duration::from_secs(10));
+    peer.options.read_timeout = Some(std::time::Duration::from_secs(30));
+    peer.options.write_timeout = Some(std::time::Duration::from_secs(30));
+    peer.options.tcp_keepalive = Some(pingora_core::protocols::TcpKeepalive {
+        idle: std::time::Duration::from_secs(60),
+        interval: std::time::Duration::from_secs(10),
+        count: 3,
+        #[cfg(target_os = "linux")]
+        user_timeout: std::time::Duration::ZERO,
+    });
+    peer.options.idle_timeout = Some(std::time::Duration::from_secs(60));
+    peer
+}
+
 // ── Route ────────────────────────────────────────────────────
 
 /// A site: one domain with its handler blocks.
@@ -598,6 +637,12 @@ impl Route {
                 handler: Handler::ReverseProxy {
                     upstream,
                     upstream_h2: false,
+                    // Peer is built here for the common single-backend case.
+                    // The compile path (compile_routes) overwrites this with a
+                    // fully-configured peer including timeout options. This
+                    // inline build covers the admin-API / test-construction path
+                    // where no compile_routes pass runs.
+                    pre_built_peer: Some(Arc::new(build_single_backend_peer(upstream))),
                 },
                 intercepts: vec![],
                 copy_response_headers: None,


### PR DESCRIPTION
## Summary

- `Handler::ReverseProxy` now carries `Option<Arc<HttpPeer>> pre_built_peer`, built once at route-compile time via `build_single_backend_peer()` (all standard timeouts/keepalive pre-applied).
- `RequestContext` caches an `Arc` clone from `request_filter()`; `upstream_peer()` clones the inner `HttpPeer` into the `Box` Pingora's trait requires — one struct copy instead of construct-from-scratch + six option assignments per request.
- Multi-backend / pool routes and gRPC requests continue building the peer inline (unchanged behaviour).

`HttpPeer` is `Clone` (verified in pingora-core 0.8.0 source — `#[derive(Debug, Clone)]`).

## Fast path conditions

All three must hold for the pre-built path to activate:
1. Single-backend route (`Handler::ReverseProxy`, no pool)
2. Not gRPC (gRPC needs `ALPN::H2` patched in post-clone)
3. No mTLS / custom CA (pool-only features — never set on single-backend routes)

## Test plan

- [x] `cargo test -p dwaar-core --lib` — 329 tests pass
- [x] `cargo test -p dwaar-config --lib` — 278 tests pass (includes 2 new pre-built peer tests)
- [x] `cargo build -p dwaar-core`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Closes #164