### PR TITLE
chore(release): v0.3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.14] - 2026-04-29
+
+### Fixed
+- `http_port` and `https_port` global directives now correctly control bind addresses (were parsed but ignored)
+- Implicit auto-HTTPS for domain-named sites without explicit `tls` directive (Caddy-compatible behavior)
+- `compile_acme_domains` includes domain-named sites with no TLS directive for automatic ACME cert provisioning
+
 ## [0.3.13] - 2026-04-27
 
 ### Fixed

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.3.13
+Licensed Work:        Dwaar 0.3.14
                       The Licensed Work is
                       (c) 2026 Permanu
 
@@ -65,7 +65,7 @@ Additional Use Grant: You may use, copy, modify, create derivative works of,
                         of the Licensed Work as part of a commercial
                         infrastructure or platform product.
 
-Change Date:          2036-04-28
+Change Date:          2036-04-29
 
 Change License:       GNU Affero General Public License v3.0
 

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.3.13"
+version = "0.3.14"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false


### PR DESCRIPTION
## Summary
Bump patch version to 0.3.14 for release.

Changes since v0.3.13:
- Implicit auto-HTTPS for domain-named sites (Caddy-compatible behavior)
- `http_port` / `https_port` global directives now correctly consumed by bind address functions
- Tests updated for new implicit TLS behavior

## Test plan
- [x] CI passes on this PR
- [ ] Tag `v0.3.14` after merge triggers Release workflow
- [ ] Agent auto-updater picks up new binary on VPS