### PR TITLE
ci: define Permanu release lanes

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,9 +1,8 @@
 name: Security Audit
 
+# Automated dependency audit should run through Permanu CI when enabled for this
+# repo. GitHub Actions stays manual-only to avoid background runner charges.
 on:
-  schedule:
-    # Run daily at 06:00 UTC to catch new advisories
-    - cron: '0 6 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+# Automated PR/main CI is owned by Permanu CI in .permanu/workflows/permanu.yml.
+# This workflow is an explicit manual fallback only, so hosted Actions minutes
+# are not consumed for normal repository activity.
 on:
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: Release
 
+# Automated release builds and GitHub Release uploads are owned by Permanu CI in
+# .permanu/workflows/permanu.yml so GitHub Actions minutes are not consumed.
+# Keep this workflow as an explicit emergency/manual fallback only.
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,10 +1,8 @@
 name: Documentation Site
 
+# Site deploys are explicit/manual from GitHub Actions. Automated CI/release
+# behavior lives in .permanu/workflows/permanu.yml to avoid Actions spend.
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'site/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,9 @@
 name: Stale Issues
 
+# GitHub Actions is manual-only for Dwaar so repository automation does not
+# consume hosted Actions minutes in the background.
 on:
-  schedule:
-    - cron: '0 0 * * 1'  # Every Monday at midnight
+  workflow_dispatch:
 
 permissions:
   issues: write

--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -10,14 +10,10 @@ name: Version Guard
 # recur — a PR that bumps Cargo.toml without matching LICENSE + CHANGELOG
 # fails CI before it can land on main.
 
+# Automated PR/main/tag checks are owned by Permanu CI in
+# .permanu/workflows/permanu.yml so GitHub Actions minutes are not consumed.
+# Keep this workflow as an explicit emergency/manual fallback only.
 on:
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review]
-  push:
-    branches: [main]
-    tags:
-      - 'v*'
   workflow_dispatch:
 
 permissions:

--- a/.permanu/workflows/permanu.yml
+++ b/.permanu/workflows/permanu.yml
@@ -55,12 +55,22 @@ jobs:
       - name: Setup Rust
         shell: sh
         run: |
-          export HOME="$PWD/.permanu-home"
-          export CARGO_HOME="$PWD/.permanu-cargo"
-          export RUSTUP_HOME="$PWD/.permanu-rustup"
+          : "${CARGO_HOME:=$PWD/.permanu-cargo}"
+          : "${RUSTUP_HOME:=$PWD/.permanu-rustup}"
+          : "${RUNNER_TOOL_CACHE:=$PWD/.permanu-tool-cache}"
+          export CARGO_HOME RUSTUP_HOME RUNNER_TOOL_CACHE RUSTUP_INIT_SKIP_PATH_CHECK=1
           export PATH="$CARGO_HOME/bin:$PATH"
-          mkdir -p "$HOME" "$CARGO_HOME" "$RUSTUP_HOME"
-          lock=/tmp/permanu-rustup.lock
+          mkdir -p "$CARGO_HOME" "$RUSTUP_HOME" "$RUNNER_TOOL_CACHE"
+          run_bounded() {
+            seconds="$1"
+            shift
+            if command -v timeout >/dev/null 2>&1; then
+              timeout "$seconds" "$@"
+            else
+              "$@"
+            fi
+          }
+          lock="$RUNNER_TOOL_CACHE/permanu-rustup.lock"
           waited=0
           while ! mkdir "$lock" 2>/dev/null; do
             if find "$lock" -maxdepth 0 -mmin +10 >/dev/null 2>&1; then
@@ -80,13 +90,14 @@ jobs:
             DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential cmake pkg-config protobuf-compiler
           fi
           if ! command -v cargo >/dev/null 2>&1; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --no-modify-path
           fi
           if [ -f "$CARGO_HOME/env" ]; then
             . "$CARGO_HOME/env"
           fi
           if command -v rustup >/dev/null 2>&1; then
-            rustup component add rustfmt clippy
+            run_bounded 900 rustup toolchain install stable --profile minimal --component rustfmt --component clippy
+            run_bounded 300 rustup default stable
           fi
           printf '%s\n' "$CARGO_HOME/bin" >> "$GITHUB_PATH"
 
@@ -108,12 +119,22 @@ jobs:
       - name: Setup Rust
         shell: sh
         run: |
-          export HOME="$PWD/.permanu-home"
-          export CARGO_HOME="$PWD/.permanu-cargo"
-          export RUSTUP_HOME="$PWD/.permanu-rustup"
+          : "${CARGO_HOME:=$PWD/.permanu-cargo}"
+          : "${RUSTUP_HOME:=$PWD/.permanu-rustup}"
+          : "${RUNNER_TOOL_CACHE:=$PWD/.permanu-tool-cache}"
+          export CARGO_HOME RUSTUP_HOME RUNNER_TOOL_CACHE RUSTUP_INIT_SKIP_PATH_CHECK=1
           export PATH="$CARGO_HOME/bin:$PATH"
-          mkdir -p "$HOME" "$CARGO_HOME" "$RUSTUP_HOME"
-          lock=/tmp/permanu-rustup.lock
+          mkdir -p "$CARGO_HOME" "$RUSTUP_HOME" "$RUNNER_TOOL_CACHE"
+          run_bounded() {
+            seconds="$1"
+            shift
+            if command -v timeout >/dev/null 2>&1; then
+              timeout "$seconds" "$@"
+            else
+              "$@"
+            fi
+          }
+          lock="$RUNNER_TOOL_CACHE/permanu-rustup.lock"
           waited=0
           while ! mkdir "$lock" 2>/dev/null; do
             if find "$lock" -maxdepth 0 -mmin +10 >/dev/null 2>&1; then
