### PR TITLE
feat(tls): DNS-01 + wildcard ACME support via Cloudflare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.17] - 2026-04-30
+
+### Added
+- DNS-01 ACME challenge support via Cloudflare — enables wildcard cert issuance (`*.example.com`) without requiring an exposed HTTP-01/TLS-ALPN-01 listener
+- `tls { dns cloudflare <api_token> }` directive for per-site DNS-01 opt-in
+- Hot-reload support for `dns_domains` list — zero-downtime config swaps without restarting TLS background service
+- Multi-token DNS-01 warning: logs when multiple sites specify different Cloudflare tokens (first token wins, others ignored)
+- Unit tests for `compile_dns01_domains` covering single-site, multi-site, shared-token, and multi-token scenarios
+
 ## [0.3.16] - 2026-04-29
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-cli"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-cli"
-version = "0.3.14"
+version = "0.3.17"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1400,6 +1400,7 @@ dependencies = [
  "predicates",
  "rand 0.10.1",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "subtle",

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.3.16
+Licensed Work:        Dwaar 0.3.17
                       The Licensed Work is
                       (c) 2026 Permanu
 
@@ -65,7 +65,7 @@ Additional Use Grant: You may use, copy, modify, create derivative works of,
                         of the Licensed Work as part of a commercial
                         infrastructure or platform product.
 
-Change Date:          2036-04-29
+Change Date:          2036-04-30
 
 Change License:       GNU Affero General Public License v3.0
 

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.3.14"
+version = "0.3.17"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false
@@ -53,6 +53,7 @@ libc = { workspace = true }
 tempfile = { workspace = true }
 subtle = { workspace = true }
 reqwest = { workspace = true }
+rustls = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.3.16"
+version = "0.3.14"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false
@@ -53,7 +53,6 @@ libc = { workspace = true }
 tempfile = { workspace = true }
 subtle = { workspace = true }
 reqwest = { workspace = true }
-rustls = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/crates/dwaar-cli/src/main.rs
+++ b/crates/dwaar-cli/src/main.rs
@@ -1718,12 +1718,40 @@ fn register_background_services(
             Arc::clone(solver),
             Arc::clone(cert_store),
         ));
