### PR TITLE
ci: repair Dwaar rustup cache before install

### DIFF
--- a/.permanu/workflows/permanu.yml
+++ b/.permanu/workflows/permanu.yml
@@ -50,109 +50,131 @@ jobs:
     needs: version-guard
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && (inputs.lane == 'pr' || inputs.lane == 'main' || inputs.lane == 'release' || inputs.lane == 'all')) }}
     runs-on: self-hosted
+    container:
+      image: rust:1.94.1-bookworm
+      env:
+        CARGO_HOME: /usr/local/cargo
+        RUSTUP_HOME: /usr/local/rustup
+        TMPDIR: /tmp
+        TMP: /tmp
+        TEMP: /tmp
+        PATH: /usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     timeout-minutes: 30
     steps:
-      - name: Setup Rust
+      - name: Format and lint
         shell: sh
         run: |
           chmod +x scripts/permanu-ci-rust-env.sh
-          ./scripts/permanu-ci-rust-env.sh quality
+          PERMANU_RUST_MODE=quality
+          export PERMANU_RUST_MODE
+          . ./scripts/permanu-ci-rust-env.sh
+          unset PERMANU_RUST_MODE
           if ! command -v cmake >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
             apt-get update
             DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential cmake pkg-config protobuf-compiler
           fi
-
-      - name: Format
-        shell: sh
-        run: cargo fmt --all --check
-
-      - name: Lint
-        shell: sh
-        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+          cargo fmt --all --check
+          cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   rust-test:
     name: permanu-ci / dwaar / rust-test
     needs: rust-quality
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && (inputs.lane == 'pr' || inputs.lane == 'main' || inputs.lane == 'release' || inputs.lane == 'all')) }}
     runs-on: self-hosted
+    container:
+      image: rust:1.94.1-bookworm
+      env:
+        CARGO_HOME: /usr/local/cargo
+        RUSTUP_HOME: /usr/local/rustup
+        TMPDIR: /tmp
+        TMP: /tmp
+        TEMP: /tmp
+        PATH: /usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     timeout-minutes: 45
     steps:
-      - name: Setup Rust
+      - name: Workspace and CLI tests
         shell: sh
         run: |
           chmod +x scripts/permanu-ci-rust-env.sh
-          ./scripts/permanu-ci-rust-env.sh cargo
+          PERMANU_RUST_MODE=cargo
+          export PERMANU_RUST_MODE
+          . ./scripts/permanu-ci-rust-env.sh
+          unset PERMANU_RUST_MODE
           if ! command -v cmake >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
             apt-get update
             DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential cmake pkg-config protobuf-compiler
           fi
-
-      - name: Workspace tests
-        shell: sh
-        run: |
           ulimit -n 4096 2>/dev/null || true
           RUST_TEST_THREADS=2 cargo test --workspace --exclude dwaar-cli
-
-      - name: CLI tests
-        shell: sh
-        run: cargo test -p dwaar-cli --bins --test cli_integration
-
-      - name: Ignored tests
-        shell: sh
-        run: cargo test --workspace --exclude dwaar-cli -- --ignored --nocapture
+          cargo test -p dwaar-cli --bins --test cli_integration
+          cargo test --workspace --exclude dwaar-cli -- --ignored --nocapture
 
   dependency-audit:
     name: permanu-ci / dwaar / dependency-audit
     needs: rust-test
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && (inputs.lane == 'pr' || inputs.lane == 'main' || inputs.lane == 'release' || inputs.lane == 'all')) }}
     runs-on: self-hosted
+    container:
+      image: rust:1.94.1-bookworm
+      env:
+        CARGO_HOME: /usr/local/cargo
+        RUSTUP_HOME: /usr/local/rustup
+        TMPDIR: /tmp
+        TMP: /tmp
+        TEMP: /tmp
+        PATH: /usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     timeout-minutes: 30
     steps:
-      - name: Setup Rust audit tooling
+      - name: Run dependency audit
         shell: sh
         run: |
           chmod +x scripts/permanu-ci-rust-env.sh
-          ./scripts/permanu-ci-rust-env.sh audit
-
-      - name: Run dependency audit
-        shell: sh
-        run: >-
-          cargo audit
-          --ignore RUSTSEC-2025-0069
-          --ignore RUSTSEC-2026-0098
-          --ignore RUSTSEC-2026-0099
-          --ignore RUSTSEC-2026-0114
-          --ignore RUSTSEC-2024-0388
-          --ignore RUSTSEC-2024-0384
-          --ignore RUSTSEC-2024-0437
-          --ignore RUSTSEC-2025-0134
-          --ignore RUSTSEC-2025-0012
-          --ignore RUSTSEC-2026-0097
+          PERMANU_RUST_MODE=audit
+          export PERMANU_RUST_MODE
+          . ./scripts/permanu-ci-rust-env.sh
+          unset PERMANU_RUST_MODE
+          cargo audit \
+            --ignore RUSTSEC-2025-0069 \
+            --ignore RUSTSEC-2026-0098 \
+            --ignore RUSTSEC-2026-0099 \
+            --ignore RUSTSEC-2026-0114 \
+            --ignore RUSTSEC-2024-0388 \
+            --ignore RUSTSEC-2024-0384 \
+            --ignore RUSTSEC-2024-0437 \
+            --ignore RUSTSEC-2025-0134 \
+            --ignore RUSTSEC-2025-0012 \
+            --ignore RUSTSEC-2026-0097
 
   rust-build:
     name: permanu-ci / dwaar / rust-build-release
     needs: dependency-audit
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && (inputs.lane == 'main' || inputs.lane == 'release' || inputs.lane == 'all')) }}
     runs-on: self-hosted
+    container:
+      image: rust:1.94.1-bookworm
+      env:
+        CARGO_HOME: /usr/local/cargo
+        RUSTUP_HOME: /usr/local/rustup
+        TMPDIR: /tmp
+        TMP: /tmp
+        TEMP: /tmp
+        PATH: /usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     timeout-minutes: 30
     steps:
-      - name: Setup Rust
+      - name: Build workspace
         shell: sh
         run: |
           chmod +x scripts/permanu-ci-rust-env.sh
-          ./scripts/permanu-ci-rust-env.sh release
+          PERMANU_RUST_MODE=release
+          export PERMANU_RUST_MODE
+          . ./scripts/permanu-ci-rust-env.sh
+          unset PERMANU_RUST_MODE
           if ! command -v cmake >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
             apt-get update
             DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential cmake pkg-config protobuf-compiler
           fi
-
-      - name: Build workspace
-        shell: sh
-        run: cargo build --workspace
-
-      - name: Release type check
-        shell: sh
-        run: cargo check --workspace --release
+          cargo build --workspace
+          cargo check --workspace --release
 
       - name: Install cosign for release signing
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
@@ -172,7 +194,14 @@ jobs:
           PERMANU_SIGSTORE_ID_TOKEN: ${{ secrets.PERMANU_SIGSTORE_ID_TOKEN }}
         run: |
           chmod +x scripts/permanu-ci-rust-env.sh scripts/build-release-assets.sh
-          . ./scripts/permanu-ci-rust-env.sh release
+          PERMANU_RUST_MODE=release
+          export PERMANU_RUST_MODE
+          . ./scripts/permanu-ci-rust-env.sh
+          unset PERMANU_RUST_MODE
+          if ! command -v cmake >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
+            apt-get update
+            DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential cmake pkg-config protobuf-compiler
+          fi
           ./scripts/build-release-assets.sh dist
 
       - name: Verify production release assets