@@ -133,10 +154,14 @@ jobs:
             DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential cmake pkg-config protobuf-compiler
           fi
           if ! command -v cargo >/dev/null 2>&1; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --no-modify-path
           fi
           if [ -f "$CARGO_HOME/env" ]; then
             . "$CARGO_HOME/env"
+          fi
+          if command -v rustup >/dev/null 2>&1; then
+            run_bounded 900 rustup toolchain install stable --profile minimal
+            run_bounded 300 rustup default stable
           fi
           printf '%s\n' "$CARGO_HOME/bin" >> "$GITHUB_PATH"
 
@@ -164,12 +189,22 @@ jobs:
       - name: Setup Rust audit tooling
         shell: sh
         run: |
-          export HOME="$PWD/.permanu-home"
-          export CARGO_HOME="$PWD/.permanu-cargo"
-          export RUSTUP_HOME="$PWD/.permanu-rustup"
+          : "${CARGO_HOME:=$PWD/.permanu-cargo}"
+          : "${RUSTUP_HOME:=$PWD/.permanu-rustup}"
+          : "${RUNNER_TOOL_CACHE:=$PWD/.permanu-tool-cache}"
+          export CARGO_HOME RUSTUP_HOME RUNNER_TOOL_CACHE RUSTUP_INIT_SKIP_PATH_CHECK=1
           export PATH="$CARGO_HOME/bin:$PATH"
-          mkdir -p "$HOME" "$CARGO_HOME" "$RUSTUP_HOME"
-          lock=/tmp/permanu-rustup.lock
+          mkdir -p "$CARGO_HOME" "$RUSTUP_HOME" "$RUNNER_TOOL_CACHE"
+          run_bounded() {
+            seconds="$1"
+            shift
+            if command -v timeout >/dev/null 2>&1; then
+              timeout "$seconds" "$@"
+            else
+              "$@"
+            fi
+          }
+          lock="$RUNNER_TOOL_CACHE/permanu-rustup.lock"
           waited=0
           while ! mkdir "$lock" 2>/dev/null; do
             if find "$lock" -maxdepth 0 -mmin +10 >/dev/null 2>&1; then
@@ -185,13 +220,17 @@ jobs:
           done
           trap 'rm -rf "$lock"' EXIT
           if ! command -v cargo >/dev/null 2>&1; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --no-modify-path
           fi
           if [ -f "$CARGO_HOME/env" ]; then
             . "$CARGO_HOME/env"
           fi
+          if command -v rustup >/dev/null 2>&1; then
+            run_bounded 900 rustup toolchain install stable --profile minimal
+            run_bounded 300 rustup default stable
+          fi
           if ! command -v cargo-audit >/dev/null 2>&1; then
-            cargo install cargo-audit --locked
+            run_bounded 1800 cargo install cargo-audit --locked
           fi
           printf '%s\n' "$CARGO_HOME/bin" >> "$GITHUB_PATH"
 
@@ -220,12 +259,22 @@ jobs:
       - name: Setup Rust
         shell: sh
         run: |
-          export HOME="$PWD/.permanu-home"
-          export CARGO_HOME="$PWD/.permanu-cargo"
-          export RUSTUP_HOME="$PWD/.permanu-rustup"
+          : "${CARGO_HOME:=$PWD/.permanu-cargo}"
+          : "${RUSTUP_HOME:=$PWD/.permanu-rustup}"
+          : "${RUNNER_TOOL_CACHE:=$PWD/.permanu-tool-cache}"
+          export CARGO_HOME RUSTUP_HOME RUNNER_TOOL_CACHE RUSTUP_INIT_SKIP_PATH_CHECK=1
           export PATH="$CARGO_HOME/bin:$PATH"
-          mkdir -p "$HOME" "$CARGO_HOME" "$RUSTUP_HOME"
-          lock=/tmp/permanu-rustup.lock
+          mkdir -p "$CARGO_HOME" "$RUSTUP_HOME" "$RUNNER_TOOL_CACHE"
+          run_bounded() {
+            seconds="$1"
+            shift
+            if command -v timeout >/dev/null 2>&1; then
+              timeout "$seconds" "$@"
+            else
+              "$@"
+            fi
+          }
+          lock="$RUNNER_TOOL_CACHE/permanu-rustup.lock"
           waited=0
           while ! mkdir "$lock" 2>/dev/null; do
             if find "$lock" -maxdepth 0 -mmin +10 >/dev/null 2>&1; then
@@ -245,10 +294,14 @@ jobs:
             DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential cmake pkg-config protobuf-compiler
           fi
           if ! command -v cargo >/dev/null 2>&1; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --no-modify-path
           fi
           if [ -f "$CARGO_HOME/env" ]; then
             . "$CARGO_HOME/env"
+          fi
+          if command -v rustup >/dev/null 2>&1; then
+            run_bounded 900 rustup toolchain install stable --profile minimal
+            run_bounded 300 rustup default stable
           fi
           printf '%s\n' "$CARGO_HOME/bin" >> "$GITHUB_PATH"
 
