### PR TITLE
feat(file_server): SPA fallback for client-routed apps (v0.3.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.12] - 2026-04-27
+
+### Added
+
+- **`file_server` SPA fallback** — new `fallback PATH` subdirective inside a `file_server { ... }` block serves the configured file (typically `/index.html`) when a request would otherwise 404. Enables client-side routed apps (`SvelteKit`, React Router, Vue Router) to be served as static builds without bringing up a separate proxy. Asset-shaped requests (`.js`, `.css`, `.wasm`, fonts, images, …) are excluded from fallback so missing chunks still produce real 404s. Method-gated to `GET`/`HEAD`. Fallback paths are canonicalized inside `root` at compile time and re-checked at request time.
+
 ## [0.3.11] - 2026-04-27
 
 Audit-batch sweep release: 28 GitHub issues (the 2026-04-13 audit drop) closed across security, performance, bug, dependency, code-quality, and testing categories. No public Dwaarfile or operator-facing API changes — pure stability and hot-path improvements. Operators upgrading from 0.3.10 should see lower per-request allocation, faster health-check cycles, and reduced background-task contention.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-cli"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Dwaarfile.example
+++ b/Dwaarfile.example
@@ -19,3 +19,16 @@ blog.example.com {
     proxy localhost:4000
     analytics on
 }
+
+# Single-page app (SvelteKit / React Router / Vue Router) served as a
+# static build. The `fallback` subdirective serves /index.html for any
+# request that would otherwise 404, so client-side routes like
+# /blog/post-slug resolve to the SPA shell. Asset-shaped paths
+# (*.js, *.css, *.wasm, fonts, images, …) still 404 cleanly.
+app.example.com {
+    root * /var/www/app-build
+    file_server {
+        browse off
+        fallback /index.html
+    }
+}

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.3.11
+Licensed Work:        Dwaar 0.3.12
                       The Licensed Work is
                       (c) 2026 Permanu
 

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.3.11"
+version = "0.3.12"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-config/src/compile.rs
+++ b/crates/dwaar-config/src/compile.rs
@@ -12,7 +12,7 @@
 
 use std::collections::HashMap;
 use std::net::{SocketAddr, ToSocketAddrs};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -154,11 +154,43 @@ fn compile_file_server_block(
         },
         |r| PathBuf::from(&r.path),
     );
+    let canonical_root = root_path.canonicalize().unwrap_or(root_path);
+    let fallback = resolve_fallback(&canonical_root, fs_directive.fallback.as_deref(), address);
     let handler = Handler::FileServer {
-        root: root_path.canonicalize().unwrap_or(root_path),
+        root: canonical_root,
         browse: fs_directive.browse,
+        fallback,
     };
     Some(build_handler_block(handler, mw))
+}
+
+/// Resolve the optional `fallback` path against the `file_server` root.
+///
+/// Returns the absolute path of the fallback file when it is safely contained
+/// under `root`. Logs a warning and drops the fallback if it would escape the
+/// root or if path resolution fails. Missing fallback files are kept (they
+/// just degrade to 404 at request time, which is the documented contract).
+fn resolve_fallback(root: &Path, fallback: Option<&str>, address: &str) -> Option<PathBuf> {
+    let raw = fallback?;
+    let trimmed = raw.trim_start_matches('/');
+    let candidate = root.join(trimmed);
+    // Cheap lexical check first — reject `..` traversal regardless of FS state.
+    if !candidate.starts_with(root) {
+        warn!(address = %address, fallback = %raw, "file_server fallback path escapes root, ignoring");
+        return None;
+    }
+    // If the fallback file already exists, canonicalize so symlinks can't
+    // re-introduce traversal at request time.
+    match candidate.canonicalize() {
+        Ok(resolved) if resolved.starts_with(root) => Some(resolved),
+        Ok(_) => {
+            warn!(address = %address, fallback = %raw, "file_server fallback resolves outside root, ignoring");
+            None
+        }
+        // File not present yet — store the lexical join. Request-time logic
+        // will treat a missing fallback file as 404.
+        Err(_) => Some(candidate),
+    }
 }
 
 /// Build a `HandlerBlock` for a `php_fastcgi` directive.
