### PR TITLE
perf(dwaar-analytics): evict aggregation entries for removed domains on reload (#167)

### DIFF
--- a/crates/dwaar-analytics/src/aggregation/service.rs
+++ b/crates/dwaar-analytics/src/aggregation/service.rs
@@ -14,6 +14,7 @@
 //! The `DashMap` is shared via `Arc` so ISSUE-029's Admin API can
 //! read it concurrently without blocking the aggregation loop.
 
+use std::collections::HashSet;
 use std::io::Write;
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::Duration;
@@ -67,6 +68,11 @@ pub struct AggregationService<RT: RouteValidator> {
     /// External sink for analytics snapshots (ISSUE-116). `None` uses the
     /// legacy stdout flush path for backwards compatibility.
     sink: Option<Box<dyn AnalyticsSink>>,
+    /// When set, `run()` listens for notifications and calls
+    /// `evict_unknown_domains()` each time one arrives. Wire this to the
+    /// same `Notify` that `ConfigWatcher::with_post_reload_notify` fires so
+    /// the map shrinks whenever domains are removed from the config. #167
+    evict_notify: Option<Arc<tokio::sync::Notify>>,
 }
 
 impl<RT: RouteValidator> std::fmt::Debug for AggregationService<RT> {
@@ -104,6 +110,7 @@ impl<RT: RouteValidator> AggregationService<RT> {
             beacon_rx: Mutex::new(Some(beacon_rx)),
             log_rx: Mutex::new(Some(log_rx)),
             sink: None,
+            evict_notify: None,
         }
     }
 
@@ -114,6 +121,35 @@ impl<RT: RouteValidator> AggregationService<RT> {
     pub fn with_sink(mut self, sink: Box<dyn AnalyticsSink>) -> Self {
         self.sink = Some(sink);
         self
+    }
+
+    /// Register the `Notify` that fires after each hot-reload. On every
+    /// notification, `run()` calls `evict_unknown_domains()` so the metrics
+    /// map shrinks when domains are removed from the config. Wire this to
+    /// `ConfigWatcher::with_post_reload_notify`. See issue #167.
+    #[must_use]
+    pub fn with_evict_notify(mut self, notify: Arc<tokio::sync::Notify>) -> Self {
+        self.evict_notify = Some(notify);
+        self
+    }
+
+    /// Drop metrics entries for domains that are no longer in the known-hosts
+    /// set.
+    ///
+    /// Called on hot-reload to keep the working set bounded as domains are
+    /// added and removed from the config over time. The pre-seeding pass at
+    /// construction (issue #163) keeps lookup contention-free; this paired
+    /// eviction sweep keeps the map from growing indefinitely. A `retain()`
+    /// over the `DashMap` is O(N) — one shard lock per shard — which is
+    /// acceptable since reloads are rare. #167
+    pub fn evict_unknown_domains(&self) {
+        let known: HashSet<String> = self.route_validator.known_hosts().into_iter().collect();
+        let before = self.metrics.len();
+        self.metrics.retain(|domain, _| known.contains(domain));
+        let removed = before.saturating_sub(self.metrics.len());
+        if removed > 0 {
+            debug!(removed, "evicted stale domain metrics after config reload");
+        }
     }
 
     /// Read-only access to the shared metrics map.
@@ -230,6 +266,17 @@ impl<RT: RouteValidator> AggregationService<RT> {
                 }
                 _ = flush_timer.tick() => {
                     self.flush();
+                }
+                // Hot-reload: drop entries for domains no longer in the config.
+                // The ConfigWatcher fires this after swapping the route table,
+                // so known_hosts() already reflects the new domain set. #167
+                () = async {
+                    match &self.evict_notify {
+                        Some(n) => n.notified().await,
+                        None => std::future::pending().await,
+                    }
+                } => {
+                    self.evict_unknown_domains();
                 }
                 _ = shutdown.changed() => {
                     self.flush();
@@ -805,6 +852,145 @@ mod tests {
         let entry = metrics.entry("a.example.com".to_string()).or_default();
         drop(entry);
         assert_eq!(metrics.len(), 3, "first ingest must not grow the map");
+    }
+
+    /// A test validator whose known-host set can be swapped at runtime,
+    /// simulating what happens when a hot-reload changes the route table.
+    struct MutableTestValidator(Arc<std::sync::Mutex<HashSet<String>>>);
+
+    impl MutableTestValidator {
+        fn new(domains: &[&str]) -> Self {
+            Self(Arc::new(std::sync::Mutex::new(
+                domains.iter().map(|&s| s.into()).collect(),
+            )))
+        }
+
+        fn set_known(&self, domains: &[&str]) {
+            *self.0.lock().expect("test mutex poisoned") =
+                domains.iter().map(|&s| s.into()).collect();
+        }
+    }
+
+    impl RouteValidator for MutableTestValidator {
+        fn is_known_host(&self, host: &str) -> bool {
+            self.0.lock().expect("test mutex poisoned").contains(host)
+        }
+
+        fn known_hosts(&self) -> Vec<String> {
+            self.0
+                .lock()
+                .expect("test mutex poisoned")
+                .iter()
+                .cloned()
+                .collect()
+        }
+    }
+
+    #[test]
+    fn evict_drops_domains_not_in_new_known_set() {
+        // Pair with #163 pre-seed: on hot reload, entries for domains that were
+        // removed from the config must be cleaned up. Without this, the DashMap
+        // grows indefinitely as domains are cycled in and out over the process
+        // lifetime. The retain() sweep is O(N) per reload — acceptable since
+        // reloads are rare. #167
+        let validator = MutableTestValidator::new(&["a.example.com", "b.example.com"]);
+        let (_beacon_tx, beacon_rx) = mpsc::channel(1);
+        let (_log_tx, log_rx) = mpsc::channel(1);
+        let metrics = Arc::new(DashMap::new());
+        let svc = AggregationService::new(
+            Arc::clone(&metrics),
+            validator,
+            beacon_rx,
+            AggReceiver { rx: log_rx },
+        );
+
+        // Both domains pre-seeded at construction (#163).
+        assert!(metrics.contains_key("a.example.com"), "a pre-seeded");
+        assert!(metrics.contains_key("b.example.com"), "b pre-seeded");
+
+        // Simulate config reload: 'a' removed from route table.
+        svc.route_validator.set_known(&["b.example.com"]);
+        svc.evict_unknown_domains();
+
+        assert!(
+            !metrics.contains_key("a.example.com"),
+            "a must be evicted after reload removes it from config"
+        );
+        assert!(
+            metrics.contains_key("b.example.com"),
+            "b must survive — it is still in the config"
+        );
+    }
+
+    #[test]
+    fn evict_with_empty_known_set_clears_all() {
+        // When all domains are removed from the config (e.g. the operator
+        // blanks the Dwaarfile during debugging), eviction must clear the map
+        // completely so no stale entry consumes memory.
+        let validator = MutableTestValidator::new(&["a.example.com"]);
+        let (_beacon_tx, beacon_rx) = mpsc::channel(1);
+        let (_log_tx, log_rx) = mpsc::channel(1);
+        let metrics = Arc::new(DashMap::new());
+        let svc = AggregationService::new(
+            Arc::clone(&metrics),
+            validator,
+            beacon_rx,
+            AggReceiver { rx: log_rx },
+        );
+
+        assert_eq!(metrics.len(), 1);
+        svc.route_validator.set_known(&[]);
+        svc.evict_unknown_domains();
+        assert_eq!(metrics.len(), 0, "empty known set must clear the map");
+    }
+
+    #[tokio::test]
+    async fn evict_notify_triggers_eviction_in_run_loop() {
+        // Verify the end-to-end wiring: when evict_notify fires, the run loop
+        // calls evict_unknown_domains() and drops stale entries. #167
+        let validator = MutableTestValidator::new(&["a.example.com", "b.example.com"]);
+        let (beacon_tx, beacon_rx) = mpsc::channel(8192);
+        let (log_tx, log_rx) = mpsc::channel(8192);
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let evict_notify = Arc::new(tokio::sync::Notify::new());
+        let metrics = Arc::new(DashMap::new());
+
+        let svc = Arc::new(
+            AggregationService::new(
+                Arc::clone(&metrics),
+                validator,
+                beacon_rx,
+                AggReceiver { rx: log_rx },
+            )
+            .with_evict_notify(Arc::clone(&evict_notify)),
+        );
+
+        // Both domains pre-seeded.
+        assert!(metrics.contains_key("a.example.com"));
+        assert!(metrics.contains_key("b.example.com"));
+
+        // Start the run loop in the background.
+        let svc_clone = Arc::clone(&svc);
+        tokio::spawn(async move { svc_clone.run(shutdown_rx).await });
+
+        // Simulate reload: remove 'a' from the route table, then fire the notify.
+        svc.route_validator.set_known(&["b.example.com"]);
+        evict_notify.notify_one();
+
+        // Give the run loop a chance to process the notification.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        assert!(
+            !metrics.contains_key("a.example.com"),
+            "run loop must evict 'a' after notify"
+        );
+        assert!(metrics.contains_key("b.example.com"), "b survives");
+
+        // Clean up
+        drop(beacon_tx);
+        drop(log_tx);
+        shutdown_tx.send(true).expect("shutdown");
+        tokio::time::sleep(Duration::from_millis(50)).await;
     }
 
     #[tokio::test]

--- a/crates/dwaar-cli/src/main.rs
+++ b/crates/dwaar-cli/src/main.rs
@@ -1355,6 +1355,11 @@ fn register_background_services(
         info!("log writer registered (JSON lines to stdout)");
     }
 
+    // Shared notify for post-reload eviction. ConfigWatcher fires it after
+    // every successful reload; AggregationService listens and drops DashMap
+    // entries for domains that are no longer in the route table. #167
+    let agg_evict_notify = Arc::new(tokio::sync::Notify::new());
+
     // Config file watcher for hot-reload
     let initial_hash = hash_content(&std::fs::read(config_path).unwrap_or_default());
     let config_watcher = ConfigWatcher::new(
@@ -1364,6 +1369,7 @@ fn register_background_services(
     )
     .with_drain_timeout(drain_timeout)
     .with_reload_notify(Arc::clone(config_notify))
+    .with_post_reload_notify(Arc::clone(&agg_evict_notify))
     .with_sni_domain_map(sni_domain_map)
     .with_health_pools(health_pools)
     .with_acme_domains(acme_domains)
@@ -1419,7 +1425,8 @@ fn register_background_services(
             LiveRouteValidator(Arc::clone(route_table_for_agg)),
             br,
             ar,
-        );
+        )
+        .with_evict_notify(Arc::clone(&agg_evict_notify));
         let agg_bg = pingora_core::services::background::background_service(
             "analytics aggregation",
             AggServiceWrapper {

--- a/crates/dwaar-config/src/watcher.rs
+++ b/crates/dwaar-config/src/watcher.rs
@@ -98,6 +98,11 @@ pub struct ConfigWatcher {
     /// Entries are keyed by absolute path. `None` values mean "we have never
     /// successfully stat'd this path" (e.g., symlink to a dangling target).
     wasm_mtimes: Mutex<HashMap<PathBuf, Option<SystemTime>>>,
+    /// Fired after every successful reload so subscribers can clean up
+    /// stale state that was valid under the old config but isn't in the
+    /// new one — e.g. the aggregation `DashMap` evicting removed domains.
+    /// `None` means no subscriber registered. See issue #167.
+    post_reload_notify: Option<Arc<tokio::sync::Notify>>,
 }
 
 impl std::fmt::Debug for ConfigWatcher {
@@ -134,6 +139,7 @@ impl ConfigWatcher {
             l4_notify: None,
             wasm_invalidator: None,
             wasm_mtimes: Mutex::new(HashMap::new()),
+            post_reload_notify: None,
         }
     }
 
@@ -221,6 +227,20 @@ impl ConfigWatcher {
     #[must_use]
     pub fn with_wasm_invalidator(mut self, invalidator: WasmInvalidator) -> Self {
         self.wasm_invalidator = Some(invalidator);
+        self
+    }
+
+    /// Register a `Notify` that fires after every successful reload.
+    ///
+    /// Subscribers use this to evict state that was valid under the old config
+    /// but is stale in the new one. The aggregation service uses it to drop
+    /// `DashMap` entries for domains that were removed from the route table.
+    /// The route table swap happens before this fires, so subscribers that
+    /// call `route_validator.known_hosts()` immediately see the new domain set.
+    /// See issue #167.
+    #[must_use]
+    pub fn with_post_reload_notify(mut self, notify: Arc<tokio::sync::Notify>) -> Self {
+        self.post_reload_notify = Some(notify);
         self
     }
 
@@ -422,6 +442,13 @@ impl ConfigWatcher {
         // Update hash — must run in both branches
         let mut last = self.last_hash.lock();
         *last = new_hash;
+
+        // Notify post-reload subscribers (e.g. the aggregation eviction loop).
+        // The route table swap happened above, so subscribers that enumerate
+        // known_hosts() now see the updated domain set. #167
+        if let Some(ref n) = self.post_reload_notify {
+            n.notify_one();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- `AggregationService::evict_unknown_domains()` sweeps the metrics `DashMap` and drops any entry whose key is not in `route_validator.known_hosts()`. The `retain()` is O(N) per reload — acceptable since reloads are rare.
- `ConfigWatcher::with_post_reload_notify()` accepts an `Arc<Notify>` that fires after every successful reload, **after** the route table swap, so subscribers see the new domain set immediately.
- `AggregationService::with_evict_notify()` wires that `Notify` into the `run()` loop via `tokio::select!`, so eviction runs automatically without blocking ingestion or flushing.
- In `main.rs`, a single `Arc<Notify>` is threaded from `ConfigWatcher` to `AggregationService`, completing the circuit.

Pairs with the #163 pre-seed: construction pre-seeds the map for contention-free ingest; this eviction sweep keeps the working set bounded as domains are removed from the config.

## Test plan

- [x] `evict_drops_domains_not_in_new_known_set` — unit test: after a simulated reload removes `a`, `evict_unknown_domains()` removes the entry while keeping `b`.
- [x] `evict_with_empty_known_set_clears_all` — unit test: empty new known set wipes the map completely.
- [x] `evict_notify_triggers_eviction_in_run_loop` — async test: fires `evict_notify`, verifies the run loop acts on it end-to-end.
- [x] `cargo test -p dwaar-analytics` — 211 passed, 0 failed
- [x] `cargo test -p dwaar-config` — 276 passed, 0 failed
- [x] `cargo build -p dwaar-cli` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Closes #167