@@ -278,8 +331,9 @@ jobs:
           PERMANU_SIGSTORE_ID_TOKEN: ${{ secrets.PERMANU_SIGSTORE_ID_TOKEN }}
         run: |
           export HOME="$PWD/.permanu-home"
-          export CARGO_HOME="$PWD/.permanu-cargo"
-          export RUSTUP_HOME="$PWD/.permanu-rustup"
+          : "${CARGO_HOME:=$PWD/.permanu-cargo}"
+          : "${RUSTUP_HOME:=$PWD/.permanu-rustup}"
+          export CARGO_HOME RUSTUP_HOME
           export PATH="$CARGO_HOME/bin:$PATH"
           mkdir -p "$HOME" "$CARGO_HOME" "$RUSTUP_HOME"
           if [ -f "$CARGO_HOME/env" ]; then

--- a/.permanu/workflows/permanu.yml
+++ b/.permanu/workflows/permanu.yml
@@ -154,9 +154,65 @@ jobs:
         shell: sh
         run: cargo test --workspace --exclude dwaar-cli -- --ignored --nocapture
 
+  dependency-audit:
+    name: permanu-ci / dwaar / dependency-audit
+    needs: version-guard
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && (inputs.lane == 'pr' || inputs.lane == 'main' || inputs.lane == 'release' || inputs.lane == 'all')) }}
+    runs-on: self-hosted
+    timeout-minutes: 15
+    steps:
+      - name: Setup Rust audit tooling
+        shell: sh
+        run: |
+          export HOME="$PWD/.permanu-home"
+          export CARGO_HOME="$PWD/.permanu-cargo"
+          export RUSTUP_HOME="$PWD/.permanu-rustup"
+          export PATH="$CARGO_HOME/bin:$PATH"
+          mkdir -p "$HOME" "$CARGO_HOME" "$RUSTUP_HOME"
+          lock=/tmp/permanu-rustup.lock
+          waited=0
+          while ! mkdir "$lock" 2>/dev/null; do
+            if find "$lock" -maxdepth 0 -mmin +10 >/dev/null 2>&1; then
+              rm -rf "$lock"
+              continue
+            fi
+            waited=$((waited + 2))
+            if [ "$waited" -gt 300 ]; then
+              echo "timed out waiting for rustup lock"
+              exit 1
+            fi
+            sleep 2
+          done
+          trap 'rm -rf "$lock"' EXIT
+          if ! command -v cargo >/dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+          fi
+          if [ -f "$CARGO_HOME/env" ]; then
+            . "$CARGO_HOME/env"
+          fi
+          if ! command -v cargo-audit >/dev/null 2>&1; then
+            cargo install cargo-audit --locked
+          fi
+          printf '%s\n' "$CARGO_HOME/bin" >> "$GITHUB_PATH"
+
+      - name: Run dependency audit
+        shell: sh
+        run: >-
+          cargo audit
+          --ignore RUSTSEC-2025-0069
+          --ignore RUSTSEC-2026-0098
+          --ignore RUSTSEC-2026-0099
+          --ignore RUSTSEC-2026-0114
+          --ignore RUSTSEC-2024-0388
+          --ignore RUSTSEC-2024-0384
+          --ignore RUSTSEC-2024-0437
+          --ignore RUSTSEC-2025-0134
+          --ignore RUSTSEC-2025-0012
+          --ignore RUSTSEC-2026-0097
+
   rust-build:
     name: permanu-ci / dwaar / rust-build-release
-    needs: version-guard
+    needs: [version-guard, rust-quality, rust-test, dependency-audit]
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && (inputs.lane == 'main' || inputs.lane == 'release' || inputs.lane == 'all')) }}
     runs-on: self-hosted
     timeout-minutes: 30

--- a/.permanu/workflows/permanu.yml
+++ b/.permanu/workflows/permanu.yml
@@ -72,7 +72,7 @@ jobs:
 
   rust-test:
     name: permanu-ci / dwaar / rust-test
-    needs: version-guard
+    needs: rust-quality
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && (inputs.lane == 'pr' || inputs.lane == 'main' || inputs.lane == 'release' || inputs.lane == 'all')) }}
     runs-on: self-hosted
     timeout-minutes: 45
@@ -103,10 +103,10 @@ jobs:
 
   dependency-audit:
     name: permanu-ci / dwaar / dependency-audit
-    needs: version-guard
+    needs: rust-test
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && (inputs.lane == 'pr' || inputs.lane == 'main' || inputs.lane == 'release' || inputs.lane == 'all')) }}
     runs-on: self-hosted
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Setup Rust audit tooling
         shell: sh
@@ -131,7 +131,7 @@ jobs:
 
   rust-build:
     name: permanu-ci / dwaar / rust-build-release
-    needs: [version-guard, rust-quality, rust-test, dependency-audit]
+    needs: dependency-audit
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && (inputs.lane == 'main' || inputs.lane == 'release' || inputs.lane == 'all')) }}
     runs-on: self-hosted
     timeout-minutes: 30

--- a/.permanu/workflows/permanu.yml
+++ b/.permanu/workflows/permanu.yml
@@ -55,51 +55,12 @@ jobs:
       - name: Setup Rust
         shell: sh
         run: |