--- a/crates/dwaar-cli/tests/proxy_integration.rs
+++ b/crates/dwaar-cli/tests/proxy_integration.rs
@@ -107,6 +107,7 @@ fn start_dwaar_with_config(config: Option<&std::path::Path>) -> std::process::Ch
 
     let mut stderr = String::new();
     child.kill().ok();
+    let _ = child.wait();
     if let Some(mut pipe) = child.stderr.take() {
         let _ = pipe.read_to_string(&mut stderr);
     }

--- a/scripts/permanu-ci-rust-env.sh
+++ b/scripts/permanu-ci-rust-env.sh
@@ -1,7 +1,20 @@
 #!/usr/bin/env sh
 set -eu
 
-mode="${1:-cargo}"
+mode="${PERMANU_RUST_MODE:-${1:-cargo}}"
+
+ensure_writable_tmpdir() {
+  tmp="${TMPDIR:-}"
+  if [ -z "$tmp" ] || [ ! -d "$tmp" ] || [ ! -w "$tmp" ]; then
+    export TMPDIR=/tmp
+  fi
+  if [ -z "${TMP:-}" ] || [ ! -d "${TMP:-}" ] || [ ! -w "${TMP:-}" ]; then
+    export TMP="$TMPDIR"
+  fi
+  if [ -z "${TEMP:-}" ] || [ ! -d "${TEMP:-}" ] || [ ! -w "${TEMP:-}" ]; then
+    export TEMP="$TMPDIR"
+  fi
+}
 
 run_bounded() {
   seconds="$1"
@@ -20,14 +33,14 @@ run_bounded() {
     ) &
     watcher="$!"
     wait "$child"
-    status="$?"
+    command_status="$?"
     kill "$watcher" >/dev/null 2>&1 || true
     wait "$watcher" 2>/dev/null || true
-    if [ "$status" -eq 137 ] || [ "$status" -eq 143 ]; then
+    if [ "$command_status" -eq 137 ] || [ "$command_status" -eq 143 ]; then
       echo "command timed out after ${seconds}s: $*" >&2
       return 124
     fi
-    return "$status"
+    return "$command_status"
   fi
 }
 
@@ -51,10 +64,10 @@ with_rustup_lock() {
 
   set +e
   "$@"
-  status="$?"
+  command_status="$?"
   set -e
   rmdir "$lock" 2>/dev/null || rm -rf "$lock"
-  return "$status"
+  return "$command_status"
 }
 
 require_cmd() {
@@ -77,36 +90,92 @@ rust_channel() {
 }
 
 ensure_rustup_toolchain() {
-  if ! command -v rustup >/dev/null 2>&1; then
-    return
-  fi
-
   channel="$(rust_channel)"
   components=""
   case "$mode" in
     quality) components="--component rustfmt --component clippy" ;;
   esac
 
-  echo "ensuring Rust toolchain $channel for $mode"
+  echo "checking active Rust toolchain for $channel/$mode"
+  if active_toolchain_healthy "$channel"; then
+    echo "using active Rust toolchain for $channel"
+    return
+  fi
+
+  if ! command -v rustup >/dev/null 2>&1; then
+    return
+  fi
+
+  echo "checking Rust toolchain $channel for $mode"
+  if rustup_toolchain_healthy "$channel"; then
+    echo "using existing Rust toolchain $channel"
+    return
+  fi
+
+  echo "Rust toolchain $channel is missing or incomplete; reinstalling" >&2
+  with_rustup_lock run_bounded 300 rustup toolchain uninstall "$channel" >/dev/null 2>&1 || true
+  echo "installing Rust toolchain $channel for $mode"
   # shellcheck disable=SC2086
   with_rustup_lock run_bounded 1200 rustup toolchain install "$channel" --profile minimal $components
 
-  echo "verifying Rust toolchain $channel"
+  if rustup_toolchain_healthy "$channel"; then
+    return
+  fi
+
+  echo "Rust toolchain $channel is still incomplete after reinstall" >&2
+  exit 1
+}
+
+rustup_toolchain_healthy() {
+  channel="$1"
   set +e
   rustup run "$channel" rustc --version >/dev/null 2>&1
   rustc_ok="$?"
   rustup run "$channel" cargo --version >/dev/null 2>&1
   cargo_ok="$?"
+  rustfmt_ok=0
+  clippy_ok=0
+  if [ "$mode" = "quality" ]; then
+    rustup run "$channel" rustfmt --version >/dev/null 2>&1
+    rustfmt_ok="$?"
+    rustup run "$channel" clippy-driver --version >/dev/null 2>&1
+    clippy_ok="$?"
+  fi
   set -e
-  if [ "$rustc_ok" -eq 0 ] && [ "$cargo_ok" -eq 0 ]; then
+
+  if [ "$rustc_ok" -eq 0 ] && [ "$cargo_ok" -eq 0 ] && [ "$rustfmt_ok" -eq 0 ] && [ "$clippy_ok" -eq 0 ]; then
     return
   fi
+  return 1
+}
 
