### PR TITLE
fix(tls): install rustls CryptoProvider before server bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16] - 2026-04-29
+
+### Fixed
+- Install rustls ring CryptoProvider before server bootstrap — prevents ACME/TLS panic when routes with implicit auto-HTTPS are compiled at startup
+
 ## [0.3.15] - 2026-04-29
 
 ### Fixed

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.3.15
+Licensed Work:        Dwaar 0.3.16
                       The Licensed Work is
                       (c) 2026 Permanu
 

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.3.15"
+version = "0.3.16"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false
@@ -53,6 +53,7 @@ libc = { workspace = true }
 tempfile = { workspace = true }
 subtle = { workspace = true }
 reqwest = { workspace = true }
+rustls = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/crates/dwaar-cli/src/main.rs
+++ b/crates/dwaar-cli/src/main.rs
@@ -931,6 +931,14 @@ fn build_pingora_server(
     };
 
     let mut server = Server::new_with_opt_and_conf(Some(pingora_opt), conf);
+
+    // Install rustls crypto provider before any TLS operations (ACME, TLS
+    // handshakes). Required since rustls 0.23 removed the implicit default.
+    // Must happen before server.bootstrap() which may start TLS services.
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok(); // ok if already installed
+
     server.bootstrap();
 
     info!(


### PR DESCRIPTION
## Summary
- When routes with implicit auto-HTTPS are compiled at startup, the ACME service starts and uses rustls internally
- Rustls 0.23 requires explicit `CryptoProvider::install_default()` call — without it, the process panics
- This was a latent bug exposed by the import-base-dir fix (PR #280): previously 0 routes were compiled at startup so ACME never started

## Test plan
- [ ] Start Dwaar with TLS routes and auto_update enabled — no panic
- [ ] ACME certificate provisioning starts successfully
- [ ] Existing tests pass