-          : "${CARGO_HOME:=$PWD/.permanu-cargo}"
-          : "${RUSTUP_HOME:=$PWD/.permanu-rustup}"
-          : "${RUNNER_TOOL_CACHE:=$PWD/.permanu-tool-cache}"
-          export CARGO_HOME RUSTUP_HOME RUNNER_TOOL_CACHE RUSTUP_INIT_SKIP_PATH_CHECK=1
-          export PATH="$CARGO_HOME/bin:$PATH"
-          mkdir -p "$CARGO_HOME" "$RUSTUP_HOME" "$RUNNER_TOOL_CACHE"
-          run_bounded() {
-            seconds="$1"
-            shift
-            if command -v timeout >/dev/null 2>&1; then
-              timeout "$seconds" "$@"
-            else
-              "$@"
-            fi
-          }
-          lock="$RUNNER_TOOL_CACHE/permanu-rustup.lock"
-          waited=0
-          while ! mkdir "$lock" 2>/dev/null; do
-            if find "$lock" -maxdepth 0 -mmin +10 >/dev/null 2>&1; then
-              rm -rf "$lock"
-              continue
-            fi
-            waited=$((waited + 2))
-            if [ "$waited" -gt 300 ]; then
-              echo "timed out waiting for rustup lock"
-              exit 1
-            fi
-            sleep 2
-          done
-          trap 'rm -rf "$lock"' EXIT
+          chmod +x scripts/permanu-ci-rust-env.sh
+          ./scripts/permanu-ci-rust-env.sh quality
           if ! command -v cmake >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
             apt-get update
             DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential cmake pkg-config protobuf-compiler
           fi
-          if ! command -v cargo >/dev/null 2>&1; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --no-modify-path
-          fi
-          if [ -f "$CARGO_HOME/env" ]; then
-            . "$CARGO_HOME/env"
-          fi
-          if command -v rustup >/dev/null 2>&1; then
-            run_bounded 900 rustup toolchain install stable --profile minimal --component rustfmt --component clippy
-            run_bounded 300 rustup default stable
-          fi
-          printf '%s\n' "$CARGO_HOME/bin" >> "$GITHUB_PATH"
 
       - name: Format
         shell: sh
@@ -119,51 +80,12 @@ jobs:
       - name: Setup Rust
         shell: sh
         run: |
-          : "${CARGO_HOME:=$PWD/.permanu-cargo}"
-          : "${RUSTUP_HOME:=$PWD/.permanu-rustup}"
-          : "${RUNNER_TOOL_CACHE:=$PWD/.permanu-tool-cache}"
-          export CARGO_HOME RUSTUP_HOME RUNNER_TOOL_CACHE RUSTUP_INIT_SKIP_PATH_CHECK=1
-          export PATH="$CARGO_HOME/bin:$PATH"
-          mkdir -p "$CARGO_HOME" "$RUSTUP_HOME" "$RUNNER_TOOL_CACHE"
-          run_bounded() {
-            seconds="$1"
-            shift
-            if command -v timeout >/dev/null 2>&1; then
-              timeout "$seconds" "$@"
-            else
-              "$@"
-            fi
-          }
-          lock="$RUNNER_TOOL_CACHE/permanu-rustup.lock"
-          waited=0
-          while ! mkdir "$lock" 2>/dev/null; do
-            if find "$lock" -maxdepth 0 -mmin +10 >/dev/null 2>&1; then
-              rm -rf "$lock"
-              continue
-            fi
-            waited=$((waited + 2))
-            if [ "$waited" -gt 300 ]; then
-              echo "timed out waiting for rustup lock"
-              exit 1
-            fi
-            sleep 2
-          done
-          trap 'rm -rf "$lock"' EXIT
+          chmod +x scripts/permanu-ci-rust-env.sh
+          ./scripts/permanu-ci-rust-env.sh cargo
           if ! command -v cmake >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
             apt-get update
             DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential cmake pkg-config protobuf-compiler
           fi
-          if ! command -v cargo >/dev/null 2>&1; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --no-modify-path
-          fi
-          if [ -f "$CARGO_HOME/env" ]; then
-            . "$CARGO_HOME/env"
-          fi
-          if command -v rustup >/dev/null 2>&1; then
-            run_bounded 900 rustup toolchain install stable --profile minimal
-            run_bounded 300 rustup default stable
-          fi
-          printf '%s\n' "$CARGO_HOME/bin" >> "$GITHUB_PATH"
 
       - name: Workspace tests
         shell: sh
@@ -189,50 +111,8 @@ jobs:
       - name: Setup Rust audit tooling
         shell: sh
         run: |