@@ -899,9 +931,12 @@ fn compile_single_block(
     } else if let Some(fs) = find_file_server(inner_directives) {
         let root_path = find_root(inner_directives)
             .map_or_else(|| PathBuf::from("."), |r| PathBuf::from(&r.path));
+        let canonical_root = root_path.canonicalize().unwrap_or(root_path);
+        let fallback = resolve_fallback(&canonical_root, fs.fallback.as_deref(), "handle block");
         Handler::FileServer {
-            root: root_path.canonicalize().unwrap_or(root_path),
+            root: canonical_root,
             browse: fs.browse,
+            fallback,
         }
     } else if let Some(fcgi) = find_php_fastcgi(inner_directives) {
         let addr = resolve_upstream(std::slice::from_ref(&fcgi.upstream))?;

--- a/crates/dwaar-config/src/format.rs
+++ b/crates/dwaar-config/src/format.rs
@@ -67,7 +67,7 @@ fn format_directive_at_depth(out: &mut String, directive: &Directive, depth: usi
         Directive::BasicAuth(ba) => format_basicauth(out, ba, depth),
         Directive::ForwardAuth(fa) => format_forward_auth(out, fa, depth),
         Directive::Root(r) => format_root(out, r),
-        Directive::FileServer(fs) => format_file_server(out, fs),
+        Directive::FileServer(fs) => format_file_server(out, fs, depth),
         Directive::Handle(h) => {
             format_handle_block(out, "handle", h.matcher.as_deref(), &h.directives, depth);
         }
@@ -440,10 +440,26 @@ fn format_root(out: &mut String, r: &RootDirective) {
     out.push_str(&r.path);
 }
 
-fn format_file_server(out: &mut String, fs: &FileServerDirective) {
+fn format_file_server(out: &mut String, fs: &FileServerDirective, depth: usize) {
     out.push_str("file_server");
-    if fs.browse {
-        out.push_str(" browse");
+    match (fs.browse, fs.fallback.as_deref()) {
+        (false, None) => {}
+        (true, None) => out.push_str(" browse"),
+        (browse, Some(fallback)) => {
+            let inner = "    ".repeat(depth + 1);
+            let outer = "    ".repeat(depth);
+            out.push_str(" {\n");
+            if browse {
+                out.push_str(&inner);
+                out.push_str("browse on\n");
+            }
+            out.push_str(&inner);
+            out.push_str("fallback ");
+            out.push_str(fallback);
+            out.push('\n');
+            out.push_str(&outer);
+            out.push('}');
+        }
     }
 }
 

--- a/crates/dwaar-config/src/model.rs
+++ b/crates/dwaar-config/src/model.rs
@@ -876,6 +876,11 @@ pub struct RootDirective {
 pub struct FileServerDirective {
     /// Enable directory listing.
     pub browse: bool,
+    /// SPA fallback: if a request resolves to `NotFound` and the request
+    /// doesn't look like a static asset, serve this path (relative to
+    /// `root`) with status 200. Used for client-side routed apps
+    /// (`SvelteKit`, React Router, Vue Router).
+    pub fallback: Option<String>,
 }
 
 /// `rewrite` — replace the request URI sent to upstream.

--- a/crates/dwaar-config/src/parser/directives.rs
+++ b/crates/dwaar-config/src/parser/directives.rs
@@ -739,13 +739,104 @@ pub(super) fn parse_root(t: &mut Tokenizer<'_>) -> Result<RootDirective, ParseEr
     }
 }
 
-/// `file_server` or `file_server browse`
-pub(super) fn parse_file_server(t: &mut Tokenizer<'_>) -> FileServerDirective {
-    let browse = matches!(t.peek().kind, TokenKind::Word(ref w) if w == "browse");
-    if browse {
+/// `file_server` — either inline (`file_server` / `file_server browse`)
+/// or block form:
+/// ```text
+/// file_server {
+///     browse on|off
+///     fallback /index.html
+/// }
+/// ```
+///
+/// The block form supports SPA-style fallback so that client-routed apps
+/// (`SvelteKit`, React Router, Vue Router) can recover from 404 by serving
+/// `index.html` for non-asset paths.
+pub(super) fn parse_file_server(t: &mut Tokenizer<'_>) -> Result<FileServerDirective, ParseError> {
+    let mut browse = false;
+    let mut fallback: Option<String> = None;
+
+    // Inline shorthand: `file_server browse` (preserves backwards compat).
+    if matches!(t.peek().kind, TokenKind::Word(ref w) if w == "browse") {
         t.next_token();
+        browse = true;
     }
-    FileServerDirective { browse }
+
+    // Optional block form follows.
+    if matches!(t.peek().kind, TokenKind::OpenBrace) {
+        t.next_token();
+        loop {
+            let tok = t.next_token();
+            let (line, col) = (tok.line, tok.col);
+            match tok.kind {
+                TokenKind::CloseBrace | TokenKind::Eof => break,
+                TokenKind::Word(ref sub) => match sub.as_str() {
+                    "browse" => {
+                        // `browse` (toggle on) or `browse on|off`
+                        match t.peek().kind {
+                            TokenKind::Word(ref w) if w == "on" => {
+                                t.next_token();
+                                browse = true;
+                            }
+                            TokenKind::Word(ref w) if w == "off" => {
+                                t.next_token();
+                                browse = false;
+                            }
+                            _ => {
+                                browse = true;
+                            }
+                        }
+                    }
+                    "fallback" => {
+                        let val = expect_word_or_quoted(t, "file_server", "fallback path")?;
+                        if val.contains("..") {
+                            return Err(ParseError {
+                                line,
+                                col,
+                                kind: ParseErrorKind::InvalidValue {
+                                    directive: "file_server".to_string(),
+                                    message: format!(
+                                        "fallback path '{val}' contains '..' (path traversal not allowed)"
+                                    ),
+                                    accepted_format: Some(
+                                        "fallback /index.html  (relative to root)",
+                                    ),
+                                },
+                            });
+                        }
+                        if val.contains('\0') {
+                            return Err(ParseError {
+                                line,
+                                col,
+                                kind: ParseErrorKind::InvalidValue {
+                                    directive: "file_server".to_string(),
+                                    message: "fallback path contains null byte".to_string(),
+                                    accepted_format: None,
+                                },
+                            });
+                        }
+                        fallback = Some(val);
+                    }
+                    other => {
+                        return Err(ParseError {
+                            line,
+                            col,
+                            kind: ParseErrorKind::InvalidValue {
+                                directive: "file_server".to_string(),
+                                message: format!(
+                                    "unknown subdirective '{other}' inside file_server block; \
+                                     expected 'browse' or 'fallback'"
+                                ),
+                                accepted_format: None,
+                            },
+                        });
+                    }
+                },
+                _ => {}
+            }
+        }
+    }
+
+    Ok(FileServerDirective { browse, fallback })
 }
 
 /// `php_fastcgi localhost:9000` — proxy to `FastCGI` backend.

--- a/crates/dwaar-config/src/parser/mod.rs
+++ b/crates/dwaar-config/src/parser/mod.rs
@@ -997,7 +997,7 @@ fn parse_directive(t: &mut Tokenizer<'_>) -> Result<Directive, ParseError> {
         )?)),
         "route" => Ok(Directive::Route(directives::parse_route(t)?)),
         "root" => Ok(Directive::Root(directives::parse_root(t)?)),
-        "file_server" => Ok(Directive::FileServer(directives::parse_file_server(t))),
+        "file_server" => Ok(Directive::FileServer(directives::parse_file_server(t)?)),
         "php_fastcgi" => Ok(Directive::PhpFastcgi(directives::parse_php_fastcgi(t)?)),
         "forward_auth" => Ok(Directive::ForwardAuth(directives::parse_forward_auth(t)?)),
         "try_files" => Ok(Directive::TryFiles(directives::parse_try_files(t)?)),

--- a/crates/dwaar-config/src/parser/tests.rs
+++ b/crates/dwaar-config/src/parser/tests.rs
@@ -856,7 +856,10 @@ fn file_server_parses() {
     assert!(matches!(config.sites[0].directives[0], Directive::Root(_)));
     assert!(matches!(
         config.sites[0].directives[1],
-        Directive::FileServer(FileServerDirective { browse: false })
+        Directive::FileServer(FileServerDirective {
+            browse: false,
+            fallback: None,
+        })
     ));
 }
 
@@ -866,8 +869,62 @@ fn file_server_browse() {
         parse("a.com {\n    root * /var/www\n    file_server browse\n}\n").expect("should parse");
     assert!(matches!(
         config.sites[0].directives[1],
-        Directive::FileServer(FileServerDirective { browse: true })
+        Directive::FileServer(FileServerDirective {
+            browse: true,
+            fallback: None,
+        })
     ));
+}
+
+#[test]
+fn file_server_block_with_fallback() {
+    let src =
+        "a.com {\n    root * /var/www\n    file_server {\n        fallback /index.html\n    }\n}\n";
+    let config = parse(src).expect("should parse");
+    let Directive::FileServer(fs) = &config.sites[0].directives[1] else {
+        panic!("expected FileServer");
+    };
+    assert!(!fs.browse);
+    assert_eq!(fs.fallback.as_deref(), Some("/index.html"));
+}
+
+#[test]
+fn file_server_block_browse_off_with_fallback() {
+    let src = "a.com {\n    root * /var/www\n    file_server {\n        browse off\n        fallback /index.html\n    }\n}\n";
+    let config = parse(src).expect("should parse");
+    let Directive::FileServer(fs) = &config.sites[0].directives[1] else {
+        panic!("expected FileServer");
+    };
+    assert!(!fs.browse);
+    assert_eq!(fs.fallback.as_deref(), Some("/index.html"));
+}
+
+#[test]
+fn file_server_block_browse_on_with_fallback() {
+    let src = "a.com {\n    root * /var/www\n    file_server {\n        browse on\n        fallback /index.html\n    }\n}\n";
+    let config = parse(src).expect("should parse");
+    let Directive::FileServer(fs) = &config.sites[0].directives[1] else {
+        panic!("expected FileServer");
+    };
+    assert!(fs.browse);
+    assert_eq!(fs.fallback.as_deref(), Some("/index.html"));
+}
+
+#[test]
+fn file_server_fallback_rejects_path_traversal() {
+    let src = "a.com {\n    root * /var/www\n    file_server {\n        fallback /../etc/passwd\n    }\n}\n";
+    let err = parse(src).expect_err("should reject ..");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("traversal") || msg.contains(".."),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn file_server_unknown_subdirective_rejected() {
+    let src = "a.com {\n    root * /var/www\n    file_server {\n        bogus value\n    }\n}\n";
+    parse(src).expect_err("should reject unknown subdirective");
 }
 
 #[test]

--- a/crates/dwaar-core/src/context.rs
+++ b/crates/dwaar-core/src/context.rs
@@ -101,7 +101,9 @@ pub struct RequestContext {
     pub forward_auth: Option<std::sync::Arc<dwaar_plugins::forward_auth::ForwardAuthConfig>>,
 
     /// File server config cached from route lookup (Guardrail #27).
-    pub file_server: Option<(std::path::PathBuf, bool)>,
+    /// Tuple: `(root, browse, fallback)` where `fallback` is the optional
+    /// SPA fallback path (already canonicalized inside `root` at compile time).
+    pub file_server: Option<(std::path::PathBuf, bool, Option<std::path::PathBuf>)>,
 
     /// `FastCGI` document root cached from route lookup (Guardrail #27).
     pub fastcgi_root: Option<std::path::PathBuf>,

--- a/crates/dwaar-core/src/file_server.rs
+++ b/crates/dwaar-core/src/file_server.rs
@@ -60,12 +60,104 @@ pub enum FileResponse {
     Forbidden,
 }
 
+/// File extensions that are obviously assets, not client-side routes.
+/// Requests with these extensions never trigger SPA fallback — otherwise a
+/// missing JS chunk would silently return `index.html`, which browsers and
+/// build tools would then try to execute as JavaScript and produce confusing
+/// MIME-type or syntax errors. Keep this list conservative: better to skip
+/// fallback for a few odd routes than to corrupt asset resolution.
+const ASSET_EXTENSIONS: &[&str] = &[
+    "js", "mjs", "cjs", "css", "map", "wasm", "woff", "woff2", "ttf", "otf", "eot", "svg", "png",
+    "jpg", "jpeg", "gif", "webp", "avif", "ico", "json", "txt", "xml", "pdf", "zip", "gz", "br",
+    "mp3", "mp4", "webm", "ogg", "wav",
+];
+
+/// Returns true when `request_path` ends with an extension we consider a
+/// static asset (and therefore should NOT fall back to `index.html` on 404).
+fn is_asset_extension(request_path: &str) -> bool {
+    // Strip query string and fragment if present (defensive — proxy normally
+    // hands us a path-only string, but be safe).
+    let no_query = request_path
+        .split_once('?')
+        .map_or(request_path, |(p, _)| p);
+    let path = no_query.split_once('#').map_or(no_query, |(p, _)| p);
+
+    let last_segment = path.rsplit('/').next().unwrap_or("");
+    let Some((_, ext)) = last_segment.rsplit_once('.') else {
+        return false;
+    };
+    let ext_lower = ext.to_ascii_lowercase();
+    ASSET_EXTENSIONS.iter().any(|e| *e == ext_lower)
+}
+
 /// Resolve a request path to a file response.
 ///
 /// `root`: the configured filesystem root (already canonicalized at compile time).
 /// `request_path`: the URL path from the client (e.g., `/css/style.css`).
 /// `browse`: whether directory listing is enabled.
-pub async fn serve_file(root: &Path, request_path: &str, browse: bool) -> FileResponse {
+/// `fallback`: optional SPA fallback path (already canonicalized inside `root`
+///   at compile time). When set, a request that would otherwise return
+///   `NotFound` and is not an asset-shaped path will be retried with this
+///   file. Used for client-routed apps (`SvelteKit`, React Router, Vue Router).
+/// `method`: HTTP method (only `GET`/`HEAD` trigger fallback).
+pub async fn serve_file(
+    root: &Path,
+    request_path: &str,
+    browse: bool,
+    fallback: Option<&Path>,
+    method: &str,
+) -> FileResponse {
+    let primary = serve_file_inner(root, request_path, browse).await;
+
+    // Fast path: anything other than NotFound (or NotFound without a configured
+    // fallback) returns immediately. Preserves backwards compat exactly.
+    let FileResponse::NotFound = primary else {
+        return primary;
+    };
+    let Some(fallback_path) = fallback else {
+        return FileResponse::NotFound;
+    };
+
+    // Method gating: fallback is a GET-shaped recovery, not a generic retry.
+    if !matches!(method, "GET" | "HEAD") {
+        return FileResponse::NotFound;
+    }
+
+    // Don't rewrite missing assets to index.html — see ASSET_EXTENSIONS rationale.
+    if is_asset_extension(request_path) {
+        return FileResponse::NotFound;
+    }
+
+    // Dotfile gate is enforced inside serve_file_inner already; if the original
+    // request was a dotfile we've returned Forbidden above (not NotFound) and
+    // never reach this branch.
+
+    // Defense-in-depth: re-verify the fallback path is contained in root.
+    // compile.rs guarantees this, but a runtime check is cheap.
+    if !fallback_path.starts_with(root) {
+        return FileResponse::NotFound;
+    }
+
+    let fallback_owned = fallback_path.to_path_buf();
+    let is_file = tokio::task::spawn_blocking(move || fallback_owned.is_file())
+        .await
+        .unwrap_or(false);
+    if !is_file {
+        return FileResponse::NotFound;
+    }
+
+    tracing::debug!(
+        from = %request_path,
+        to = %fallback_path.display(),
+        "serve_file: SPA fallback engaged"
+    );
+    read_file(fallback_path).await
+}
+
+/// Inner resolver — original `serve_file` logic without the fallback layer.
+/// Kept as a separate function so the fallback wrapper can call it twice
+/// without re-implementing path validation.
+async fn serve_file_inner(root: &Path, request_path: &str, browse: bool) -> FileResponse {
     // Reject null bytes before any filesystem access
     if request_path.contains('\0') {
         return FileResponse::Forbidden;
@@ -308,10 +400,17 @@ mod tests {
         (dir, canonical)
     }
 
+    /// Convenience wrapper that calls `serve_file` with the legacy
+    /// no-fallback contract — keeps existing tests focused on their
+    /// original behavior.
+    async fn serve(root: &Path, path: &str, browse: bool) -> FileResponse {
+        serve_file(root, path, browse, None, "GET").await
+    }
+
     #[tokio::test]
     async fn serves_existing_file() {
         let (_dir, root) = setup_test_dir();
-        let resp = serve_file(&root, "/style.css", false).await;
+        let resp = serve(&root, "/style.css", false).await;
         match resp {
             FileResponse::Found {
                 content_type, body, ..
@@ -326,21 +425,21 @@ mod tests {
     #[tokio::test]
     async fn serves_index_html_for_directory() {
         let (_dir, root) = setup_test_dir();
-        let resp = serve_file(&root, "/", false).await;
+        let resp = serve(&root, "/", false).await;
         assert!(matches!(resp, FileResponse::Found { .. }));
     }
 
     #[tokio::test]
     async fn not_found_for_missing_file() {
         let (_dir, root) = setup_test_dir();
-        let resp = serve_file(&root, "/nonexistent.txt", false).await;
+        let resp = serve(&root, "/nonexistent.txt", false).await;
         assert!(matches!(resp, FileResponse::NotFound));
     }
 
     #[tokio::test]
     async fn rejects_path_traversal() {
         let (_dir, root) = setup_test_dir();
-        let resp = serve_file(&root, "/../../../etc/passwd", false).await;
+        let resp = serve(&root, "/../../../etc/passwd", false).await;
         assert!(matches!(
             resp,
             FileResponse::Forbidden | FileResponse::NotFound
@@ -350,21 +449,21 @@ mod tests {
     #[tokio::test]
     async fn rejects_null_bytes() {
         let (_dir, root) = setup_test_dir();
-        let resp = serve_file(&root, "/style.css\0.txt", false).await;
+        let resp = serve(&root, "/style.css\0.txt", false).await;
         assert!(matches!(resp, FileResponse::Forbidden));
     }
 
     #[tokio::test]
     async fn rejects_dotfiles() {
         let (_dir, root) = setup_test_dir();
-        let resp = serve_file(&root, "/.env", false).await;
+        let resp = serve(&root, "/.env", false).await;
         assert!(matches!(resp, FileResponse::Forbidden));
     }
 
     #[tokio::test]
     async fn directory_listing_when_browse_enabled() {
         let (_dir, root) = setup_test_dir();
-        let resp = serve_file(&root, "/sub/", true).await;
+        let resp = serve(&root, "/sub/", true).await;
         match resp {
             FileResponse::DirectoryListing { body } => {
                 let html = std::str::from_utf8(&body).expect("valid utf8");
@@ -379,21 +478,21 @@ mod tests {
     async fn no_listing_when_browse_disabled() {
         let (_dir, root) = setup_test_dir();
         // /sub/ has page.html but no index.html — without browse, returns NotFound
-        let resp = serve_file(&root, "/sub/", false).await;
+        let resp = serve(&root, "/sub/", false).await;
         assert!(matches!(resp, FileResponse::NotFound));
     }
 
     #[tokio::test]
     async fn serves_subdirectory_file() {
         let (_dir, root) = setup_test_dir();
-        let resp = serve_file(&root, "/sub/page.html", false).await;
+        let resp = serve(&root, "/sub/page.html", false).await;
         assert!(matches!(resp, FileResponse::Found { .. }));
     }
 
     #[tokio::test]
     async fn etag_is_set() {
         let (_dir, root) = setup_test_dir();
-        if let FileResponse::Found { etag, .. } = serve_file(&root, "/style.css", false).await {
+        if let FileResponse::Found { etag, .. } = serve(&root, "/style.css", false).await {
             assert!(etag.is_some());
             let tag = etag.expect("etag");
             assert!(tag.starts_with('"'));
@@ -401,6 +500,113 @@ mod tests {
         } else {
             panic!("expected Found");
         }
+    }
+
+    // ── SPA fallback tests ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn fallback_engages_for_missing_route() {
+        let (_dir, root) = setup_test_dir();
+        let fallback = root.join("index.html");
+        let resp = serve_file(&root, "/blog/post-slug", false, Some(&fallback), "GET").await;
+        match resp {
+            FileResponse::Found {
+                content_type, body, ..
+            } => {
+                assert_eq!(content_type, "text/html; charset=utf-8");
+                assert_eq!(body.as_ref(), b"<html>hello</html>");
+            }
+            other => panic!("expected fallback Found, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fallback_skipped_for_asset_extensions() {
+        let (_dir, root) = setup_test_dir();
+        let fallback = root.join("index.html");
+        // A missing .js must NOT serve index.html — that would corrupt the page.
+        let resp = serve_file(&root, "/missing.js", false, Some(&fallback), "GET").await;
+        assert!(matches!(resp, FileResponse::NotFound));
+    }
+
+    #[tokio::test]
+    async fn fallback_serves_existing_file_unchanged() {
+        let (_dir, root) = setup_test_dir();
+        let fallback = root.join("index.html");
+        // Existing files are never rerouted to fallback.
+        let resp = serve_file(&root, "/style.css", false, Some(&fallback), "GET").await;
+        match resp {
+            FileResponse::Found {
+                content_type, body, ..
+            } => {
+                assert_eq!(content_type, "text/css; charset=utf-8");
+                assert_eq!(body.as_ref(), b"body{}");
+            }
+            other => panic!("expected Found, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fallback_returns_404_when_fallback_file_missing() {
+        let (_dir, root) = setup_test_dir();
+        let fallback = root.join("does-not-exist.html");
+        let resp = serve_file(&root, "/blog/post", false, Some(&fallback), "GET").await;
+        assert!(matches!(resp, FileResponse::NotFound));
+    }
+
+    #[tokio::test]
+    async fn fallback_engages_for_head_method() {
+        let (_dir, root) = setup_test_dir();
+        let fallback = root.join("index.html");
+        let resp = serve_file(&root, "/blog/post", false, Some(&fallback), "HEAD").await;
+        assert!(matches!(resp, FileResponse::Found { .. }));
+    }
+
+    #[tokio::test]
+    async fn fallback_does_not_engage_for_post() {
+        let (_dir, root) = setup_test_dir();
+        let fallback = root.join("index.html");
+        let resp = serve_file(&root, "/blog/post", false, Some(&fallback), "POST").await;
+        assert!(matches!(resp, FileResponse::NotFound));
+    }
+
+    #[tokio::test]
+    async fn fallback_does_not_override_dotfile_forbidden() {
+        let (_dir, root) = setup_test_dir();
+        let fallback = root.join("index.html");
+        // Dotfile requests are 403 before fallback can be considered.
+        let resp = serve_file(&root, "/.env", false, Some(&fallback), "GET").await;
+        assert!(matches!(resp, FileResponse::Forbidden));
+    }
+
+    #[tokio::test]
+    async fn fallback_rejected_when_outside_root() {
+        let (_dir, root) = setup_test_dir();
+        // Fabricate a fallback that points outside the root.
+        let outside = std::env::temp_dir().join("totally-elsewhere.html");
+        let resp = serve_file(&root, "/blog/post", false, Some(&outside), "GET").await;
+        assert!(matches!(resp, FileResponse::NotFound));
+    }
+
+    #[tokio::test]
+    async fn no_fallback_preserves_legacy_404() {
+        let (_dir, root) = setup_test_dir();
+        // Regression guard: missing file with no fallback configured.
+        let resp = serve_file(&root, "/blog/post", false, None, "GET").await;
+        assert!(matches!(resp, FileResponse::NotFound));
+    }
+
+    #[test]
+    fn asset_extension_detection() {
+        assert!(is_asset_extension("/app.js"));
+        assert!(is_asset_extension("/styles/main.CSS"));
+        assert!(is_asset_extension("/_app/immutable/chunks/abc.js"));
+        assert!(is_asset_extension("/img/logo.png"));
+        assert!(!is_asset_extension("/blog/post"));
+        assert!(!is_asset_extension("/about"));
+        assert!(!is_asset_extension("/"));
+        // Query string shouldn't fool us
+        assert!(is_asset_extension("/app.js?v=1"));
     }
 
     #[test]

--- a/crates/dwaar-core/src/proxy.rs
+++ b/crates/dwaar-core/src/proxy.rs
@@ -937,8 +937,12 @@ impl ProxyHttp for DwaarProxy {
                         crate::route::Handler::StaticResponse { status, body } => {
                             ctx.static_response = Some((*status, body.clone()));
                         }
-                        crate::route::Handler::FileServer { root, browse } => {
-                            ctx.file_server = Some((root.clone(), *browse));
+                        crate::route::Handler::FileServer {
+                            root,
+                            browse,
+                            fallback,
+                        } => {
+                            ctx.file_server = Some((root.clone(), *browse, fallback.clone()));
                         }
                         crate::route::Handler::ReverseProxy {
                             upstream,
@@ -1333,13 +1337,22 @@ impl ProxyHttp for DwaarProxy {
         }
 
         // --- File server handler (ISSUE-048) ---
-        if let Some((ref root, browse)) = ctx.file_server {
+        if let Some((ref root, browse, ref fallback)) = ctx.file_server {
             let request_path = ctx
                 .effective_path
                 .as_deref()
                 .unwrap_or(ctx.plugin_ctx.path.as_str());
+            let method = ctx.plugin_ctx.method.as_str();
 
-            match crate::file_server::serve_file(root, request_path, browse).await {
+            match crate::file_server::serve_file(
+                root,
+                request_path,
+                browse,
+                fallback.as_deref(),
+                method,
+            )
+            .await
+            {
                 crate::file_server::FileResponse::Found {
                     body,
                     content_type,

--- a/crates/dwaar-core/src/route.rs
+++ b/crates/dwaar-core/src/route.rs
@@ -155,6 +155,10 @@ pub enum Handler {
     FileServer {
         root: std::path::PathBuf,
         browse: bool,
+        /// Optional SPA fallback path (already canonicalized inside `root`
+        /// at compile time). Engaged when a request would otherwise 404
+        /// and the path doesn't look like a static asset.
+        fallback: Option<std::path::PathBuf>,
     },
     /// Proxy to a `FastCGI` backend (`php-fpm`). Used by `php_fastcgi` directive.
     FastCgi {
@@ -191,12 +195,14 @@ impl PartialEq for Handler {
                 Handler::FileServer {
                     root: r1,
                     browse: b1,
+                    fallback: f1,
                 },
                 Handler::FileServer {
                     root: r2,
                     browse: b2,
+                    fallback: f2,
                 },
-            ) => r1 == r2 && b1 == b2,
+            ) => r1 == r2 && b1 == b2 && f1 == f2,
             (
                 Handler::FastCgi {
                     upstream: u1,


### PR DESCRIPTION
## Summary

Add `fallback PATH` subdirective to `file_server` block so static SvelteKit / React Router / Vue Router builds can be served without bringing up a separate proxy. When a request would otherwise 404 and isn't asset-shaped, Dwaar serves the configured fallback file (typically `/index.html`) with status 200 and that file's own MIME/ETag/Last-Modified.

```dwaarfile
app.example.com {
    root * /var/www/svelte-build
    file_server {
        browse off
        fallback /index.html
    }
}
```

## Behavior contract

- **Asset allowlist** — `.js`, `.css`, `.map`, `.wasm`, `.woff(2)`, `.ttf`, `.svg`, `.png`, `.jpg`, `.gif`, `.webp`, `.ico`, `.json`, `.txt`, `.xml`, `.pdf`, `.zip`, `.gz`, etc. never fall back. A missing JS chunk must be a real 404, not an HTML page.
- **Method gate** — only `GET` and `HEAD` trigger fallback; POST/PUT/DELETE/etc. still 404 cleanly.
- **Dotfile / path-traversal guards** apply *before* fallback is considered.
- **Fallback canonicalized** inside `root` at config compile time and re-checked at request time (defense-in-depth).
- **Cache headers** derived from the fallback file (its mtime/size), so SvelteKit's hashed `_app/immutable/*` keep their immutable cache, while `index.html` gets a weak ETag.
- **Logging** — `tracing::debug!` on engagement: `serve_file: SPA fallback engaged from=<requested> to=<fallback>`.
- **Backwards-compatible** — existing `file_server` and `file_server browse` configs are untouched (no signature change for the inline form).

## Files

- `crates/dwaar-config/src/model.rs` — `FileServerDirective.fallback: Option<String>`
- `crates/dwaar-config/src/parser/directives.rs` — block-form parser with `browse on|off` and `fallback PATH`; rejects `..` at parse time
- `crates/dwaar-config/src/compile.rs` — canonicalize fallback against root, drop with warn if it escapes
- `crates/dwaar-config/src/format.rs` — round-trip emit for block form
- `crates/dwaar-core/src/route.rs` + `context.rs` + `proxy.rs` — thread fallback + method through to file_server
- `crates/dwaar-core/src/file_server.rs` — asset-extension allowlist, method gate, fallback retry layered on top of original `serve_file_inner`
- `CHANGELOG.md` — v0.3.12 entry
- `crates/dwaar-cli/Cargo.toml` — bumped to `0.3.12` (per `feedback_dwaar_version_bump`)
- `Dwaarfile.example` — SPA section

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test -p dwaar-config` — 283 passed
- [x] `cargo test -p dwaar-core` — 370 passed (includes 22 file_server tests, 11 new for SPA fallback)
- [x] Manual smoke against `/tmp/spa-smoke` (index.html + `_app/immutable/chunks/real.js`):
  ```
  GET /                                       → 200 text/html  (index.html)
  GET /blog/post                              → 200 text/html  (fallback engaged)
  GET /_app/immutable/chunks/real.js          → 200 application/javascript
  GET /_app/immutable/chunks/missing.js       → 404            (asset allowlist works)
  HEAD /some/spa/path                         → 200            (HEAD honored)
  POST /some/spa/path                         → 404            (POST not gated to fallback)
  GET /.env                                   → 403            (dotfile guard intact)
  ```
- [x] Pre-existing `dwaar-cli/proxy_integration` flakes on macOS (port 8080 conflict / connection-refused) reproduce on `main` and are unrelated to this PR.

## Notes

- No new dependencies.
- The runtime asset-extension list lives in a `const ASSET_EXTENSIONS` slice — easy to extend later if operators ask for configurability, but the spec said "ship a sensible default" and that's what's here.
- Dwaarfile inline form `file_server /var/www/build` was *not* added — Dwaar's existing convention is `root * PATH` then `file_server`, and conflating the two would be a drive-by change. The block form composes cleanly with the existing `root` directive.