-        let tls_service = TlsBackgroundService::new(
+        let mut tls_service = TlsBackgroundService::new(
             Arc::clone(&acme_domains),
             "/etc/dwaar/certs",
             issuer,
             Arc::clone(cert_store),
         );
+
+        // Wire DNS-01 provider when the config contains `tls { dns cloudflare }` sites.
+        let dns01_entries = dwaar_config::compile::compile_dns01_domains(config);
+        if !dns01_entries.is_empty() {
+            // Use the first entry's provider/token — in practice all sites in one
+            // Dwaarfile share the same Cloudflare zone. We collect the domain list
+            // for routing inside TlsBackgroundService.
+            let (_, provider_name, api_token) = &dns01_entries[0];
+            if provider_name == "cloudflare" {
+                let cf = Arc::new(dwaar_tls::dns_cloudflare::CloudflareDnsProvider::new(
+                    api_token.clone(),
+                ));
+                let dns_domain_list: Vec<String> =
+                    dns01_entries.iter().map(|(d, _, _)| d.clone()).collect();
+                let dns_domains = Arc::new(ArcSwap::from_pointee(dns_domain_list));
+                tls_service = tls_service.with_dns_provider(cf, dns_domains);
+                info!(
+                    count = dns01_entries.len(),
+                    "DNS-01 Cloudflare provider registered for ACME"
+                );
+            } else {
+                tracing::warn!(
+                    provider = %provider_name,
+                    "unsupported DNS-01 provider — only 'cloudflare' is supported; \
+                     DNS-01 domains will fall back to HTTP-01"
+                );
+            }
+        }
 
         let bg = pingora_core::services::background::background_service(
             "TLS cert & OCSP manager",

--- a/crates/dwaar-cli/src/main.rs
+++ b/crates/dwaar-cli/src/main.rs
@@ -1710,6 +1710,10 @@ fn register_background_services(
         info!("upstream health checker registered");
     }
 
+    // Holds the dns_domains Arc built inside the TLS block so ConfigWatcher
+    // can hot-swap the list when `tls { dns … }` sites change at runtime.
+    let mut dns_domains_for_watcher: Option<Arc<ArcSwap<Vec<String>>>> = None;
+
     // ACME + OCSP background service
     if let Some(solver) = challenge_solver {
         let issuer = Arc::new(CertIssuer::new(
@@ -1732,6 +1736,22 @@ fn register_background_services(
             // Dwaarfile share the same Cloudflare zone. We collect the domain list
             // for routing inside TlsBackgroundService.
             let (_, provider_name, api_token) = &dns01_entries[0];
+
+            // Warn if multiple distinct tokens exist for the same provider — the
+            // second and subsequent tokens are silently ignored.
+            let distinct_tokens = dns01_entries
+                .iter()
+                .filter(|(_, p, _)| p == provider_name)
+                .map(|(_, _, t)| t.as_str())
+                .collect::<std::collections::HashSet<_>>();
+            if distinct_tokens.len() > 1 {
+                tracing::warn!(
+                    provider = %provider_name,
+                    "multiple distinct API tokens for provider {} not supported; \
+                     using token from first entry",
+                    provider_name
+                );
+            }
             if provider_name == "cloudflare" {
                 let cf = Arc::new(dwaar_tls::dns_cloudflare::CloudflareDnsProvider::new(
                     api_token.clone(),
@@ -1739,7 +1759,11 @@ fn register_background_services(
                 let dns_domain_list: Vec<String> =
                     dns01_entries.iter().map(|(d, _, _)| d.clone()).collect();
                 let dns_domains = Arc::new(ArcSwap::from_pointee(dns_domain_list));
-                tls_service = tls_service.with_dns_provider(cf, dns_domains);
+                tls_service = tls_service.with_dns_provider(cf, Arc::clone(&dns_domains));
+                // Hand the same Arc to the ConfigWatcher so hot-reload can
+                // swap the domain list when `tls { dns … }` sites are added or
+                // removed at runtime.
+                dns_domains_for_watcher = Some(dns_domains);
                 info!(
                     count = dns01_entries.len(),
                     "DNS-01 Cloudflare provider registered for ACME"
@@ -1802,6 +1826,11 @@ fn register_background_services(
     .with_acme_domains(acme_domains)
     .with_cert_store(Arc::clone(cert_store))
     .with_l4_servers(l4_servers, l4_reload_notify);
+    let config_watcher = if let Some(dd) = dns_domains_for_watcher {
+        config_watcher.with_dns_domains(dd)
+    } else {
+        config_watcher
+    };
     let config_watcher = if let Some(cb) = cache_backend {
         config_watcher.with_cache_backend(cb)
     } else {

--- a/crates/dwaar-config/src/compile.rs
+++ b/crates/dwaar-config/src/compile.rs
@@ -2212,6 +2212,74 @@ mod tests {
         assert!(domains.is_empty());
     }
 
+    // ── DNS-01 domain extraction ─────────────────────────────
+
+    #[test]
+    fn compile_dns01_domains_extracts_dns_challenge_sites() {
+        let config = DwaarConfig {
+            global_options: None,
+            sites: vec![SiteBlock {
+                address: "*.example.com".to_string(),
+                matchers: vec![],
+                directives: vec![
+                    rp("127.0.0.1:3000"),
+                    Directive::Tls(TlsDirective::DnsChallenge {
+                        provider: "cloudflare".to_string(),
+                        api_token: "tok123".to_string(),
+                    }),
+                ],
+            }],
+        };
+        let entries = compile_dns01_domains(&config);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, "*.example.com");
+        assert_eq!(entries[0].1, "cloudflare");
+        assert_eq!(entries[0].2, "tok123");
+    }
+
+    #[test]
+    fn compile_dns01_domains_mixed_auto_and_dns() {
+        let config = DwaarConfig {
+            global_options: None,
+            sites: vec![
+                SiteBlock {
+                    address: "auto.example.com".to_string(),
+                    matchers: vec![],
+                    directives: vec![rp("127.0.0.1:3000"), Directive::Tls(TlsDirective::Auto)],
+                },
+                SiteBlock {
+                    address: "*.example.com".to_string(),
+                    matchers: vec![],
+                    directives: vec![
+                        rp("127.0.0.1:4000"),
+                        Directive::Tls(TlsDirective::DnsChallenge {
+                            provider: "cloudflare".to_string(),
+                            api_token: "tok456".to_string(),
+                        }),
+                    ],
+                },
+            ],
+        };
+        let entries = compile_dns01_domains(&config);
+        // Only the DnsChallenge site should appear
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, "*.example.com");
+    }
+
+    #[test]
+    fn compile_dns01_domains_empty_when_no_dns_challenge() {
+        let config = DwaarConfig {
+            global_options: None,
+            sites: vec![SiteBlock {
+                address: "plain.example.com".to_string(),
+                matchers: vec![],
+                directives: vec![rp("127.0.0.1:3000")],
+            }],
+        };
+        let entries = compile_dns01_domains(&config);
+        assert!(entries.is_empty());
+    }
+
     // ── Rate limit extraction (ISSUE-031) ───────────────────
 
     #[test]

--- a/crates/dwaar-config/src/compile.rs
+++ b/crates/dwaar-config/src/compile.rs
@@ -710,7 +710,11 @@ pub fn compile_dns01_domains(config: &DwaarConfig) -> Vec<(String, String, Strin
         .iter()
         .filter_map(|site| {
             site.directives.iter().find_map(|d| {
-                if let Directive::Tls(TlsDirective::DnsChallenge { provider, api_token }) = d {
+                if let Directive::Tls(TlsDirective::DnsChallenge {
+                    provider,
+                    api_token,
+                }) = d
+                {
                     Some((
                         site.address.to_lowercase(),
                         provider.clone(),

--- a/crates/dwaar-config/src/compile.rs
+++ b/crates/dwaar-config/src/compile.rs
@@ -697,6 +697,33 @@ pub fn compile_acme_domains(config: &DwaarConfig) -> Vec<String> {
         .collect()
 }
 
+/// Extract `(domain, provider, api_token)` tuples for DNS-01 challenge sites.
+///
+/// Used to build a [`CloudflareDnsProvider`](crate::model::TlsDirective) and
+/// the `dns_domains` list passed to `TlsBackgroundService::with_dns_provider`.
+///
+/// In the common case all DNS-01 sites share the same provider and token
+/// (e.g. one Cloudflare zone). The caller deduplicates as needed.
+pub fn compile_dns01_domains(config: &DwaarConfig) -> Vec<(String, String, String)> {
+    config
+        .sites
+        .iter()
+        .filter_map(|site| {
+            site.directives.iter().find_map(|d| {
+                if let Directive::Tls(TlsDirective::DnsChallenge { provider, api_token }) = d {
+                    Some((
+                        site.address.to_lowercase(),
+                        provider.clone(),
+                        api_token.clone(),
+                    ))
+                } else {
+                    None
+                }
+            })
+        })
+        .collect()
+}
+
 /// The fallback HTTP listen address when no `bind` directive is present.
 const DEFAULT_HTTP_BIND: &str = "0.0.0.0:6188";
 

--- a/crates/dwaar-config/src/watcher.rs
+++ b/crates/dwaar-config/src/watcher.rs
@@ -31,8 +31,8 @@ use dwaar_tls::cert_store::CertStore;
 
 use crate::MAX_CONFIG_SIZE;
 use crate::compile::{
-    collect_pools, compile_acme_domains, compile_l4_servers, compile_l4_wrappers, compile_routes,
-    compile_tls_configs,
+    collect_pools, compile_acme_domains, compile_dns01_domains, compile_l4_servers,
+    compile_l4_wrappers, compile_routes, compile_tls_configs,
 };
 use crate::parser;
 
@@ -78,6 +78,13 @@ pub struct ConfigWatcher {
     /// Shared ACME domain list. Swapped on reload so `TlsBackgroundService`
     /// picks up new/removed `tls auto` domains without a restart.
     acme_domains: Option<Arc<ArcSwap<Vec<String>>>>,
+    /// Shared DNS-01 domain list. Swapped on reload so `TlsBackgroundService`
+    /// uses the correct challenge type for newly added/removed `tls { dns … }`
+    /// sites without a restart.
+    ///
+    /// Note: only the domain list is hot-swapped; provider/token changes still
+    /// require a process restart (the provider is wired once at startup).
+    dns_domains: Option<Arc<ArcSwap<Vec<String>>>>,
     /// Shared cache backend (ISSUE-111). On reload, if the max cache size
     /// changed, a new backend is leaked and swapped in.
     cache_backend: Option<dwaar_core::cache::SharedCacheBackend>,
@@ -133,6 +140,7 @@ impl ConfigWatcher {
             sni_domain_map: None,
             health_pools: None,
             acme_domains: None,
+            dns_domains: None,
             cache_backend: None,
             cert_store: None,
             l4_servers: None,
@@ -182,6 +190,17 @@ impl ConfigWatcher {
     #[must_use]
     pub fn with_acme_domains(mut self, domains: Arc<ArcSwap<Vec<String>>>) -> Self {
         self.acme_domains = Some(domains);
+        self
+    }
+
+    /// Attach the shared DNS-01 domain list so hot-reload swaps in the
+    /// correct set of domains that must use DNS-01.
+    ///
+    /// Only the domain list is hot-swapped; provider/token changes still
+    /// require a process restart (the provider is constructed once at startup).
+    #[must_use]
+    pub fn with_dns_domains(mut self, domains: Arc<ArcSwap<Vec<String>>>) -> Self {
+        self.dns_domains = Some(domains);
         self
     }
 
@@ -389,6 +408,16 @@ impl ConfigWatcher {
             let domains = compile_acme_domains(&config);
             ad.store(Arc::new(domains));
             debug!("ACME domain list refreshed");
+        }
+
+        // Refresh DNS-01 domain list from the new config so that newly added
+        // `tls { dns … }` sites use DNS-01 without a restart.  Only the domain
+        // list is swapped here; provider/token changes require a restart.
+        if let Some(ref dd) = self.dns_domains {
+            let dns_entries = compile_dns01_domains(&config);
+            let dns_domain_list: Vec<String> = dns_entries.into_iter().map(|(d, _, _)| d).collect();
+            dd.store(Arc::new(dns_domain_list));
+            debug!("DNS-01 domain list refreshed");
         }
 
         refresh_cache_backend(self.cache_backend.as_ref(), &new_table);

--- a/crates/dwaar-tls/src/acme/error.rs
+++ b/crates/dwaar-tls/src/acme/error.rs
@@ -47,4 +47,10 @@ pub enum AcmeError {
 
     #[error("TLS-ALPN-01 challenge cert generation failed for {domain}: {reason}")]
     AlpnCertGeneration { domain: String, reason: String },
+
+    #[error(
+        "DNS-01 required for '{domain}' but no DNS provider is configured — \
+         add `tls {{ dns cloudflare {{env.CLOUDFLARE_API_TOKEN}} }}` to the site block"
+    )]
+    NoDnsProvider { domain: String },
 }

--- a/crates/dwaar-tls/src/acme/service.rs
+++ b/crates/dwaar-tls/src/acme/service.rs
@@ -481,6 +481,32 @@ mod tests {
         assert!(!svc.needs_issuance("valid.example.com").await);
     }
 
+    // ── needs_dns01 ──────────────────────────────────────────
+
+    #[test]
+    fn needs_dns01_wildcard_returns_true() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let svc = make_service(vec!["*.example.com".into()], dir.path());
+        assert!(svc.needs_dns01("*.example.com"));
+    }
+
+    #[test]
+    fn needs_dns01_explicit_dns_domain_returns_true() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut svc = make_service(vec![], dir.path());
+        svc.dns_domains = Arc::new(ArcSwap::from_pointee(vec!["api.example.com".into()]));
+        assert!(svc.needs_dns01("api.example.com"));
+    }
+
+    #[test]
+    fn needs_dns01_unregistered_non_wildcard_returns_false() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let svc = make_service(vec!["www.example.com".into()], dir.path());
+        // www.example.com is in `domains` (acme list) but not in dns_domains
+        // and is not a wildcard, so needs_dns01 must return false.
+        assert!(!svc.needs_dns01("www.example.com"));
+    }
+
     #[test]
     fn revoked_cert_paths_match_issuer_convention() {
         let (cert, key) = revoked_cert_paths("/tmp/certs", "example.com");

--- a/crates/dwaar-tls/src/acme/service.rs
+++ b/crates/dwaar-tls/src/acme/service.rs
@@ -6,9 +6,13 @@
 
 //! Pingora background service for TLS certificate management.
 //!
-//! On startup, checks all `tls auto` domains for missing or expiring certs
-//! and fetches OCSP responses. Then runs a 12-hour loop to refresh OCSP
-//! staples and renew certs within 30 days of expiry.
+//! On startup, checks all `tls auto` / `tls { dns cloudflare }` domains for
+//! missing or expiring certs and fetches OCSP responses. Then runs a 12-hour
+//! loop to refresh OCSP staples and renew certs within 30 days of expiry.
+//!
+//! DNS-01 challenge domains are issued via the attached [`DnsProvider`] (e.g.
+//! Cloudflare). Non-wildcard `tls auto` domains prefer TLS-ALPN-01 and fall
+//! back to HTTP-01.
 
 use std::collections::HashSet;
 use std::path::Path;
@@ -27,17 +31,26 @@ use super::{
     AcmeError, GTS_DIRECTORY_URL, INTER_DOMAIN_DELAY, RENEWAL_WINDOW_DAYS, le_directory_url,
 };
 use crate::cert_store::CertStore;
+use crate::dns::DnsProvider;
 
 /// Background service that provisions/renews ACME certificates and refreshes
 /// OCSP staples.
 ///
 /// The domain list is behind `ArcSwap` so that `ConfigWatcher` can swap in a
 /// new set of domains on hot-reload without restarting this service.
+///
+/// When a [`DnsProvider`] is supplied (e.g. Cloudflare), wildcard domains and
+/// any domain listed as a DNS-01 challenge site are issued via DNS-01 rather
+/// than HTTP-01 / TLS-ALPN-01.
 pub struct TlsBackgroundService {
     domains: Arc<ArcSwap<Vec<String>>>,
+    /// Domains that must use DNS-01 (typically wildcard or `tls { dns … }` sites).
+    dns_domains: Arc<ArcSwap<Vec<String>>>,
     cert_dir: String,
     issuer: Arc<CertIssuer>,
     cert_store: Arc<CertStore>,
+    /// Optional DNS provider for DNS-01 challenges (e.g. Cloudflare).
+    dns_provider: Option<Arc<dyn DnsProvider>>,
     in_flight: tokio::sync::Mutex<HashSet<String>>,
 }
 
@@ -45,6 +58,10 @@ impl std::fmt::Debug for TlsBackgroundService {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TlsBackgroundService")
             .field("cert_dir", &self.cert_dir)
+            .field(
+                "dns_provider",
+                &self.dns_provider.as_ref().map(|p| p.name()),
+            )
             .finish_non_exhaustive()
     }
 }
@@ -58,11 +75,29 @@ impl TlsBackgroundService {
     ) -> Self {
         Self {
             domains,
+            dns_domains: Arc::new(ArcSwap::from_pointee(Vec::new())),
             cert_dir: cert_dir.to_string(),
             issuer,
             cert_store,
+            dns_provider: None,
             in_flight: tokio::sync::Mutex::new(HashSet::new()),
         }
+    }
+
+    /// Attach a DNS provider for DNS-01 challenge issuance.
+    ///
+    /// Call this before the service starts (before `server.add_service`).
+    /// `dns_domains` lists the domains that must use DNS-01 — typically
+    /// wildcard domains or any site configured with `tls { dns cloudflare }`.
+    #[must_use]
+    pub fn with_dns_provider(
+        mut self,
+        provider: Arc<dyn DnsProvider>,
+        dns_domains: Arc<ArcSwap<Vec<String>>>,
+    ) -> Self {
+        self.dns_provider = Some(provider);
+        self.dns_domains = dns_domains;
+        self
     }
 
     /// Check if a domain's cert is missing or expiring within the renewal window.
@@ -116,23 +151,61 @@ impl TlsBackgroundService {
         result
     }
 
+    /// Returns `true` if `domain` must use DNS-01 (it's in the `dns_domains`
+    /// list or is a wildcard like `*.example.com`).
+    fn needs_dns01(&self, domain: &str) -> bool {
+        if domain.starts_with("*.") {
+            return true;
+        }
+        self.dns_domains.load().iter().any(|d| d == domain)
+    }
+
     async fn try_issue(&self, domain: &str) -> Result<(), AcmeError> {
         let le_url = le_directory_url();
 
-        // For non-wildcard domains, prefer TLS-ALPN-01 (needs only port 443)
-        // over HTTP-01 (needs port 80). Fall back to HTTP-01 if ALPN fails.
-        let is_wildcard = domain.starts_with("*.");
+        // DNS-01 path — used for wildcard domains and sites configured with
+        // `tls { dns cloudflare <token> }`. Requires a DNS provider.
+        if self.needs_dns01(domain) {
+            let Some(ref provider) = self.dns_provider else {
+                return Err(AcmeError::NoDnsProvider {
+                    domain: domain.to_string(),
+                });
+            };
 
-        if !is_wildcard {
-            match self.issuer.issue_tls_alpn01(domain, le_url, "le").await {
-                Ok(()) => return Ok(()),
-                Err(e) => {
-                    debug!(
+            return match self
+                .issuer
+                .issue_dns01(domain, le_url, "le", provider.as_ref())
+                .await
+            {
+                Ok(()) => Ok(()),
+                Err(le_err) => {
+                    warn!(
                         domain,
-                        error = %e,
-                        "TLS-ALPN-01 failed, falling back to HTTP-01"
+                        error = %le_err,
+                        "Let's Encrypt DNS-01 failed, trying Google Trust Services"
                     );
+                    self.issuer
+                        .issue_dns01(domain, GTS_DIRECTORY_URL, "gts", provider.as_ref())
+                        .await
+                        .map_err(|gts_err| AcmeError::AllCasFailed {
+                            domain: domain.to_string(),
+                            le_error: le_err.to_string(),
+                            gts_error: gts_err.to_string(),
+                        })
                 }
+            };
+        }
+
+        // Non-wildcard path: prefer TLS-ALPN-01 (needs only port 443),
+        // fall back to HTTP-01, then GTS.
+        match self.issuer.issue_tls_alpn01(domain, le_url, "le").await {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                debug!(
+                    domain,
+                    error = %e,
+                    "TLS-ALPN-01 failed, falling back to HTTP-01"
+                );
             }
         }
 
@@ -379,6 +452,7 @@ mod tests {
             solver,
             Arc::clone(&cert_store),
         ));
+        // No DNS provider in unit tests — DNS-01 requires a live API.
         TlsBackgroundService::new(
             Arc::new(ArcSwap::from_pointee(domains)),
             cert_dir.to_str().expect("utf8"),


### PR DESCRIPTION
## Summary

- **Gap closed**: Dwaar had no DNS-01 challenge path, so wildcard certs (`*.example.com`) and any site using `tls { dns cloudflare }` could not issue — they require DNS-01 because no HTTP-01/TLS-ALPN-01 listener is exposed for them.
- **How it's wired**: `TlsBackgroundService` gains an optional `DnsProvider` (set via `with_dns_provider()` builder). At startup, `dwaar-cli` constructs a `CloudflareDnsProvider` from the config and wires it in. `compile_dns01_domains()` enumerates all `tls { dns ... }` sites; `compile_acme_domains()` now includes those sites too so they participate in the renewal loop.
- **Fallback chain preserved**: Non-DNS domains continue to use TLS-ALPN-01 → HTTP-01 → GTS as before. DNS-01 only activates for wildcard domains or domains explicitly configured with `tls { dns ... }`.

## Fallback chain

| Domain type | Challenge path |
|-------------|---------------|
| Wildcard (`*.example.com`) | DNS-01 (LE → GTS fallback) |
| `tls { dns cloudflare }` | DNS-01 (LE → GTS fallback) |
| All others | TLS-ALPN-01 → HTTP-01 → GTS |

## Version bump

`dwaar-cli`: `0.3.13` → `0.3.14`. The installer uses this version to determine whether a new release is available.

## Test plan

- [ ] `cargo build --workspace` passes (verified locally)
- [ ] `cargo clippy --workspace -- -D warnings` passes (verified locally — 3 lint fixes applied)
- [ ] CI checks green
- [ ] Wildcard cert issuance smoke-tested against Cloudflare DNS on staging after merge