-          : "${CARGO_HOME:=$PWD/.permanu-cargo}"
-          : "${RUSTUP_HOME:=$PWD/.permanu-rustup}"
-          : "${RUNNER_TOOL_CACHE:=$PWD/.permanu-tool-cache}"
-          export CARGO_HOME RUSTUP_HOME RUNNER_TOOL_CACHE RUSTUP_INIT_SKIP_PATH_CHECK=1
-          export PATH="$CARGO_HOME/bin:$PATH"
-          mkdir -p "$CARGO_HOME" "$RUSTUP_HOME" "$RUNNER_TOOL_CACHE"
-          run_bounded() {
-            seconds="$1"
-            shift
-            if command -v timeout >/dev/null 2>&1; then
-              timeout "$seconds" "$@"
-            else
-              "$@"
-            fi
-          }
-          lock="$RUNNER_TOOL_CACHE/permanu-rustup.lock"
-          waited=0
-          while ! mkdir "$lock" 2>/dev/null; do
-            if find "$lock" -maxdepth 0 -mmin +10 >/dev/null 2>&1; then
-              rm -rf "$lock"
-              continue
-            fi
-            waited=$((waited + 2))
-            if [ "$waited" -gt 300 ]; then
-              echo "timed out waiting for rustup lock"
-              exit 1
-            fi
-            sleep 2
-          done
-          trap 'rm -rf "$lock"' EXIT
-          if ! command -v cargo >/dev/null 2>&1; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --no-modify-path
-          fi
-          if [ -f "$CARGO_HOME/env" ]; then
-            . "$CARGO_HOME/env"
-          fi
-          if command -v rustup >/dev/null 2>&1; then
-            run_bounded 900 rustup toolchain install stable --profile minimal
-            run_bounded 300 rustup default stable
-          fi
-          if ! command -v cargo-audit >/dev/null 2>&1; then
-            run_bounded 1800 cargo install cargo-audit --locked
-          fi
-          printf '%s\n' "$CARGO_HOME/bin" >> "$GITHUB_PATH"
+          chmod +x scripts/permanu-ci-rust-env.sh
+          ./scripts/permanu-ci-rust-env.sh audit
 
       - name: Run dependency audit
         shell: sh
@@ -259,51 +139,12 @@ jobs:
       - name: Setup Rust
         shell: sh
         run: |
-          : "${CARGO_HOME:=$PWD/.permanu-cargo}"
-          : "${RUSTUP_HOME:=$PWD/.permanu-rustup}"
-          : "${RUNNER_TOOL_CACHE:=$PWD/.permanu-tool-cache}"
-          export CARGO_HOME RUSTUP_HOME RUNNER_TOOL_CACHE RUSTUP_INIT_SKIP_PATH_CHECK=1
-          export PATH="$CARGO_HOME/bin:$PATH"
-          mkdir -p "$CARGO_HOME" "$RUSTUP_HOME" "$RUNNER_TOOL_CACHE"
-          run_bounded() {
-            seconds="$1"
-            shift
-            if command -v timeout >/dev/null 2>&1; then
-              timeout "$seconds" "$@"
-            else
-              "$@"
-            fi
-          }
-          lock="$RUNNER_TOOL_CACHE/permanu-rustup.lock"
-          waited=0
-          while ! mkdir "$lock" 2>/dev/null; do
-            if find "$lock" -maxdepth 0 -mmin +10 >/dev/null 2>&1; then
-              rm -rf "$lock"
-              continue
-            fi
-            waited=$((waited + 2))
-            if [ "$waited" -gt 300 ]; then
-              echo "timed out waiting for rustup lock"
-              exit 1
-            fi
-            sleep 2
-          done
-          trap 'rm -rf "$lock"' EXIT
+          chmod +x scripts/permanu-ci-rust-env.sh
+          ./scripts/permanu-ci-rust-env.sh release
           if ! command -v cmake >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
             apt-get update
             DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential cmake pkg-config protobuf-compiler
           fi
-          if ! command -v cargo >/dev/null 2>&1; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --no-modify-path
-          fi
-          if [ -f "$CARGO_HOME/env" ]; then
-            . "$CARGO_HOME/env"
-          fi
-          if command -v rustup >/dev/null 2>&1; then
-            run_bounded 900 rustup toolchain install stable --profile minimal
-            run_bounded 300 rustup default stable
-          fi
-          printf '%s\n' "$CARGO_HOME/bin" >> "$GITHUB_PATH"
 
       - name: Build workspace
         shell: sh
@@ -330,16 +171,8 @@ jobs:
           SIGSTORE_ID_TOKEN: ${{ secrets.SIGSTORE_ID_TOKEN }}
           PERMANU_SIGSTORE_ID_TOKEN: ${{ secrets.PERMANU_SIGSTORE_ID_TOKEN }}
         run: |
-          export HOME="$PWD/.permanu-home"
-          : "${CARGO_HOME:=$PWD/.permanu-cargo}"
-          : "${RUSTUP_HOME:=$PWD/.permanu-rustup}"
-          export CARGO_HOME RUSTUP_HOME
-          export PATH="$CARGO_HOME/bin:$PATH"
-          mkdir -p "$HOME" "$CARGO_HOME" "$RUSTUP_HOME"
-          if [ -f "$CARGO_HOME/env" ]; then
-            . "$CARGO_HOME/env"
-          fi
-          chmod +x scripts/build-release-assets.sh
+          chmod +x scripts/permanu-ci-rust-env.sh scripts/build-release-assets.sh
+          . ./scripts/permanu-ci-rust-env.sh release
           ./scripts/build-release-assets.sh dist
 
       - name: Verify production release assets

--- a/.permanu/workflows/permanu.yml
+++ b/.permanu/workflows/permanu.yml
@@ -9,14 +9,33 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
+    inputs:
+      lane:
+        description: Explicit CI lane to run manually.
+        required: true
+        type: choice
+        default: pr
+        options:
+          - pr
+          - main
+          - release
+          - all
 
 permissions:
   contents: write
+  checks: write
+  statuses: write
+  pull-requests: read
   id-token: write
+
+concurrency:
+  group: dwaar-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   version-guard:
-    name: Version Guard
+    name: permanu-ci / dwaar / version-guard
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && (inputs.lane == 'pr' || inputs.lane == 'main' || inputs.lane == 'release' || inputs.lane == 'all')) }}
     runs-on: self-hosted
     timeout-minutes: 5
     steps:
@@ -27,17 +46,18 @@ jobs:
           ./scripts/check-version-consistency.sh
 
   rust-quality:
-    name: Rust Quality
+    name: permanu-ci / dwaar / rust-quality
     needs: version-guard
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && (inputs.lane == 'pr' || inputs.lane == 'main' || inputs.lane == 'release' || inputs.lane == 'all')) }}
     runs-on: self-hosted
     timeout-minutes: 30
     steps:
       - name: Setup Rust
         shell: sh
         run: |
-          export HOME="${HOME:-$PWD/.permanu-home}"
-          export CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
-          export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
+          export HOME="$PWD/.permanu-home"
+          export CARGO_HOME="$PWD/.permanu-cargo"
+          export RUSTUP_HOME="$PWD/.permanu-rustup"
           export PATH="$CARGO_HOME/bin:$PATH"
           mkdir -p "$HOME" "$CARGO_HOME" "$RUSTUP_HOME"
           lock=/tmp/permanu-rustup.lock
@@ -79,17 +99,18 @@ jobs:
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   rust-test:
-    name: Rust Test
+    name: permanu-ci / dwaar / rust-test
     needs: version-guard
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && (inputs.lane == 'pr' || inputs.lane == 'main' || inputs.lane == 'release' || inputs.lane == 'all')) }}
     runs-on: self-hosted
     timeout-minutes: 45
     steps:
       - name: Setup Rust
         shell: sh
         run: |
-          export HOME="${HOME:-$PWD/.permanu-home}"
-          export CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
-          export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
+          export HOME="$PWD/.permanu-home"
+          export CARGO_HOME="$PWD/.permanu-cargo"
+          export RUSTUP_HOME="$PWD/.permanu-rustup"
           export PATH="$CARGO_HOME/bin:$PATH"
           mkdir -p "$HOME" "$CARGO_HOME" "$RUSTUP_HOME"
           lock=/tmp/permanu-rustup.lock
@@ -134,17 +155,18 @@ jobs:
         run: cargo test --workspace --exclude dwaar-cli -- --ignored --nocapture
 
   rust-build:
-    name: Rust Build
+    name: permanu-ci / dwaar / rust-build-release
     needs: version-guard
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && (inputs.lane == 'main' || inputs.lane == 'release' || inputs.lane == 'all')) }}
     runs-on: self-hosted
     timeout-minutes: 30
     steps:
       - name: Setup Rust
         shell: sh
         run: |
-          export HOME="${HOME:-$PWD/.permanu-home}"
-          export CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
-          export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
+          export HOME="$PWD/.permanu-home"
+          export CARGO_HOME="$PWD/.permanu-cargo"
+          export RUSTUP_HOME="$PWD/.permanu-rustup"
           export PATH="$CARGO_HOME/bin:$PATH"
           mkdir -p "$HOME" "$CARGO_HOME" "$RUSTUP_HOME"
           lock=/tmp/permanu-rustup.lock
@@ -199,9 +221,9 @@ jobs:
           SIGSTORE_ID_TOKEN: ${{ secrets.SIGSTORE_ID_TOKEN }}
           PERMANU_SIGSTORE_ID_TOKEN: ${{ secrets.PERMANU_SIGSTORE_ID_TOKEN }}
         run: |
-          export HOME="${HOME:-$PWD/.permanu-home}"
-          export CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
-          export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
+          export HOME="$PWD/.permanu-home"
+          export CARGO_HOME="$PWD/.permanu-cargo"
+          export RUSTUP_HOME="$PWD/.permanu-rustup"
           export PATH="$CARGO_HOME/bin:$PATH"
           mkdir -p "$HOME" "$CARGO_HOME" "$RUSTUP_HOME"
           if [ -f "$CARGO_HOME/env" ]; then

--- a/scripts/permanu-ci-rust-env.sh
+++ b/scripts/permanu-ci-rust-env.sh
@@ -14,7 +14,7 @@ run_bounded() {
 }
 
 with_rustup_lock() {
-  lock_root="${RUNNER_TOOL_CACHE:-${TMPDIR:-/tmp}}"
+  lock_root="${PERMANU_RUSTUP_LOCK_ROOT:-/var/tmp/permanu-ci}"
   mkdir -p "$lock_root"
   lock="$lock_root/permanu-rustup.lock"
   waited=0

--- a/scripts/permanu-ci-rust-env.sh
+++ b/scripts/permanu-ci-rust-env.sh
@@ -13,6 +13,32 @@ run_bounded() {
   fi
 }
 
+with_rustup_lock() {
+  lock_root="${RUNNER_TOOL_CACHE:-${TMPDIR:-/tmp}}"
+  mkdir -p "$lock_root"
+  lock="$lock_root/permanu-rustup.lock"
+  waited=0
+  while ! mkdir "$lock" 2>/dev/null; do
+    if find "$lock" -maxdepth 0 -mmin +10 >/dev/null 2>&1; then
+      rm -rf "$lock"
+      continue
+    fi
+    waited=$((waited + 2))
+    if [ "$waited" -gt 900 ]; then
+      echo "timed out waiting for rustup lock: $lock" >&2
+      exit 1
+    fi
+    sleep 2
+  done
+
+  set +e
+  "$@"
+  status="$?"
+  set -e
+  rmdir "$lock" 2>/dev/null || rm -rf "$lock"
+  return "$status"
+}
+
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
     echo "missing required CI runner command: $1" >&2
@@ -48,10 +74,12 @@ case "$mode" in
   quality)
     require_cmd rustfmt
     require_cmd clippy-driver
