### PR TITLE
chore: release Dwaar 0.3.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.24] - 2026-06-03
+
+### Fixed
+
+- Serve the complete configured TLS certificate chain for SNI-selected
+  certificates. This fixes clients that do not already have the issuing
+  intermediate cached, including newly onboarded Azure VPS agents connecting to
+  Permanu's production gRPC endpoint.
+
 ## [0.3.23] - 2026-05-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,7 +1313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dwaar-admin"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-analytics"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "base64",
  "brotli 8.0.2",
@@ -1374,7 +1374,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-cli"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-config"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-core"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-docker"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-geo"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "arc-swap",
  "criterion",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-grpc"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-ingress"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "anyhow",
  "clap",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-log"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-plugins"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "dwaar-tls"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Permanu
-Licensed Work:        Dwaar 0.3.23
+Licensed Work:        Dwaar 0.3.24
                       The Licensed Work is
                       (c) 2026 Permanu
 

--- a/crates/dwaar-admin/Cargo.toml
+++ b/crates/dwaar-admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-admin"
-version = "0.3.23"
+version = "0.3.24"
 description = "Admin API service — route management, health, metrics, config"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-analytics/Cargo.toml
+++ b/crates/dwaar-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-analytics"
-version = "0.3.23"
+version = "0.3.24"
 description = "First-party analytics — JS injection, beacon collection, in-memory aggregation"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-cli/Cargo.toml
+++ b/crates/dwaar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-cli"
-version = "0.3.23"
+version = "0.3.24"
 description = "Dwaar CLI — binary entry point, commands, process management"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-config/Cargo.toml
+++ b/crates/dwaar-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-config"
-version = "0.3.23"
+version = "0.3.24"
 description = "Dwaarfile parser, configuration validation, and hot-reload"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-core/Cargo.toml
+++ b/crates/dwaar-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-core"
-version = "0.3.23"
+version = "0.3.24"
 description = "Core proxy engine — ProxyHttp implementation, route table, request context"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-docker/Cargo.toml
+++ b/crates/dwaar-docker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-docker"
-version = "0.3.23"
+version = "0.3.24"
 description = "Docker socket watcher — auto-discover containers via labels"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-geo/Cargo.toml
+++ b/crates/dwaar-geo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-geo"
-version = "0.3.23"
+version = "0.3.24"
 description = "GeoIP lookup — IP to country/city via MaxMind GeoLite2"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-grpc/Cargo.toml
+++ b/crates/dwaar-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-grpc"
-version = "0.3.23"
+version = "0.3.24"
 description = "Bidirectional gRPC control fabric — DwaarControl service (Permanu ↔ Dwaar)"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-ingress/Cargo.toml
+++ b/crates/dwaar-ingress/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-ingress"
-version = "0.3.23"
+version = "0.3.24"
 description = "Kubernetes ingress controller — watches Ingress resources and syncs routes to Dwaar"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-log/Cargo.toml
+++ b/crates/dwaar-log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-log"
-version = "0.3.23"
+version = "0.3.24"
 description = "Request logging — structured log types, batch writer, output destinations"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-plugins/Cargo.toml
+++ b/crates/dwaar-plugins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-plugins"
-version = "0.3.23"
+version = "0.3.24"
 description = "Plugin trait, plugin chain, built-in plugins (bot detection, rate limiting, compression, security headers)"
 edition.workspace = true
 publish = false

--- a/crates/dwaar-tls/Cargo.toml
+++ b/crates/dwaar-tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dwaar-tls"
-version = "0.3.23"
+version = "0.3.24"
 description = "TLS termination, ACME client (Let's Encrypt + Google Trust Services), certificate management"
 edition.workspace = true
 publish = false


### PR DESCRIPTION
Release Dwaar 0.3.24 with the full TLS certificate-chain serving fix required for Permanu production gRPC onboarding.