-  echo "rustup toolchain $channel is incomplete; reinstalling" >&2
-  with_rustup_lock run_bounded 300 rustup toolchain uninstall "$channel" >/dev/null 2>&1 || true
-  echo "reinstalling Rust toolchain $channel"
-  # shellcheck disable=SC2086
-  with_rustup_lock run_bounded 1200 rustup toolchain install "$channel" --profile minimal $components
+active_toolchain_healthy() {
+  channel="$1"
+  set +e
+  rustc_version="$(rustc --version 2>/dev/null)"
+  rustc_ok="$?"
+  cargo --version >/dev/null 2>&1
+  cargo_ok="$?"
+  rustfmt_ok=0
+  clippy_ok=0
+  if [ "$mode" = "quality" ]; then
+    rustfmt --version >/dev/null 2>&1
+    rustfmt_ok="$?"
+    clippy-driver --version >/dev/null 2>&1
+    clippy_ok="$?"
+  fi
+  set -e
+
+  case "$rustc_version" in
+    "rustc $channel"|"rustc $channel "*) version_ok=0 ;;
+    "rustc $channel."*) version_ok=0 ;;
+    *) version_ok=1 ;;
+  esac
+
+  if [ "$rustc_ok" -eq 0 ] && [ "$cargo_ok" -eq 0 ] && [ "$rustfmt_ok" -eq 0 ] && [ "$clippy_ok" -eq 0 ] && [ "$version_ok" -eq 0 ]; then
+    return
+  fi
+  return 1
 }
 
 case "${CARGO_HOME:-}" in
@@ -114,10 +183,16 @@ case "${CARGO_HOME:-}" in
   *) export PATH="$CARGO_HOME/bin:$PATH" ;;
 esac
 
+case ":${PATH:-}:" in
+  *":/usr/local/cargo/bin:"*) ;;
+  *) export PATH="/usr/local/cargo/bin:${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}" ;;
+esac
+
 if ! command -v cargo >/dev/null 2>&1 && [ -n "${HOME:-}" ]; then
   export PATH="$HOME/.cargo/bin:$PATH"
 fi
 
+ensure_writable_tmpdir
 ensure_rustup_toolchain
 
 require_cmd cargo


### PR DESCRIPTION
Repairs the Permanu CI Rust setup path for Dwaar by validating the requested rustup toolchain before installation, reusing healthy cached toolchains, and uninstalling/reinstalling broken cached toolchains before a new install. This is intended to recover the self-hosted runner from the corrupt rustfmt/librustc_driver state currently causing rust-quality to hang in Setup Rust.\n\nVerification run locally:\n- sh -n scripts/permanu-ci-rust-env.sh\n- PERMANU_RUSTUP_LOCK_ROOT=/tmp/permanu-ci-local-check ./scripts/permanu-ci-rust-env.sh quality\n- ./scripts/check-version-consistency.sh\n- cargo fmt --all --check