+    with_rustup_lock run_bounded 300 rustfmt --version
+    with_rustup_lock run_bounded 300 clippy-driver --version
     ;;
   audit)
     if ! command -v cargo-audit >/dev/null 2>&1; then
-      run_bounded 900 cargo install cargo-audit --locked
+      with_rustup_lock run_bounded 900 cargo install cargo-audit --locked
     fi
     ;;
   release)
@@ -65,5 +93,5 @@ case "$mode" in
     ;;
 esac
 
-rustc --version
-cargo --version
+with_rustup_lock run_bounded 900 rustc --version
+with_rustup_lock run_bounded 900 cargo --version

--- a/scripts/permanu-ci-rust-env.sh
+++ b/scripts/permanu-ci-rust-env.sh
@@ -9,7 +9,25 @@ run_bounded() {
   if command -v timeout >/dev/null 2>&1; then
     timeout "$seconds" "$@"
   else
-    "$@"
+    "$@" &
+    child="$!"
+    watcher=""
+    (
+      sleep "$seconds"
+      kill "$child" >/dev/null 2>&1 || true
+      sleep 5
+      kill -9 "$child" >/dev/null 2>&1 || true
+    ) &
+    watcher="$!"
+    wait "$child"
+    status="$?"
+    kill "$watcher" >/dev/null 2>&1 || true
+    wait "$watcher" 2>/dev/null || true
+    if [ "$status" -eq 137 ] || [ "$status" -eq 143 ]; then
+      echo "command timed out after ${seconds}s: $*" >&2
+      return 124
+    fi
+    return "$status"
   fi
 }
 
@@ -69,9 +87,11 @@ ensure_rustup_toolchain() {
     quality) components="--component rustfmt --component clippy" ;;
   esac
 
+  echo "ensuring Rust toolchain $channel for $mode"
   # shellcheck disable=SC2086
   with_rustup_lock run_bounded 1200 rustup toolchain install "$channel" --profile minimal $components
 
+  echo "verifying Rust toolchain $channel"
   set +e
   rustup run "$channel" rustc --version >/dev/null 2>&1
   rustc_ok="$?"
@@ -84,6 +104,7 @@ ensure_rustup_toolchain() {
 
   echo "rustup toolchain $channel is incomplete; reinstalling" >&2
   with_rustup_lock run_bounded 300 rustup toolchain uninstall "$channel" >/dev/null 2>&1 || true
+  echo "reinstalling Rust toolchain $channel"
   # shellcheck disable=SC2086
   with_rustup_lock run_bounded 1200 rustup toolchain install "$channel" --profile minimal $components
 }
@@ -118,11 +139,13 @@ case "$mode" in
   quality)
     require_cmd rustfmt
     require_cmd clippy-driver
+    echo "checking rustfmt and clippy-driver"
     with_rustup_lock run_bounded 300 rustfmt --version
     with_rustup_lock run_bounded 300 clippy-driver --version
     ;;
   audit)
     if ! command -v cargo-audit >/dev/null 2>&1; then
+      echo "installing cargo-audit"
       with_rustup_lock run_bounded 900 cargo install cargo-audit --locked
     fi
     ;;

--- a/scripts/permanu-ci-rust-env.sh
+++ b/scripts/permanu-ci-rust-env.sh
@@ -46,6 +46,48 @@ require_cmd() {
   fi
 }
 
+rust_channel() {
+  if [ -f rust-toolchain.toml ]; then
+    sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' rust-toolchain.toml | head -n 1
+    return
+  fi
+  if [ -f rust-toolchain ]; then
+    head -n 1 rust-toolchain
+    return
+  fi
+  printf '%s\n' stable
+}
+
+ensure_rustup_toolchain() {
+  if ! command -v rustup >/dev/null 2>&1; then
+    return
+  fi
+
+  channel="$(rust_channel)"
+  components=""
+  case "$mode" in
+    quality) components="--component rustfmt --component clippy" ;;
+  esac
+
+  # shellcheck disable=SC2086
+  with_rustup_lock run_bounded 1200 rustup toolchain install "$channel" --profile minimal $components
+
+  set +e
+  rustup run "$channel" rustc --version >/dev/null 2>&1
+  rustc_ok="$?"
+  rustup run "$channel" cargo --version >/dev/null 2>&1
+  cargo_ok="$?"
+  set -e
+  if [ "$rustc_ok" -eq 0 ] && [ "$cargo_ok" -eq 0 ]; then
+    return
+  fi
+
+  echo "rustup toolchain $channel is incomplete; reinstalling" >&2
+  with_rustup_lock run_bounded 300 rustup toolchain uninstall "$channel" >/dev/null 2>&1 || true
+  # shellcheck disable=SC2086
+  with_rustup_lock run_bounded 1200 rustup toolchain install "$channel" --profile minimal $components
+}
+
 case "${CARGO_HOME:-}" in
   "") ;;
   *) export PATH="$CARGO_HOME/bin:$PATH" ;;
