### PR TITLE
fix(config): resolve imports relative to Dwaarfile, not CWD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.15] - 2026-04-29
+
+### Fixed
+- Import directives (`import apps/*.dwaar`) resolved relative to Dwaarfile directory, not CWD — fixes zero routes on startup when running as systemd service
+- Initial config hash uses expanded content to match watcher behavior, preventing spurious first-reload
+
 ## [0.3.14] - 2026-04-29
 
 ### Fixed

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.3.14
+Licensed Work:        Dwaar 0.3.15
                       The Licensed Work is
                       (c) 2026 Permanu
 

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.3.14"
+version = "0.3.15"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-cli/src/main.rs
+++ b/crates/dwaar-cli/src/main.rs
@@ -1746,7 +1746,13 @@ fn register_background_services(
     let agg_evict_notify = Arc::new(tokio::sync::Notify::new());
 
     // Config file watcher for hot-reload
-    let initial_hash = hash_content(&std::fs::read(config_path).unwrap_or_default());
+    // Hash expanded content so it matches the watcher's hash (which expands imports).
+    let initial_hash = {
+        let raw = std::fs::read_to_string(config_path).unwrap_or_default();
+        let base = config_path.parent().unwrap_or(std::path::Path::new("."));
+        let expanded = dwaar_config::import::expand_imports(&raw, base).unwrap_or(raw);
+        hash_content(expanded.as_bytes())
+    };
     let config_watcher = ConfigWatcher::new(
         config_path.to_path_buf(),
         Arc::clone(route_table),
@@ -1949,7 +1955,9 @@ fn load_config(path: &std::path::Path) -> anyhow::Result<dwaar_config::model::Dw
     let config_text = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read config file: {}", path.display()))?;
 
-    let config = dwaar_config::parser::parse(&config_text).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let base_dir = path.parent().unwrap_or(std::path::Path::new("."));
+    let config = dwaar_config::parser::parse_with_base_dir(&config_text, base_dir)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
 
     info!(
         sites = config.sites.len(),


### PR DESCRIPTION
## Summary
- `load_config()` called `parser::parse()` which hardcodes `base_dir` to `"."` (CWD), causing `import apps/*.dwaar` to resolve against the wrong directory when running as a systemd service (CWD = `/` or `/root`, not `/etc/dwaar/`)
- Import glob matched zero files silently, producing 0 routes on every startup
- Config watcher correctly used `config_path.parent()`, which is why routes appeared after touching the Dwaarfile
- Also fixes initial hash to use expanded content, matching the watcher's behavior

## Test plan
- [ ] Start Dwaar with CWD != Dwaarfile directory, verify imported routes are compiled
- [ ] Verify initial hash matches watcher hash (no spurious first-reload)
- [ ] Existing `compile::tests` pass
