### PR TITLE
fix(install): support sigstore .bundle (transition) + legacy .sig/.cert fallback + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.19] - 2026-05-02
+
+### Fixed
+
+- **`scripts/install.sh` sigstore bundle support** — the public installer
+  served from `dwaar.dev/install.sh` now downloads the single
+  `${ARTIFACT}.bundle` cosign artefact and verifies with
+  `cosign verify-blob --bundle …`. Earlier releases shipped split
+  `.sig` + `.cert` files; that path is preserved as a fallback for
+  re-installs of historical versions, but new releases verify via the
+  bundle. Previously the installer hard-coded a `curl` of the legacy
+  `.sig` / `.cert` filenames, both of which 404 on bundle-only releases
+  and aborted the script under `set -eu` — silently degrading callers
+  (e.g. Permanu's agent installer) that swallowed the failure as
+  non-fatal. The installer now also probes for the artefacts before
+  downloading and exits with an actionable error if neither shape is
+  present, instead of attempting an unverifiable install.
+
 ## [0.3.18] - 2026-05-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,7 +1313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dwaar-admin"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1339,7 +1339,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-analytics"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "base64",
  "brotli 8.0.2",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-cli"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-config"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1442,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-core"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-docker"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-geo"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "arc-swap",
  "criterion",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-grpc"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-ingress"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "anyhow",
  "clap",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-log"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-plugins"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-tls"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.3.18
+Licensed Work:        Dwaar 0.3.19
                       The Licensed Work is
                       (c) 2026 Permanu
 
@@ -65,7 +65,7 @@ Additional Use Grant: You may use, copy, modify, create derivative works of,
                         of the Licensed Work as part of a commercial
                         infrastructure or platform product.
 
-Change Date:          2036-05-01
+Change Date:          2036-05-02
 
 Change License:       GNU Affero General Public License v3.0
 

--- a/crates/dwaar-admin/Cargo.toml
+++ b/crates/dwaar-admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-admin"
-version = "0.3.18"
+version = "0.3.19"
 description = "Admin API service — route management, health, metrics, config"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-analytics/Cargo.toml
+++ b/crates/dwaar-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-analytics"
-version = "0.3.18"
+version = "0.3.19"
 description = "First-party analytics — JS injection, beacon collection, in-memory aggregation"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.3.18"
+version = "0.3.19"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-config/Cargo.toml
+++ b/crates/dwaar-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-config"
-version = "0.3.18"
+version = "0.3.19"
 description = "Dwaarfile parser, configuration validation, and hot-reload"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-core/Cargo.toml
+++ b/crates/dwaar-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-core"
-version = "0.3.18"
+version = "0.3.19"
 description = "Core proxy engine — ProxyHttp implementation, route table, request context"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-docker/Cargo.toml
+++ b/crates/dwaar-docker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-docker"
-version = "0.3.18"
+version = "0.3.19"
 description = "Docker socket watcher — auto-discover containers via labels"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-geo/Cargo.toml
+++ b/crates/dwaar-geo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-geo"
-version = "0.3.18"
+version = "0.3.19"
 description = "GeoIP lookup — IP to country/city via MaxMind GeoLite2"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-grpc/Cargo.toml
+++ b/crates/dwaar-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-grpc"
-version = "0.3.18"
+version = "0.3.19"
 description = "Bidirectional gRPC control fabric — DwaarControl service (Permanu ↔ Dwaar)"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-ingress/Cargo.toml
+++ b/crates/dwaar-ingress/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-ingress"
-version = "0.3.18"
+version = "0.3.19"
 description = "Kubernetes ingress controller — watches Ingress resources and syncs routes to Dwaar"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-log/Cargo.toml
+++ b/crates/dwaar-log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-log"
-version = "0.3.18"
+version = "0.3.19"
 description = "Request logging — structured log types, batch writer, output destinations"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-plugins/Cargo.toml
+++ b/crates/dwaar-plugins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-plugins"
-version = "0.3.18"
+version = "0.3.19"
 description = "Plugin trait, plugin chain, built-in plugins (bot detection, rate limiting, compression, security headers)"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-tls/Cargo.toml
+++ b/crates/dwaar-tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-tls"
-version = "0.3.18"
+version = "0.3.19"
 description = "TLS termination, ACME client (Let's Encrypt + Google Trust Services), certificate management"
 edition.workspace = true
 publish = false

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -129,6 +129,22 @@ download() {
 }
 
 # ---------------------------------------------------------------------------
+# HEAD-style existence check — returns 0 if URL responds 2xx, 1 otherwise.
+# Used to probe optional release assets (e.g. .bundle vs legacy .sig/.cert)
+# without aborting the script under `set -e`.
+# ---------------------------------------------------------------------------
+http_exists() {
+    URL="$1"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSLI -o /dev/null "${URL}" >/dev/null 2>&1
+    elif command -v wget >/dev/null 2>&1; then
+        wget -q --spider "${URL}" >/dev/null 2>&1
+    else
+        die "Neither curl nor wget is available. Please install one and retry."
+    fi
+}
+
+# ---------------------------------------------------------------------------
 # SHA256 verification
 # ---------------------------------------------------------------------------
 verify_sha256() {
@@ -433,6 +449,8 @@ main() {
     BINARY_TMP="${TMPDIR_DWAAR}/${ARTIFACT}"
     SHA256_TMP="${TMPDIR_DWAAR}/${ARTIFACT}.sha256"
 
+    BUNDLE_URL="${BINARY_URL}.bundle"
+    BUNDLE_TMP="${TMPDIR_DWAAR}/${ARTIFACT}.bundle"
     SIG_URL="${BINARY_URL}.sig"
     CERT_URL="${BINARY_URL}.cert"
     SIG_TMP="${TMPDIR_DWAAR}/${ARTIFACT}.sig"
@@ -449,35 +467,66 @@ main() {
     success "SHA256 checksum verified."
 
     # 5a. Cosign signature verification (keyless OIDC).
-    # The .sig and .cert files are published alongside every release binary.
-    # If cosign is installed, we verify the cryptographic signature — the cert
-    # chains to Fulcio with the GitHub Actions OIDC issuer and pins the exact
-    # workflow path that produced this binary.  This is a stronger guarantee
-    # than sha256 alone (sha256 only proves download integrity; cosign proves
-    # build provenance).
     #
-    # If cosign is NOT installed we fall back to sha256-only and print a loud
-    # warning — we never silently bypass signature verification.
+    # As of v0.3.18 every release ships a single sigstore bundle
+    # (`${ARTIFACT}.bundle`) that embeds both the signature and the Fulcio
+    # certificate. Older releases shipped split `.sig` + `.cert` files; we
+    # keep that path as a fallback so re-installs of historical versions
+    # still verify cleanly.
+    #
+    # Verification chains to Fulcio with the GitHub Actions OIDC issuer and
+    # pins the exact workflow path that produced this binary — a stronger
+    # guarantee than sha256 alone (sha256 proves download integrity; cosign
+    # proves build provenance).
+    #
+    # If cosign is NOT installed we fall back to sha256-only and print a
+    # loud warning — we never silently bypass signature verification.
     info "Verifying cosign signature..."
-    download "${SIG_URL}"  "${SIG_TMP}"
-    download "${CERT_URL}" "${CERT_TMP}"
+    SIG_MODE=""
+    if http_exists "${BUNDLE_URL}"; then
+        download "${BUNDLE_URL}" "${BUNDLE_TMP}"
+        SIG_MODE="bundle"
+    elif http_exists "${SIG_URL}" && http_exists "${CERT_URL}"; then
+        download "${SIG_URL}"  "${SIG_TMP}"
+        download "${CERT_URL}" "${CERT_TMP}"
+        SIG_MODE="legacy"
+    else
+        die "No signature artefacts found for ${ARTIFACT}. Looked for:
+  ${BUNDLE_URL}
+  ${SIG_URL} + ${CERT_URL}
+Refusing to install an unverifiable binary."
+    fi
+
     if command -v cosign >/dev/null 2>&1; then
-        cosign verify-blob \
-            --certificate "${CERT_TMP}" \
-            --signature "${SIG_TMP}" \
-            --certificate-identity-regexp "^https://github\.com/permanu/Dwaar/\.github/workflows/release\.yml@.*" \
-            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-            "${BINARY_TMP}"
-        success "Cosign signature verified."
+        if [ "${SIG_MODE}" = "bundle" ]; then
+            cosign verify-blob \
+                --bundle "${BUNDLE_TMP}" \
+                --certificate-identity-regexp "^https://github\.com/permanu/Dwaar/\.github/workflows/release\.yml@.*" \
+                --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+                "${BINARY_TMP}"
+        else
+            cosign verify-blob \
+                --certificate "${CERT_TMP}" \
+                --signature "${SIG_TMP}" \
+                --certificate-identity-regexp "^https://github\.com/permanu/Dwaar/\.github/workflows/release\.yml@.*" \
+                --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+                "${BINARY_TMP}"
+        fi
+        success "Cosign signature verified (${SIG_MODE})."
     else
         printf "%bWarning: cosign not installed, skipping signature verification (sha256 still checked).%b\n" \
             "${YELLOW}" "${RESET}" >&2
         printf "%b         Install cosign from https://github.com/sigstore/cosign/releases%b\n" \
             "${YELLOW}" "${RESET}" >&2
         printf "%b         then verify manually:%b\n" "${YELLOW}" "${RESET}" >&2
-        printf "%b         cosign verify-blob \\%b\n" "${YELLOW}" "${RESET}" >&2
-        printf "%b           --certificate %s.cert \\%b\n" "${YELLOW}" "${ARTIFACT}" "${RESET}" >&2
-        printf "%b           --signature %s.sig \\%b\n" "${YELLOW}" "${ARTIFACT}" "${RESET}" >&2
+        if [ "${SIG_MODE}" = "bundle" ]; then
+            printf "%b         cosign verify-blob \\%b\n" "${YELLOW}" "${RESET}" >&2
+            printf "%b           --bundle %s.bundle \\%b\n" "${YELLOW}" "${ARTIFACT}" "${RESET}" >&2
+        else
+            printf "%b         cosign verify-blob \\%b\n" "${YELLOW}" "${RESET}" >&2
+            printf "%b           --certificate %s.cert \\%b\n" "${YELLOW}" "${ARTIFACT}" "${RESET}" >&2
+            printf "%b           --signature %s.sig \\%b\n" "${YELLOW}" "${ARTIFACT}" "${RESET}" >&2
+        fi
         printf '%b           --certificate-identity-regexp "^https://github\\.com/permanu/Dwaar/\\.github/workflows/release\\.yml@.*" \\%b\n' \
             "${YELLOW}" "${RESET}" >&2
         printf '%b           --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \\%b\n' \


### PR DESCRIPTION
## Summary

`scripts/install.sh` (served from `dwaar.dev/install.sh`) hard-coded
two `curl` calls for `${ARTIFACT}.sig` and `${ARTIFACT}.cert`, but
recent releases (v0.3.18+) publish a single sigstore bundle
(`${ARTIFACT}.bundle`) instead. Both legacy paths 404; under `set -eu`
the failed curl aborts the script. Downstream callers (notably
Permanu's agent installer) catch the abort with a `|| { echo Warning... }`
and silently continue without the reverse proxy.

This PR:

- Probes `${ARTIFACT}.bundle` first with a HEAD-style helper
  (`http_exists`) that does not trip `set -e`, then verifies with
  `cosign verify-blob --bundle`.
- Falls back to legacy `${ARTIFACT}.sig` + `${ARTIFACT}.cert` when both
  exist (so re-installs of historical pre-bundle releases continue to
  verify).
- Hard-fails with an actionable error citing every URL it tried when no
  signature artefact is reachable, rather than installing an
  unverifiable binary.
- Bumps the patch version 0.3.18 → 0.3.19 across all crate
  `Cargo.toml` files, `Cargo.lock`, `LICENSE`, and `CHANGELOG.md` so
  the installer auto-update path picks up the fix (and version-guard
  CI passes).

## Background — Permanu-side install transcript (F3)

Operator ran the standard install one-liner on a fresh Hetzner VPS
(`159.69.251.149`, Debian, amd64):

```
==> Installing Dwaar reverse proxy...
Installing dwaar v0.3.18 (linux/amd64)
######################################################################## 100.0%
curl: (22) The requested URL returned error: 404
Warning: Dwaar install failed (non-fatal). Proxy features will be unavailable.
```

The 100% bar is the binary itself downloading successfully; the 404
comes from the *next* curl in the same script (the `.sig` / `.cert`
download). HEAD probes against the v0.3.18 release confirmed:

| URL                                  | Status |
| ------------------------------------ | ------ |
| `dwaar-linux-amd64`                  | 302→200 |
| `dwaar-linux-amd64.sha256`           | 302→200 |
| `dwaar-linux-amd64.bundle`           | 302→200 |
| `dwaar-linux-amd64.sig`              | **404** |
| `dwaar-linux-amd64.cert`             | **404** |

Full finding: `permanu/Permanu` repo at
`docs/verification/cycles/cycle-1/preflight-dwaar-release-404.md`.

## Version bump

Per `feedback_dwaar_version_bump.md`: every Dwaar PR merge bumps the
patch version so the installer / agent auto-update path sees the
release. 0.3.18 → 0.3.19 applied across the workspace (12 crates),
LICENSE Licensed Work line (via `scripts/bump-license-date.sh
0.3.19`), and CHANGELOG. `scripts/check-version-consistency.sh`
passes locally.

## Test plan

- [ ] `scripts/check-version-consistency.sh` green in CI (version-guard.yml)
- [ ] `sh -n scripts/install.sh` syntax check
- [ ] Manual smoke after merge + tag: `curl -fsSL https://dwaar.dev/install.sh | sh` on a fresh VPS — expect `Cosign signature verified (bundle).`
- [ ] Re-installing a historical pre-bundle release (e.g. v0.2.x) still verifies via the legacy `.sig` + `.cert` path
- [ ] Permanu agent installer no longer prints the "Dwaar install failed (non-fatal)" warning