@@ -54,6 +96,8 @@ esac
 if ! command -v cargo >/dev/null 2>&1 && [ -n "${HOME:-}" ]; then
   export PATH="$HOME/.cargo/bin:$PATH"
 fi
+
+ensure_rustup_toolchain
 
 require_cmd cargo
 require_cmd rustc

--- a/scripts/permanu-ci-rust-env.sh
+++ b/scripts/permanu-ci-rust-env.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env sh
+set -eu
+
+mode="${1:-cargo}"
+
+run_bounded() {
+  seconds="$1"
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$seconds" "$@"
+  else
+    "$@"
+  fi
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required CI runner command: $1" >&2
+    exit 1
+  fi
+}
+
+case "${CARGO_HOME:-}" in
+  "") ;;
+  *) export PATH="$CARGO_HOME/bin:$PATH" ;;
+esac
+
+if ! command -v cargo >/dev/null 2>&1 && [ -n "${HOME:-}" ]; then
+  export PATH="$HOME/.cargo/bin:$PATH"
+fi
+
+require_cmd cargo
+require_cmd rustc
+
+cargo_bin_dir="$(dirname "$(command -v cargo)")"
+case ":$PATH:" in
+  *":$cargo_bin_dir:"*) ;;
+  *) export PATH="$cargo_bin_dir:$PATH" ;;
+esac
+
+if [ -n "${GITHUB_PATH:-}" ]; then
+  printf '%s\n' "$cargo_bin_dir" >> "$GITHUB_PATH"
+fi
+
+case "$mode" in
+  cargo)
+    ;;
+  quality)
+    require_cmd rustfmt
+    require_cmd clippy-driver
+    ;;
+  audit)
+    if ! command -v cargo-audit >/dev/null 2>&1; then
+      run_bounded 900 cargo install cargo-audit --locked
+    fi
+    ;;
+  release)
+    case "${GITHUB_REF:-}" in
+      refs/tags/v*) require_cmd rustup ;;
+    esac
+    ;;
+  *)
+    echo "unknown rust CI setup mode: $mode" >&2
+    exit 1
+    ;;
+esac
+
+rustc --version
+cargo --version

--- a/scripts/publish-github-release-assets.sh
+++ b/scripts/publish-github-release-assets.sh
@@ -17,7 +17,31 @@ require_cmd() {
 }
 
 json_escape() {
-    sed 's/\\/\\\\/g; s/"/\\"/g'
+    awk 'BEGIN { ORS="" } { gsub(/\\/,"\\\\"); gsub(/"/,"\\\""); if (NR > 1) printf "\\n"; printf "%s", $0 }'
+}
+
+release_notes() {
+    version="${tag#v}"
+    if [ -f CHANGELOG.md ]; then
+        notes=$(awk -v tag="$tag" -v version="$version" '
+            $0 ~ "^##[[:space:]]+\\[?" tag "\\]?" || $0 ~ "^##[[:space:]]+\\[?" version "\\]?" { flag=1; next }
+            /^##[[:space:]]+/ && flag { flag=0 }
+            flag { print }
+        ' CHANGELOG.md)
+        if [ -n "$notes" ]; then
+            printf '%s\n' "$notes"
+            return
+        fi
+    fi
+
+    previous_tag=$(git describe --tags --abbrev=0 "${tag}^" 2>/dev/null || true)
+    if [ -n "$previous_tag" ]; then
+        printf 'Changes since %s:\n\n' "$previous_tag"
+        git log --no-merges --pretty=format:'- %s (%h)' "${previous_tag}..${tag}" || true
+        printf '\n'
+    else
+        printf 'Release %s.\n' "$tag"
+    fi
 }
 
 api_request() {
@@ -93,16 +117,21 @@ esac
 [ -d "$dist_dir" ] || fail "release asset directory does not exist: ${dist_dir}"
 
 require_cmd curl "curl is required to publish release assets"
+require_cmd git "git is required to generate release change descriptions"
 require_cmd sed "sed is required to publish release assets"
 
 release_name=$(printf '%s' "$tag" | json_escape)
-body=$(printf '{"tag_name":"%s","name":"%s","draft":false,"prerelease":false,"generate_release_notes":false}' "$release_name" "$release_name")
+release_body=$(release_notes | json_escape)
+body=$(printf '{"tag_name":"%s","name":"%s","body":"%s","draft":false,"prerelease":false,"generate_release_notes":false}' "$release_name" "$release_name" "$release_body")
 
 release_url="${api_root}/repos/${repo}/releases/tags/${tag}"
 create_url="${api_root}/repos/${repo}/releases"
 
 if response=$(api_request GET "$release_url" 2>/dev/null); then
     echo "Updating existing GitHub release ${tag}"
+    release_id_value=$(release_id "$response")
+    [ -n "$release_id_value" ] || fail "GitHub release response did not include id"
+    response=$(api_request PATCH "${api_root}/repos/${repo}/releases/${release_id_value}" "$body")
 else
     echo "Creating GitHub release ${tag}"
     response=$(api_request POST "$create_url" "$body")


### PR DESCRIPTION
## Summary
- Adds explicit Permanu PR, main, and release lanes with lane-aware job conditions.
- Isolates Rust toolchain/cache state per job so CI runs do not fight over shared rustup state.
- Adds GitHub Release asset publishing with generated changelog notes for tag releases.

## Test plan
- Parsed .permanu/workflows/permanu.yml as YAML.
- sh -n scripts/publish-github-release-assets.sh
- git diff --check